### PR TITLE
wip: extract the binlog subscription logic from Dolt

### DIFF
--- a/binlogreplication/binlog_file_utils.go
+++ b/binlogreplication/binlog_file_utils.go
@@ -1,0 +1,132 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binlogreplication
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/dolthub/vitess/go/mysql"
+)
+
+// binlogFileMagicNumber holds the four bytes that start off every
+// MySQL binlog file and identify the file as a MySQL binlog.
+var binlogFileMagicNumber = []byte{0xfe, 0x62, 0x69, 0x6e}
+
+// fileExists returns true if the specified |filepath| exists on disk and is not a directory,
+// otherwise returns false. |filepath| is a fully specified path to a file on disk.
+func fileExists(filepath string) bool {
+	info, err := os.Stat(filepath)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
+// openBinlogFileForReading opens the specified |logfile| for reading and reads the first four bytes to make sure they
+// are the expected binlog file magic numbers. If any problems are encountered opening the file or reading the first
+// four bytes, an error is returned.
+func openBinlogFileForReading(logfile string) (*os.File, error) {
+	file, err := os.Open(logfile)
+	if err != nil {
+		return nil, err
+	}
+	buffer := make([]byte, len(binlogFileMagicNumber))
+	bytesRead, err := file.Read(buffer)
+	if err != nil {
+		return nil, err
+	}
+	if bytesRead != len(binlogFileMagicNumber) || string(buffer) != string(binlogFileMagicNumber) {
+		return nil, fmt.Errorf("invalid magic number in binlog file!")
+	}
+
+	return file, nil
+}
+
+// readBinlogEventFromFile reads the next binlog event from the specified, open |file| and
+// returns it. If no more events are available in the file, then io.EOF is returned.
+func readBinlogEventFromFile(file *os.File) (mysql.BinlogEvent, error) {
+	headerBuffer := make([]byte, 4+1+4+4+4+2)
+	_, err := file.Read(headerBuffer)
+	if err != nil {
+		return nil, err
+	}
+
+	// Event Header:
+	//timestamp := headerBuffer[0:4]
+	//eventType := headerBuffer[4]
+	//serverId := binary.LittleEndian.Uint32(headerBuffer[5:5+4])
+	eventSize := binary.LittleEndian.Uint32(headerBuffer[9 : 9+4])
+
+	payloadBuffer := make([]byte, eventSize-uint32(len(headerBuffer)))
+	_, err = file.Read(payloadBuffer)
+	if err != nil {
+		return nil, err
+	}
+
+	return mysql.NewMysql56BinlogEvent(append(headerBuffer, payloadBuffer...)), nil
+}
+
+// readFirstGtidEventFromFile reads events from |file| until a GTID event is found, then
+// returns that GTID event. If |file| has been read completely and no GTID events were found,
+// then io.EOF is returned.
+func readFirstGtidEventFromFile(file *os.File) (mysql.BinlogEvent, error) {
+	for {
+		binlogEvent, err := readBinlogEventFromFile(file)
+		if err != nil {
+			return nil, err
+		}
+
+		if binlogEvent.IsGTID() {
+			return binlogEvent, nil
+		}
+	}
+}
+
+// formatBinlogFilename formats a binlog filename using the specified |branch| and |sequence| number. The
+// returned filename will be of the form "binlog-main.000001".
+func formatBinlogFilename(branch string, sequence int) string {
+	return fmt.Sprintf("binlog-%s.%06d", branch, sequence)
+}
+
+// parseBinlogFilename parses a binlog filename, of the form "binlog-main.000001", into its branch and
+// sequence number.
+func parseBinlogFilename(filename string) (branch string, sequence int, err error) {
+	if !strings.HasPrefix(filename, "binlog-") {
+		return "", 0, fmt.Errorf("invalid binlog filename: %s; must start with 'binlog-'", filename)
+	}
+
+	filename = strings.TrimPrefix(filename, "binlog-")
+
+	splits := strings.Split(filename, ".")
+	if len(splits) != 2 {
+		return "", 0, fmt.Errorf(
+			"unable to parse binlog filename: %s; expected format 'binlog-branch.sequence'", filename)
+	}
+
+	branch = splits[0]
+	sequenceString := splits[1]
+
+	sequence, err = strconv.Atoi(sequenceString)
+	if err != nil {
+		return "", 0, fmt.Errorf(
+			"unable to parse binlog sequence number: %s; %s", sequenceString, err.Error())
+	}
+
+	return branch, sequence, nil
+}

--- a/binlogreplication/binlog_json_serialization.go
+++ b/binlogreplication/binlog_json_serialization.go
@@ -1,0 +1,358 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binlogreplication
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+const jsonTypeSmallObject = byte(0x00)
+const jsonTypeLargeObject = byte(0x01)
+const jsonTypeSmallArray = byte(0x02)
+const jsonTypeLargeArray = byte(0x03)
+const jsonTypeLiteral = byte(0x04)
+const jsonTypeInt16 = byte(0x05)
+const jsonTypeUint16 = byte(0x06)
+const jsonTypeInt32 = byte(0x07)
+const jsonTypeUint32 = byte(0x08)
+const jsonTypeInt64 = byte(0x09)
+const jsonTypeUint64 = byte(0x0a)
+const jsonTypeDouble = byte(0x0b)
+const jsonTypeString = byte(0x0c)
+const jsonTypeCustom = byte(0x0f)
+
+const jsonLiteralValueNull = byte(0x00)
+const jsonLiteralValueTrue = byte(0x01)
+const jsonLiteralValueFalse = byte(0x02)
+
+// maxOffsetSize is used to determine if an byte offset into an array or object encoding will exceed the capacity
+// of a uint16 and whether the encoding needs to switch to the large array or large object format.
+const maxOffsetSize = uint32(65_535)
+
+// encodeJsonDoc encodes the specified |jsonDoc| into MySQL's custom/internal binary encoding
+// so that it can be included in a binlog event.
+//
+// The internal MySQL JSON binary format is documented here:
+// https://dev.mysql.com/doc/dev/mysql-server/latest/json__binary_8h.html
+//
+// And a third-party description is here:
+// https://lafengnan.gitbooks.io/blog/content/mysql/chapter2.html
+func encodeJsonDoc(jsonDoc sql.JSONWrapper) (buffer []byte, err error) {
+	val, err := jsonDoc.ToInterface()
+	if err != nil {
+		return nil, err
+	}
+	typeId, encodedValue, err := encodeJsonValue(val)
+	if err != nil {
+		return nil, err
+	}
+	buffer = append(buffer, typeId)
+	return append(buffer, encodedValue...), nil
+}
+
+// encodeJsonArray encodes the specified |jsonArray| into MySQL's internal JSON encoding and returns
+// the type ID indicating whether this is a small or large array, the encoded array data, and any
+// error encountered. The |largeEncoding| param controls whether this function will use the small
+// array encoding (i.e. using 2 bytes for counts, sizes, and offsets), or the large array encoding
+// (i.e. using 4 bytes for counts, sizes, and offsets).
+//
+// A JSON Array is encoded into the following components:
+// - Type Identifier: Always 1 byte; jsonTypeSmallArray or jsonTypeLargeArray; not included in the returned []byte.
+// - Count:  2 bytes for small encoding, otherwise 4; number of elements in the array
+// - Size: 2 bytes for small encoding, otherwise 4; total size of the encoded array (everything but the Type ID)
+// - Value Entries: 1 per value; 1 byte for type ID, variable sized offset (or inlined literal value)
+// - Values: 1 per value; encoded value bytes
+func encodeJsonArray(jsonArray []any, largeEncoding bool) (typeId byte, encodedArray []byte, err error) {
+	if !largeEncoding && len(jsonArray) > int(maxOffsetSize) {
+		return 0, nil, fmt.Errorf(
+			"too many elements in JSON array (%d) to serialize in small array encoding", len(jsonArray))
+	}
+
+	var valueEntriesBuffer []byte
+	var valuesBuffer []byte
+	nextValuesOffset := calculateInitialArrayValuesOffset(len(jsonArray), largeEncoding)
+
+	for _, element := range jsonArray {
+		typeId, encodedValue, err := encodeJsonValue(element)
+		if err != nil {
+			return 0, nil, err
+		}
+
+		// Literals can be inlined in the value-entries section
+		if typeId == jsonTypeLiteral {
+			valueEntriesBuffer = append(valueEntriesBuffer, typeId)
+			if len(encodedValue) != 1 {
+				return 0, nil, fmt.Errorf("unexpected buffer length")
+			}
+			valueEntriesBuffer = appendForEncoding(valueEntriesBuffer, uint32(encodedValue[0]), largeEncoding)
+		} else {
+			if !largeEncoding && nextValuesOffset > maxOffsetSize-uint32(len(encodedValue)) {
+				return 0, nil, fmt.Errorf("offset too large for small array encoding")
+			}
+
+			valueEntriesBuffer = append(valueEntriesBuffer, typeId)
+			valueEntriesBuffer = appendForEncoding(valueEntriesBuffer, nextValuesOffset, largeEncoding)
+			valuesBuffer = append(valuesBuffer, encodedValue...)
+			nextValuesOffset += uint32(len(encodedValue))
+		}
+	}
+
+	// element count (uint16 for small arrays)
+	encodedArray = appendForEncoding(encodedArray, uint32(len(jsonArray)), largeEncoding)
+
+	// Grab the total size of the array data from the next offset position pointing to the end of the values buffer
+	arrayPayloadLength := nextValuesOffset
+
+	encodedArray = appendForEncoding(encodedArray, arrayPayloadLength, largeEncoding)
+	encodedArray = append(encodedArray, valueEntriesBuffer...)
+	encodedArray = append(encodedArray, valuesBuffer...)
+
+	if !largeEncoding {
+		return jsonTypeSmallArray, encodedArray, nil
+	} else {
+		return jsonTypeLargeArray, encodedArray, nil
+	}
+}
+
+// encodeJsonObject encodes the specified |jsonObject| into MySQL's internal JSON encoding and returns
+// the type ID indicating whether this is a small or large object, the encoded object data, and any
+// error encountered. The |largeEncoding| param controls whether this function will use the small
+// object encoding (i.e. using 2 bytes for counts, sizes, and offsets), or the large object encoding
+// (i.e. using 4 bytes for counts, sizes, and offsets).
+//
+// A JSON Object is encoded into the following components:
+// - Type Identifier: Always 1 byte; either jsonTypeSmallObject or jsonTypeLargeObject (not included in returned []byte)
+// - Count: variable based on small/large encoding; holds the number of keys in the object
+// - Size: variable based on small/large encoding; total size of the encoded object (i.e. everything but the Type ID)
+// - Key Entries: 1 per key; variable length key offset (based on small/large encoding), plus 2 bytes for key length
+// - Value Entries (variable): 1 per value; 1 byte for type ID, 2 bytes for offset or inlined literal value for jsonTypeSmallObject, otherwise 4
+// - Keys (variable): 1 per key; encoded string bytes
+// - Values (variable): 1 per value; encoded value bytes
+func encodeJsonObject(jsonObject map[string]any, largeEncoding bool) (typeId byte, encodedObject []byte, err error) {
+	var keyEntriesBuffer []byte
+	var keysBuffer []byte
+	nextKeysOffset := calculateInitialObjectKeysOffset(len(jsonObject), largeEncoding)
+
+	// Sort the keys so that we can process the keys and values in a consistent order. MySQL seems to sort
+	// json keys internally first by length, then alphabetically, but correct replication doesn't seem to
+	// rely on matching that behavior.
+	sortedKeys := make([]string, 0, len(jsonObject))
+	for key := range jsonObject {
+		sortedKeys = append(sortedKeys, key)
+	}
+	sort.Strings(sortedKeys)
+
+	// Process keys first, since value entry data depends on offsets that we don't know until we
+	// process all the keys.
+	for _, key := range sortedKeys {
+		// NOTE: Don't use encodeJsonValue for the key – its length gets encoded slightly differently
+		//       for JSON objects.
+		encodedValue := []byte(key)
+
+		if !largeEncoding && nextKeysOffset > maxOffsetSize-uint32(len(encodedValue)) {
+			return 0, nil, fmt.Errorf("offset too large for small object encoding")
+		}
+
+		keyEntriesBuffer = appendForEncoding(keyEntriesBuffer, nextKeysOffset, largeEncoding)
+		keyEntriesBuffer = append(keyEntriesBuffer, byte(len(encodedValue)), byte(len(encodedValue)<<8))
+		keysBuffer = append(keysBuffer, encodedValue...)
+		nextKeysOffset += uint32(len(encodedValue))
+	}
+
+	// Process values – since the object values are written after the keys, and we need to store the
+	// offsets to those locations in the value entries that appear before the keys and the values, we
+	// have to make a second pass through the object to process the values once we know the final
+	// length of the keys section.
+	var valueEntriesBuffer []byte
+	var valuesBuffer []byte
+	nextValuesOffset := nextKeysOffset
+	for _, key := range sortedKeys {
+		value := jsonObject[key]
+		typeId, encodedValue, err := encodeJsonValue(value)
+		if err != nil {
+			return 0, nil, err
+		}
+
+		// Literals may be inlined in the value-entries section
+		if typeId == jsonTypeLiteral {
+			valueEntriesBuffer = append(valueEntriesBuffer, typeId)
+			if len(encodedValue) != 1 {
+				return 0, nil, fmt.Errorf("unexpected buffer length")
+			}
+			valueEntriesBuffer = appendForEncoding(valueEntriesBuffer, uint32(encodedValue[0]), largeEncoding)
+		} else {
+			if !largeEncoding && nextValuesOffset > maxOffsetSize-uint32(len(encodedValue)) {
+				return 0, nil, fmt.Errorf("offset too large for small object encoding")
+			}
+
+			valueEntriesBuffer = append(valueEntriesBuffer, typeId)
+			valueEntriesBuffer = appendForEncoding(valueEntriesBuffer, nextValuesOffset, largeEncoding)
+			valuesBuffer = append(valuesBuffer, encodedValue...)
+			nextValuesOffset += uint32(len(encodedValue))
+		}
+	}
+
+	// element count (uint16 for small objects)
+	encodedObject = appendForEncoding(encodedObject, uint32(len(jsonObject)), largeEncoding)
+
+	// Grab the total size of the object data from the next offset position pointing to the end of the values buffer
+	objectPayloadLength := nextValuesOffset
+
+	encodedObject = appendForEncoding(encodedObject, objectPayloadLength, largeEncoding)
+	encodedObject = append(encodedObject, keyEntriesBuffer...)
+	encodedObject = append(encodedObject, valueEntriesBuffer...)
+	encodedObject = append(encodedObject, keysBuffer...)
+	encodedObject = append(encodedObject, valuesBuffer...)
+
+	if !largeEncoding {
+		return jsonTypeSmallObject, encodedObject, nil
+	} else {
+		return jsonTypeLargeObject, encodedObject, nil
+	}
+}
+
+// encodeJsonObject encodes the specified |jsonValue| into MySQL's internal JSON encoding and returns
+// the type ID indicating what type of value this is, the encoded value, and any error encountered.
+func encodeJsonValue(jsonValue any) (typeId byte, buffer []byte, err error) {
+	if jsonValue == nil {
+		buffer = append(buffer, jsonLiteralValueNull)
+		return jsonTypeLiteral, buffer, nil
+	}
+
+	switch v := jsonValue.(type) {
+	case bool:
+		if v {
+			buffer = append(buffer, jsonLiteralValueTrue)
+		} else {
+			buffer = append(buffer, jsonLiteralValueFalse)
+		}
+		return jsonTypeLiteral, buffer, nil
+
+	case string:
+		// String lengths use a special encoding that can span multiple bytes
+		buffer, err = appendStringLength(buffer, len(v))
+		if err != nil {
+			return 0, nil, err
+		}
+
+		buffer = append(buffer, []byte(v)...)
+		return jsonTypeString, buffer, nil
+
+	case float64:
+		// NOTE: all our numbers end up being represented as float64s currently when we parse stored JSON
+		bits := math.Float64bits(v)
+		buffer = append(buffer, make([]byte, 8)...)
+		binary.LittleEndian.PutUint64(buffer, bits)
+		return jsonTypeDouble, buffer, nil
+
+	case []any:
+		// MySQL attempts to use the small encoding first, and if offset sizes overflow, then it switches to the
+		// large encoding. This is a little messy/inefficient to try the small encoding first, but because of the
+		// way the binary format is designed, we can't know if/when we'll need the large format without serializing
+		// the data first.
+		id, encodedArray, err := encodeJsonArray(v, false)
+		if err == nil {
+			return id, encodedArray, nil
+		}
+		return encodeJsonArray(v, true)
+
+	case map[string]any:
+		// See the comment above about MySQL's JSON serialization format, and why we try the small encoding first,
+		// before we know if we need the large encoding or not.
+		id, encodedObject, err := encodeJsonObject(v, false)
+		if err == nil {
+			return id, encodedObject, nil
+		}
+		return encodeJsonObject(v, true)
+
+	default:
+		return 0x00, nil, fmt.Errorf("unexpected type in JSON document: %T", v)
+	}
+}
+
+// appendForEncoding appends the |value| to the specified |bytes| and returns the updated byte slice. If
+// |largeEncoding| is true, then 4 bytes are added to |bytes| to represent |value|, otherwise 2 bytes are used.
+// This is a helper function for serializing the smallArray/largeArray and smallObject/largeObject formats, since
+// they are identical formats, except that offsets, counts, and sizes are stored as 2 bytes in the small encodings,
+// and stored as 4 bytes in the large encodings.
+func appendForEncoding(bytes []byte, value uint32, largeEncoding bool) []byte {
+	if !largeEncoding {
+		bytes = append(bytes, byte(value), byte(value>>8))
+	} else {
+		bytes = append(bytes, byte(value), byte(value>>8), byte(value>>16), byte(value>>24))
+	}
+	return bytes
+}
+
+// appendStringLength appends a variable number of bytes to the specified |bytes| to encode |length|, the
+// length of a string. For string lengths, if the length is larger than 127 bytes, we set the high bit of
+// the first byte and use two bytes to encode the length. Similarly, if the high bit of the second byte is
+// also set, the length is encoded over three bytes.
+func appendStringLength(bytes []byte, length int) ([]byte, error) {
+	switch {
+	case length > 0x1FFFFF:
+		return nil, fmt.Errorf("strings larger than 2,097,151 bytes not supported")
+
+	case length > 0x3FFF: // 16,383
+		return append(bytes,
+			byte(length&0x7F|0x80),
+			byte(length>>7|0x80),
+			byte(length>>14)), nil
+
+	case length > 0x7F: // 127
+		return append(bytes,
+			byte(length&0x7F|0x80),
+			byte(length>>7)), nil
+
+	default:
+		return append(bytes, byte(length)), nil
+	}
+}
+
+// calculateInitialArrayValuesOffset returns the initial offset value for the first array value in the
+// encoded array byte slice. When |largeEncoding| is false, this value includes the two bytes for the
+// element count, the two bytes for the encoded size, and three bytes (one byte for type ID, and two
+// bytes for the offset) for each element in the array, specified by |arrayLength|. When |largeEncoding|
+// is true, this value includes four bytes for the element count, four bytes for the encoded size, and
+// five bytes (one byte for type ID, and four bytes for the offset) for each element in the array,
+// specified by |arrayLength|.
+func calculateInitialArrayValuesOffset(arrayLength int, largeEncoding bool) uint32 {
+	if !largeEncoding {
+		return uint32(2 + 2 + (arrayLength * 3))
+	}
+	return uint32(4 + 4 + (arrayLength * 5))
+}
+
+// calculateInitialObjectKeysOffset returns the initial offset value for the first key in the encoded
+// object byte slice. When |largeEncoding| is false, the first key offset position is calculated by adding
+// 2 bytes (the key/value pair count field), 2 bytes (the size of encoded object field), 4 bytes (2 bytes
+// for the key offset, and 2 bytes for the length of the key) per key/value pair, specified by |objectLength|,
+// and another 3 bytes (1 byte for the value's type ID, and 2 bytes for the offset to the value's data) for
+// each key/value pair. When |largeEncoding| is true, the first key offset position is calculated by adding
+// 4 bytes (the key/value pair count field), 4 bytes (the size of encoded object field), 6 bytes (4 bytes
+// for the key offset, and 2 bytes for the length of the key) per key/value pair, specified by |objectLength|,
+// and another 5 bytes (1 byte for the value's type ID, and 4 bytes for the offset to the value's data) for
+// each key/value pair.
+func calculateInitialObjectKeysOffset(objectLength int, largeEncoding bool) uint32 {
+	if !largeEncoding {
+		return uint32(2 + 2 + objectLength*4 + objectLength*3)
+	}
+	return uint32(4 + 4 + objectLength*6 + objectLength*5)
+}

--- a/binlogreplication/binlog_json_serialization_test.go
+++ b/binlogreplication/binlog_json_serialization_test.go
@@ -1,0 +1,322 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binlogreplication
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	gmstypes "github.com/dolthub/go-mysql-server/sql/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestJsonSerialization_EncodedBytes tests that we can properly encode JSON data to MySQL's internal encoding.
+func TestJsonSerialization_EncodedBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected []byte
+	}{
+		// Literals
+		{
+			json:     "true",
+			expected: []byte{0x4, 0x1},
+		},
+		{
+			json:     "false",
+			expected: []byte{0x4, 0x2},
+		},
+		{
+			json:     "null",
+			expected: []byte{0x4, 0x0},
+		},
+
+		// Scalars
+		{
+			json:     `"foo"`,
+			expected: []byte{0xc, 0x3, 0x66, 0x6f, 0x6f},
+		},
+		{
+			json:     "1.0",
+			expected: []byte{0xb, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf0, 0x3f},
+		},
+		{
+			// String values up to 127 bytes use a one byte length encoding
+			name:     "127 byte string value",
+			json:     fmt.Sprintf("%q", generateLargeString(127)),
+			expected: append([]byte{0xc, 0x7f}, []byte(generateLargeString(127))...),
+		},
+		{
+			// String values over 127 bytes use a two byte length encoding
+			name:     "128 byte string value",
+			json:     fmt.Sprintf("%q", generateLargeString(128)),
+			expected: append([]byte{0xc, 0x80, 0x1}, []byte(generateLargeString(128))...),
+		},
+		{
+			// String values up to 16,383 bytes use a two byte length encoding
+			name:     "16,383 byte string value",
+			json:     fmt.Sprintf("%q", generateLargeString(16383)),
+			expected: append([]byte{0xc, 0xff, 0x7f}, []byte(generateLargeString(16383))...),
+		},
+		{
+			// String values over 16,383 bytes use a three byte length encoding
+			name:     "16,384 byte string value",
+			json:     fmt.Sprintf("%q", generateLargeString(16384)),
+			expected: append([]byte{0xc, 0x80, 0x80, 0x1}, []byte(generateLargeString(16384))...),
+		},
+
+		// Arrays
+		{
+			name: "small array encoding",
+			json: `["foo", "bar", true, "baz"]`,
+			expected: []byte{0x2, 0x4, 0x0, 0x1c, 0x0, 0xc, 0x10, 0x0, 0xc, 0x14, 0x0, 0x4, 0x1,
+				0x0, 0xc, 0x18, 0x0, 0x3, 0x66, 0x6f, 0x6f, 0x3, 0x62, 0x61, 0x72, 0x3, 0x62, 0x61, 0x7a},
+		},
+		{
+			name: "large array encoding",
+			json: fmt.Sprintf(`["a","%s","%s","c"]`, generateLargeString(35_000), generateLargeString(35_000)),
+			expected: appendByteSlices([]byte{0x3, 0x4, 0x0, 0x0, 0x0, 0x96, 0x11, 0x1, 0x0, 0xc, 0x1c, 0x0, 0x0, 0x0, 0xc, 0x1e, 0x0, 0x0, 0x0, 0xc, 0xd9, 0x88, 0x0, 0x0, 0xc, 0x94, 0x11, 0x1, 0x0, 0x1, 0x61},
+				[]byte{0xb8, 0x91, 0x2}, // 35_00 length
+				[]byte(generateLargeString(35_000)),
+				[]byte{0xb8, 0x91, 0x2}, // 35_00 length
+				[]byte(generateLargeString(35_000)),
+				[]byte{0x01, 'c'}),
+		},
+
+		// Objects
+		{
+			name: "small object encoding",
+			json: `{"foo": "bar", "zap": true}`,
+			expected: []byte{0x0, 0x2, 0x0, 0x1c, 0x0, 0x12, 0x0, 0x3, 0x0, 0x15, 0x0, 0x3, 0x0, 0xc,
+				0x18, 0x0, 0x4, 0x1, 0x0, 0x66, 0x6f, 0x6f, 0x7a, 0x61, 0x70, 0x3, 0x62, 0x61, 0x72},
+		},
+		{
+			name: "large object encoding",
+			json: fmt.Sprintf(`{"a":"%s", "b":"%s"}`, generateLargeString(35_000), generateLargeString(35_000)),
+			expected: appendByteSlices([]byte{0x1, 0x2, 0x0, 0x0, 0x0, 0x96, 0x11, 0x1, 0x0, 0x1e, 0x0, 0x0, 0x0, 0x1, 0x0, 0x1f, 0x0, 0x0, 0x0, 0x1, 0x0, 0xc, 0x20, 0x0, 0x0, 0x0, 0xc, 0xdb, 0x88, 0x0, 0x0, 0x61, 0x62},
+				[]byte{0xb8, 0x91, 0x2}, // 35_00 length
+				[]byte(generateLargeString(35_000)),
+				[]byte{0xb8, 0x91, 0x2}, // 35_00 length
+				[]byte(generateLargeString(35_000)),
+			),
+		},
+	}
+
+	for _, test := range tests {
+		name := test.json
+		if test.name != "" {
+			name = test.name
+		}
+		t.Run(name, func(t *testing.T) {
+			var jsonDoc any
+			require.NoError(t, json.Unmarshal([]byte(test.json), &jsonDoc))
+			encoded, err := encodeJsonDoc(gmstypes.JSONDocument{Val: jsonDoc})
+			require.NoError(t, err)
+			require.Equal(t, test.expected, encoded)
+		})
+	}
+}
+
+// TestJsonSerialization_VitessRoundTrip tests that we can properly encode JSON data to MySQL's internal encoding, then
+// decode it with Vitess's logic that parses the binary representation and turns it back into a SQL expression.
+func TestJsonSerialization_VitessRoundTrip(t *testing.T) {
+	tests := []struct {
+		name           string
+		json           string
+		expected       string
+		expectedTypeId byte
+		expectedErr    string
+	}{
+		// Literals
+		{
+			json:           "true",
+			expected:       "'true'",
+			expectedTypeId: jsonTypeLiteral,
+		},
+		{
+			json:           "false",
+			expected:       "'false'",
+			expectedTypeId: jsonTypeLiteral,
+		},
+		{
+			json:           "null",
+			expected:       "'null'",
+			expectedTypeId: jsonTypeLiteral,
+		},
+
+		// Scalars
+		{
+			json:           `"foo"`,
+			expected:       `'"foo"'`,
+			expectedTypeId: jsonTypeString,
+		},
+		{
+			json:           "1.0",
+			expected:       "'1E+00'",
+			expectedTypeId: jsonTypeDouble,
+		},
+		{
+			// String values up to 127 bytes use a one byte length encoding
+			name:     "127 byte string value",
+			json:     fmt.Sprintf("%q", generateLargeString(127)),
+			expected: fmt.Sprintf("'%q'", generateLargeString(127)),
+		},
+		{
+			// String values over 127 bytes use a two byte length encoding
+			name:     "128 byte string value",
+			json:     fmt.Sprintf("%q", generateLargeString(128)),
+			expected: fmt.Sprintf("'%q'", generateLargeString(128)),
+		},
+		{
+			// String values up to 16,383 bytes use a two byte length encoding
+			name:     "16,383 byte string value",
+			json:     fmt.Sprintf("%q", generateLargeString(16383)),
+			expected: fmt.Sprintf("'%q'", generateLargeString(16383)),
+		},
+		{
+			// String values over 16,383 bytes use a three byte length encoding
+			name:     "16,384 byte string value",
+			json:     fmt.Sprintf("%q", generateLargeString(16384)),
+			expected: fmt.Sprintf("'%q'", generateLargeString(16384)),
+		},
+		{
+			// String values over 2,097,151 bytes throw an error
+			name:        "2,097,152 bytes string value",
+			json:        fmt.Sprintf("%q", generateLargeString(2_097_152)),
+			expectedErr: "strings larger than 2,097,151 bytes not supported",
+		},
+
+		// Small Arrays
+		{
+			json:           `["foo", null]`,
+			expected:       "JSON_ARRAY('foo',null)",
+			expectedTypeId: jsonTypeSmallArray,
+		},
+		{
+			json:           `["foo", "bar", 1, 2, 3]`,
+			expected:       "JSON_ARRAY('foo','bar',1E+00,2E+00,3E+00)",
+			expectedTypeId: jsonTypeSmallArray,
+		},
+		{
+			json:           `[1.1, [2.2, "foo"], "bar", ["baz", "bash"]]`,
+			expected:       "JSON_ARRAY(1.1E+00,JSON_ARRAY(2.2E+00,'foo'),'bar',JSON_ARRAY('baz','bash'))",
+			expectedTypeId: jsonTypeSmallArray,
+		},
+		{
+			json:           `[1.1, [2.2, [3.3, ["foo"]]]]`,
+			expected:       "JSON_ARRAY(1.1E+00,JSON_ARRAY(2.2E+00,JSON_ARRAY(3.3E+00,JSON_ARRAY('foo'))))",
+			expectedTypeId: jsonTypeSmallArray,
+		},
+		{
+			json:           `[1.1, {"foo": ["bar", "baz", "bash"]}, 2.2]`,
+			expected:       "JSON_ARRAY(1.1E+00,JSON_OBJECT('foo',JSON_ARRAY('bar','baz','bash')),2.2E+00)",
+			expectedTypeId: jsonTypeSmallArray,
+		},
+
+		// Small Objects
+		{
+			json:           `{"foo": "bar", "baz": 1.23}`,
+			expected:       "JSON_OBJECT('baz',1.23E+00,'foo','bar')",
+			expectedTypeId: jsonTypeSmallObject,
+		},
+		{
+			json:           `{"foo": {"bar": {"baz": {"bash": 1.0}, "boo": 2.0}}}`,
+			expected:       "JSON_OBJECT('foo',JSON_OBJECT('bar',JSON_OBJECT('baz',JSON_OBJECT('bash',1E+00),'boo',2E+00)))",
+			expectedTypeId: jsonTypeSmallObject,
+		},
+		{
+			json:           `{"foo": ["bar", {"baz": {"bash": [1.123, 2.234]}, "boo": 2.0}]}`,
+			expected:       "JSON_OBJECT('foo',JSON_ARRAY('bar',JSON_OBJECT('baz',JSON_OBJECT('bash',JSON_ARRAY(1.123E+00,2.234E+00)),'boo',2E+00)))",
+			expectedTypeId: jsonTypeSmallObject,
+		},
+
+		// Large Arrays
+		{
+			name: "large array",
+			json: fmt.Sprintf(`[%q, %q, "baz", "bash"]`,
+				generateLargeString(33_000), generateLargeString(33_000)),
+			expected: fmt.Sprintf(`JSON_ARRAY('%s','%s','baz','bash')`,
+				generateLargeString(33_000), generateLargeString(33_000)),
+			expectedTypeId: jsonTypeLargeArray,
+		},
+
+		// Large Objects
+		{
+			name: "large object",
+			json: fmt.Sprintf(`{"foo": %q, "bar": %q, "zoo": "glorp"}`,
+				generateLargeString(33_000), generateLargeString(33_000)),
+			expected: fmt.Sprintf(`JSON_OBJECT('bar','%s','foo','%s','zoo','glorp')`,
+				generateLargeString(33_000), generateLargeString(33_000)),
+			expectedTypeId: jsonTypeLargeObject,
+		},
+	}
+
+	for _, test := range tests {
+		name := test.name
+		if test.name == "" {
+			name = test.json
+		}
+		t.Run(name, func(t *testing.T) {
+			var jsonDoc any
+			require.NoError(t, json.Unmarshal([]byte(test.json), &jsonDoc))
+			encoded, err := encodeJsonDoc(gmstypes.JSONDocument{Val: jsonDoc})
+
+			if test.expectedErr != "" {
+				require.Equal(t, test.expectedErr, err.Error())
+			} else {
+				require.NoError(t, err)
+				if test.expectedTypeId > 0 {
+					require.Equal(t, test.expectedTypeId, encoded[0],
+						"Expected type ID (%X) doesn't match actual type ID (%X)", test.expectedTypeId, encoded[0])
+				}
+
+				// TODO(fan): Available in the latest Vitess version, but not in the version we're using.
+				// sql, err := mysql.ConvertBinaryJSONToSQL(encoded)
+				// require.NoError(t, err)
+				// require.Equal(t, test.expected, sql)
+			}
+		})
+	}
+}
+
+func generateLargeString(length uint) (s string) {
+	sampleText := "abcdefghijklmnopqrstuvwxyz1234567890"
+
+	for len(s) < int(length) {
+		pos := len(sampleText)
+		if pos > int(length)-len(s) {
+			pos = int(length) - len(s)
+		}
+		s += sampleText[0:pos]
+	}
+
+	return s
+}
+
+func appendByteSlices(bytes ...[]byte) []byte {
+	length := 0
+	for _, byteSlice := range bytes {
+		length += len(byteSlice)
+	}
+	result := make([]byte, length)
+
+	pos := 0
+	for _, byteSlice := range bytes {
+		pos += copy(result[pos:], byteSlice)
+	}
+	return result
+}

--- a/binlogreplication/binlog_metadata_persistence.go
+++ b/binlogreplication/binlog_metadata_persistence.go
@@ -1,0 +1,149 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binlogreplication
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/mysql_db"
+)
+
+// replicationRunningStateDirectory is the directory where the "replica-running" file is stored to indicate that
+// replication on a replica was running the last time the server was running.
+const replicationRunningStateDirectory = ".replica"
+
+// replicaRunningFilename holds the name of the file that indicates replication was running on a replica server.
+const replicaRunningFilename = "replica-running"
+
+// replicaRunningState indicates if a replica was actively running replication.
+type replicaRunningState int
+
+const (
+	running replicaRunningState = iota
+	notRunning
+)
+
+// persistReplicationConfiguration saves the specified |replicaSourceInfo| to the "mysql"
+// database |mysqlDb|. If any problems are encountered while saving to disk, an error is returned.
+func persistReplicationConfiguration(ctx *sql.Context, replicaSourceInfo *mysql_db.ReplicaSourceInfo, mysqlDb *mysql_db.MySQLDb) error {
+	ed := mysqlDb.Editor()
+	defer ed.Close()
+	ed.PutReplicaSourceInfo(replicaSourceInfo)
+	return mysqlDb.Persist(ctx, ed)
+}
+
+// loadReplicationRunningState loads the replication running state from disk by looking for a "replica-running" file
+// in the .doltcfg directory. An error is returned if any problems were encountered loading the state from disk.
+func loadReplicationRunningState(ctx *sql.Context) (replicaRunningState, error) {
+	replicationRunningStateFilepath, err := filepath.Abs(
+		filepath.Join(replicationRunningStateDirectory, replicaRunningFilename))
+	if err != nil {
+		return notRunning, err
+	}
+
+	if _, err := os.Stat(replicationRunningStateFilepath); err == nil {
+		return running, nil
+	} else if errors.Is(err, fs.ErrNotExist) {
+		return notRunning, nil
+	} else {
+		return notRunning, err
+	}
+}
+
+// persistReplicaRunningState records the running |state| of a replica to disk by creating a "replica-running" empty
+// file in the .doltcfg directory. An error is returned if any problems were encountered saving the state to disk.
+func persistReplicaRunningState(ctx *sql.Context, state replicaRunningState) error {
+	// The .doltcfg dir may not exist yet, so create it if necessary.
+	err := createReplicaDir()
+	if err != nil {
+		return err
+	}
+
+	replicationRunningStateFilepath, err := filepath.Abs(
+		filepath.Join(replicationRunningStateDirectory, replicaRunningFilename))
+	if err != nil {
+		return err
+	}
+
+	switch state {
+	case running:
+		return createEmptyFile(replicationRunningStateFilepath)
+	case notRunning:
+		_, err = os.Stat(replicationRunningStateFilepath)
+		if os.IsNotExist(err) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		return os.Remove(replicationRunningStateFilepath)
+	default:
+		return fmt.Errorf("unsupported replica running state: %v", state)
+	}
+}
+
+// loadReplicationConfiguration loads the replication configuration for default channel ("") from
+// the "mysql" database, |mysqlDb|.
+func loadReplicationConfiguration(_ *sql.Context, mysqlDb *mysql_db.MySQLDb) (*mysql_db.ReplicaSourceInfo, error) {
+	rd := mysqlDb.Reader()
+	defer rd.Close()
+
+	rsi, ok := rd.GetReplicaSourceInfo(mysql_db.ReplicaSourceInfoPrimaryKey{
+		Channel: "",
+	})
+	if ok {
+		return rsi, nil
+	}
+
+	return nil, nil
+}
+
+// deleteReplicationConfiguration deletes all replication configuration for the default channel ("")
+// from the specified "mysql" database, |mysqlDb|.
+func deleteReplicationConfiguration(ctx *sql.Context, mysqlDb *mysql_db.MySQLDb) error {
+	ed := mysqlDb.Editor()
+	defer ed.Close()
+
+	ed.RemoveReplicaSourceInfo(mysql_db.ReplicaSourceInfoPrimaryKey{})
+
+	return mysqlDb.Persist(ctx, ed)
+}
+
+// persistSourceUuid saves the specified |sourceUuid| to the "mysql" database, |mysqlDb|.
+func persistSourceUuid(ctx *sql.Context, sourceUuid string, mysqlDb *mysql_db.MySQLDb) error {
+	replicaSourceInfo, err := loadReplicationConfiguration(ctx, mysqlDb)
+	if err != nil {
+		return err
+	}
+
+	replicaSourceInfo.Uuid = sourceUuid
+	return persistReplicationConfiguration(ctx, replicaSourceInfo, mysqlDb)
+}
+
+// createEmptyFile creates an empty file at |fullFilepath| if a file does not exist already. If a file does exist
+// at that path, no action is taken.
+func createEmptyFile(fullFilepath string) (err error) {
+	_, err = os.Stat(fullFilepath)
+	if os.IsNotExist(err) {
+		var emptyFile *os.File
+		emptyFile, err = os.Create(fullFilepath)
+		defer emptyFile.Close()
+	}
+	return err
+}

--- a/binlogreplication/binlog_position_store.go
+++ b/binlogreplication/binlog_position_store.go
@@ -1,0 +1,143 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binlogreplication
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/vitess/go/mysql"
+)
+
+const binlogPositionDirectory = ".replica"
+const binlogPositionFilename = "binlog-position"
+const mysqlFlavor = "MySQL56"
+
+// binlogPositionStore manages loading and saving data to the binlog position file stored on disk. This provides
+// durable storage for the set of GTIDs that have been successfully executed on the replica, so that the replica
+// server can be restarted and resume binlog event messages at the correct point.
+type binlogPositionStore struct {
+	mu sync.Mutex
+}
+
+// Load loads a mysql.Position instance from the .replica/binlog-position file at the root of working directory
+// This file MUST be stored at the root of the provider's filesystem, and NOT inside a nested database's .replica directory,
+// since the binlog position contains events that cover all databases in a SQL server. The returned mysql.Position
+// represents the set of GTIDs that have been successfully executed and applied on this replica. Currently only the
+// default binlog channel ("") is supported. If no .replica/binlog-position file is stored, this method returns a nil
+// mysql.Position and a nil error. If any errors are encountered, a nil mysql.Position and an error are returned.
+func (store *binlogPositionStore) Load() (*mysql.Position, error) {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	_, err := os.Stat(binlogPositionDirectory)
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	_, err = os.Stat(filepath.Join(binlogPositionDirectory, binlogPositionFilename))
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	filePath, err := filepath.Abs(filepath.Join(binlogPositionDirectory, binlogPositionFilename))
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	positionString := string(bytes)
+
+	// Strip off the "MySQL56/" prefix
+	prefix := "MySQL56/"
+	if strings.HasPrefix(positionString, prefix) {
+		positionString = string(bytes[len(prefix):])
+	}
+
+	position, err := mysql.ParsePosition(mysqlFlavor, positionString)
+	if err != nil {
+		return nil, err
+	}
+
+	return &position, nil
+}
+
+// Save saves the specified |position| to disk in the .replica/binlog-position file at the root of the provider's
+// filesystem. This file MUST be stored at the root of the provider's filesystem, and NOT inside a nested database's
+// .replica directory, since the binlog position contains events that cover all databases in a SQL server. |position|
+// represents the set of GTIDs that have been successfully executed and applied on this replica. Currently only the
+// default binlog channel ("") is supported. If any errors are encountered persisting the position to disk, an
+// error is returned.
+func (store *binlogPositionStore) Save(ctx *sql.Context, position *mysql.Position) error {
+	if position == nil {
+		return fmt.Errorf("unable to save binlog position: nil position passed")
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	// The .replica dir may not exist yet, so create it if necessary.
+	if err := createReplicaDir(); err != nil {
+		return err
+	}
+
+	filePath, err := filepath.Abs(filepath.Join(binlogPositionDirectory, binlogPositionFilename))
+	if err != nil {
+		return err
+	}
+
+	encodedPosition := mysql.EncodePosition(*position)
+	return os.WriteFile(filePath, []byte(encodedPosition), 0666)
+}
+
+// Delete deletes the stored mysql.Position information stored in .replica/binlog-position in the root of the provider's
+// filesystem. This is useful for the "RESET REPLICA" command, since it clears out the current replication state. If
+// any errors are encountered removing the position file, an error is returned.
+func (store *binlogPositionStore) Delete(ctx *sql.Context) error {
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	return os.Remove(filepath.Join(binlogPositionDirectory, binlogPositionFilename))
+}
+
+// createReplicaDir creates the .replica directory if it doesn't already exist.
+func createReplicaDir() error {
+	stat, err := os.Stat(binlogPositionDirectory)
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
+		err := os.MkdirAll(binlogPositionDirectory, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("unable to save binlog metadata: %s", err)
+		}
+	} else if err != nil {
+		return err
+	} else if !stat.IsDir() {
+		return fmt.Errorf("unable to save binlog metadata: %s exists as a file, not a dir", binlogPositionDirectory)
+	}
+
+	return nil
+}

--- a/binlogreplication/binlog_replica_applier.go
+++ b/binlogreplication/binlog_replica_applier.go
@@ -1,0 +1,933 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binlogreplication
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	gms "github.com/dolthub/go-mysql-server"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/binlogreplication"
+	"github.com/dolthub/go-mysql-server/sql/mysql_db"
+	"github.com/dolthub/go-mysql-server/sql/planbuilder"
+	"github.com/dolthub/go-mysql-server/sql/rowexec"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/vitess/go/mysql"
+	"github.com/dolthub/vitess/go/sqltypes"
+	vquery "github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/sirupsen/logrus"
+)
+
+// positionStore is a singleton instance for loading/saving binlog position state to disk for durable storage.
+var positionStore = &binlogPositionStore{}
+
+const (
+	ERNetReadError      = 1158
+	ERFatalReplicaError = 13117
+)
+
+// binlogReplicaApplier represents the process that applies updates from a binlog connection.
+//
+// This type is NOT used concurrently – there is currently only one single applier process running to process binlog
+// events, so the state in this type is NOT protected with a mutex.
+type binlogReplicaApplier struct {
+	format                *mysql.BinlogFormat
+	tableMapsById         map[uint64]*mysql.TableMap
+	stopReplicationChan   chan struct{}
+	currentGtid           mysql.GTID
+	replicationSourceUuid string
+	currentPosition       *mysql.Position // successfully executed GTIDs
+	filters               *filterConfiguration
+	running               atomic.Bool
+	engine                *gms.Engine
+}
+
+func newBinlogReplicaApplier(filters *filterConfiguration) *binlogReplicaApplier {
+	return &binlogReplicaApplier{
+		tableMapsById:       make(map[uint64]*mysql.TableMap),
+		stopReplicationChan: make(chan struct{}),
+		filters:             filters,
+	}
+}
+
+// Row Flags – https://mariadb.com/kb/en/rows_event_v1v2-rows_compressed_event_v1/
+
+// rowFlag_endOfStatement indicates that a row event with this flag set is the last event in a statement.
+const rowFlag_endOfStatement = 0x0001
+const rowFlag_noForeignKeyChecks = 0x0002
+const rowFlag_noUniqueKeyChecks = 0x0004
+const rowFlag_noCheckConstraints = 0x0010
+
+// rowFlag_rowsAreComplete indicates that rows in this event are complete, and contain values for all columns of the table.
+const rowFlag_rowsAreComplete = 0x0008
+
+// Go spawns a new goroutine to run the applier's binlog event handler.
+func (a *binlogReplicaApplier) Go(ctx *sql.Context) {
+	go func() {
+		a.running.Store(true)
+		err := a.replicaBinlogEventHandler(ctx)
+		a.running.Store(false)
+		if err != nil {
+			ctx.GetLogger().Errorf("unexpected error of type %T: '%v'", err, err.Error())
+			DoltBinlogReplicaController.setSqlError(mysql.ERUnknownError, err.Error())
+		}
+	}()
+}
+
+// IsRunning returns true if this binlog applier is running and has not been stopped, otherwise returns false.
+func (a *binlogReplicaApplier) IsRunning() bool {
+	return a.running.Load()
+}
+
+// connectAndStartReplicationEventStream connects to the configured MySQL replication source, including pausing
+// and retrying if errors are encountered.
+func (a *binlogReplicaApplier) connectAndStartReplicationEventStream(ctx *sql.Context) (*mysql.Conn, error) {
+	var maxConnectionAttempts uint64
+	var connectRetryDelay uint32
+	DoltBinlogReplicaController.updateStatus(func(status *binlogreplication.ReplicaStatus) {
+		status.ReplicaIoRunning = binlogreplication.ReplicaIoConnecting
+		status.ReplicaSqlRunning = binlogreplication.ReplicaSqlRunning
+		maxConnectionAttempts = status.SourceRetryCount
+		connectRetryDelay = status.ConnectRetry
+	})
+
+	var conn *mysql.Conn
+	var err error
+	for connectionAttempts := uint64(0); ; connectionAttempts++ {
+		replicaSourceInfo, err := loadReplicationConfiguration(ctx, a.engine.Analyzer.Catalog.MySQLDb)
+
+		if replicaSourceInfo == nil {
+			err = ErrServerNotConfiguredAsReplica
+			DoltBinlogReplicaController.setIoError(ERFatalReplicaError, err.Error())
+			return nil, err
+		} else if replicaSourceInfo.Uuid != "" {
+			a.replicationSourceUuid = replicaSourceInfo.Uuid
+		}
+
+		if replicaSourceInfo.Host == "" {
+			DoltBinlogReplicaController.setIoError(ERFatalReplicaError, ErrEmptyHostname.Error())
+			return nil, ErrEmptyHostname
+		} else if replicaSourceInfo.User == "" {
+			DoltBinlogReplicaController.setIoError(ERFatalReplicaError, ErrEmptyUsername.Error())
+			return nil, ErrEmptyUsername
+		}
+
+		connParams := mysql.ConnParams{
+			Host:             replicaSourceInfo.Host,
+			Port:             int(replicaSourceInfo.Port),
+			Uname:            replicaSourceInfo.User,
+			Pass:             replicaSourceInfo.Password,
+			ConnectTimeoutMs: 4_000,
+		}
+
+		conn, err = mysql.Connect(ctx, &connParams)
+		if err != nil {
+			logrus.Warnf("failed connection attempt to source (%s): %s",
+				replicaSourceInfo.Host, err.Error())
+
+			if connectionAttempts >= maxConnectionAttempts {
+				ctx.GetLogger().Errorf("Exceeded max connection attempts (%d) to source (%s)",
+					maxConnectionAttempts, replicaSourceInfo.Host)
+				return nil, err
+			}
+			// If there was an error connecting (and we haven't used up all our retry attempts), listen for a
+			// STOP REPLICA signal or for the retry delay timer to fire. We need to use select here so that we don't
+			// block on our retry backoff and ignore the STOP REPLICA signal for a long time.
+			select {
+			case <-a.stopReplicationChan:
+				ctx.GetLogger().Debugf("Received stop replication signal while trying to connect")
+				return nil, ErrReplicationStopped
+			case <-time.After(time.Duration(connectRetryDelay) * time.Second):
+				// Nothing to do here if our timer completes; just fall through
+			}
+		} else {
+			break
+		}
+	}
+
+	// Request binlog events to start
+	// TODO: This should also have retry logic
+	err = a.startReplicationEventStream(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+
+	DoltBinlogReplicaController.updateStatus(func(status *binlogreplication.ReplicaStatus) {
+		status.ReplicaIoRunning = binlogreplication.ReplicaIoRunning
+	})
+
+	return conn, nil
+}
+
+// startReplicationEventStream sends a request over |conn|, the connection to the MySQL source server, to begin
+// sending binlog events.
+func (a *binlogReplicaApplier) startReplicationEventStream(ctx *sql.Context, conn *mysql.Conn) error {
+	serverId, err := loadReplicaServerId()
+	if err != nil {
+		return err
+	}
+
+	position, err := positionStore.Load()
+	if err != nil {
+		return err
+	}
+
+	if position == nil {
+		// If the positionStore doesn't have a record of executed GTIDs, check to see if the gtid_purged system
+		// variable is set. If it holds a GTIDSet, then we use that as our starting position. As part of loading
+		// a mysqldump onto a replica, gtid_purged will be set to indicate where to start replication.
+		_, value, ok := sql.SystemVariables.GetGlobal("gtid_purged")
+		gtidPurged, isString := value.(string)
+		if ok && value != nil && isString {
+			// Starting in MySQL 8.0, when setting the GTID_PURGED sys variable, if the new value starts with '+', then
+			// the specified GTID Set value is added to the current GTID Set value to get a new GTID Set that contains
+			// all the previous GTIDs, plus the new ones from the current assignment. Dolt doesn't support this
+			// special behavior for appending to GTID Sets yet, so in this case the GTID_PURGED sys var will end up
+			// with a "+" prefix. For now, just ignore the "+" prefix if we see it.
+			// https://dev.mysql.com/doc/refman/8.0/en/replication-options-gtids.html#sysvar_gtid_purged
+			if strings.HasPrefix(gtidPurged, "+") {
+				ctx.GetLogger().Warnf("Ignoring unsupported '+' prefix on @@GTID_PURGED value")
+				gtidPurged = gtidPurged[1:]
+			}
+
+			purged, err := mysql.ParsePosition(mysqlFlavor, gtidPurged)
+			if err != nil {
+				return err
+			}
+			position = &purged
+		}
+	}
+
+	if position == nil {
+		// If we still don't have any record of executed GTIDs, we create a GTIDSet with just one transaction ID
+		// for the 0000 server ID. There doesn't seem to be a cleaner way of saying "start at the very beginning".
+		//
+		// Also... "starting position" is a bit of a misnomer – it's actually the processed GTIDs, which
+		// indicate the NEXT GTID where replication should start, but it's not as direct as specifying
+		// a starting position, like the Vitess function signature seems to suggest.
+		gtid := mysql.Mysql56GTID{
+			Sequence: 1,
+		}
+		position = &mysql.Position{GTIDSet: gtid.GTIDSet()}
+	}
+
+	a.currentPosition = position
+
+	// Clear out the format description in case we're reconnecting, so that we don't use the old format description
+	// to interpret any event messages before we receive the new format description from the new stream.
+	a.format = nil
+
+	// If the source server has binlog checksums enabled (@@global.binlog_checksum), then the replica MUST
+	// set @master_binlog_checksum to handshake with the server to acknowledge that it knows that checksums
+	// are in use. Without this step, the server will just send back error messages saying that the replica
+	// does not support the binlog checksum algorithm in use on the primary.
+	// For more details, see: https://dev.mysql.com/worklog/task/?id=2540
+	_, err = conn.ExecuteFetch("set @master_binlog_checksum=@@global.binlog_checksum;", 0, false)
+	if err != nil {
+		return err
+	}
+
+	return conn.SendBinlogDumpCommand(serverId, *position)
+}
+
+// replicaBinlogEventHandler runs a loop, processing binlog events until the applier's stop replication channel
+// receives a signal to stop.
+func (a *binlogReplicaApplier) replicaBinlogEventHandler(ctx *sql.Context) error {
+	engine := a.engine
+
+	var conn *mysql.Conn
+	var eventProducer *binlogEventProducer
+
+	// Process binlog events
+	for {
+		if conn == nil {
+			ctx.GetLogger().Debug("no binlog connection to source, attempting to establish one")
+			if eventProducer != nil {
+				eventProducer.Stop()
+			}
+
+			var err error
+			if conn, err = a.connectAndStartReplicationEventStream(ctx); err == ErrReplicationStopped {
+				return nil
+			} else if err != nil {
+				return err
+			}
+			eventProducer = newBinlogEventProducer(conn)
+			eventProducer.Go(ctx)
+		}
+
+		select {
+		case event := <-eventProducer.EventChan():
+			err := a.processBinlogEvent(ctx, engine, event)
+			if err != nil {
+				ctx.GetLogger().Errorf("unexpected error of type %T: '%v'", err, err.Error())
+				DoltBinlogReplicaController.setSqlError(mysql.ERUnknownError, err.Error())
+			}
+
+		case err := <-eventProducer.ErrorChan():
+			if sqlError, isSqlError := err.(*mysql.SQLError); isSqlError {
+				badConnection := sqlError.Message == io.EOF.Error() ||
+					strings.HasPrefix(sqlError.Message, io.ErrUnexpectedEOF.Error())
+				if badConnection {
+					DoltBinlogReplicaController.updateStatus(func(status *binlogreplication.ReplicaStatus) {
+						status.LastIoError = sqlError.Message
+						status.LastIoErrNumber = ERNetReadError
+						currentTime := time.Now()
+						status.LastIoErrorTimestamp = &currentTime
+					})
+					eventProducer.Stop()
+					eventProducer = nil
+					conn.Close()
+					conn = nil
+				}
+			} else {
+				// otherwise, log the error if it's something we don't expect and continue
+				ctx.GetLogger().Errorf("unexpected error of type %T: '%v'", err, err.Error())
+				DoltBinlogReplicaController.setIoError(mysql.ERUnknownError, err.Error())
+			}
+
+		case <-a.stopReplicationChan:
+			ctx.GetLogger().Trace("received stop replication signal")
+			eventProducer.Stop()
+			return nil
+		}
+	}
+}
+
+// processBinlogEvent processes a single binlog event message and returns an error if there were any problems
+// processing it.
+func (a *binlogReplicaApplier) processBinlogEvent(ctx *sql.Context, engine *gms.Engine, event mysql.BinlogEvent) error {
+	var err error
+	createCommit := false
+	commitToAllDatabases := false
+
+	// We don't support checksum validation, so we MUST strip off any checksum bytes if present, otherwise it gets
+	// interpreted as part of the payload and corrupts the data. Future checksum sizes, are not guaranteed to be the
+	// same size, so we can't strip the checksum until we've seen a valid Format binlog event that definitively
+	// tells us if checksums are enabled and what algorithm they use. We can NOT strip the checksum off of
+	// FormatDescription events, because FormatDescription always includes a CRC32 checksum, and Vitess depends on
+	// those bytes always being present when we parse the event into a FormatDescription type.
+	if a.format != nil && event.IsFormatDescription() == false {
+		var err error
+		event, _, err = event.StripChecksum(*a.format)
+		if err != nil {
+			msg := fmt.Sprintf("unable to strip checksum from binlog event: '%v'", err.Error())
+			ctx.GetLogger().Error(msg)
+			DoltBinlogReplicaController.setSqlError(mysql.ERUnknownError, msg)
+		}
+	}
+
+	switch {
+	case event.IsRand():
+		// A RAND_EVENT contains two seed values that set the rand_seed1 and rand_seed2 system variables that are
+		// used to compute the random number. For more details, see: https://mariadb.com/kb/en/rand_event/
+		// Note: it is written only before a QUERY_EVENT and is NOT used with row-based logging.
+		ctx.GetLogger().Trace("Received binlog event: Rand")
+
+	case event.IsXID():
+		// An XID event is generated for a COMMIT of a transaction that modifies one or more tables of an
+		// XA-capable storage engine. For more details, see: https://mariadb.com/kb/en/xid_event/
+		ctx.GetLogger().Trace("Received binlog event: XID")
+		createCommit = true
+		commitToAllDatabases = true
+
+	case event.IsQuery():
+		// A Query event represents a statement executed on the source server that should be executed on the
+		// replica. Used for all statements with statement-based replication, DDL statements with row-based replication
+		// as well as COMMITs for non-transactional engines such as MyISAM.
+		// For more details, see: https://mariadb.com/kb/en/query_event/
+		query, err := event.Query(*a.format)
+		if err != nil {
+			return err
+		}
+		ctx.GetLogger().WithFields(logrus.Fields{
+			"database": query.Database,
+			"charset":  query.Charset,
+			"query":    query.SQL,
+			"options":  fmt.Sprintf("0x%x", query.Options),
+			"sql_mode": fmt.Sprintf("0x%x", query.SqlMode),
+		}).Trace("Received binlog event: Query")
+
+		// When executing SQL statements sent from the primary, we can't be sure what database was modified unless we
+		// look closely at the statement. For example, we could be connected to db01, but executed
+		// "create table db02.t (...);" – i.e., looking at query.Database is NOT enough to always determine the correct
+		// database that was modified, so instead, we commit to all databases when we see a Query binlog event to
+		// avoid issues with correctness, at the cost of being slightly less efficient
+		commitToAllDatabases = true
+
+		if query.Options&mysql.QFlagOptionAutoIsNull > 0 {
+			ctx.GetLogger().Tracef("Setting sql_auto_is_null ON")
+			ctx.SetSessionVariable(ctx, "sql_auto_is_null", 1)
+		} else {
+			ctx.GetLogger().Tracef("Setting sql_auto_is_null OFF")
+			ctx.SetSessionVariable(ctx, "sql_auto_is_null", 0)
+		}
+
+		if query.Options&mysql.QFlagOptionNotAutocommit > 0 {
+			ctx.GetLogger().Tracef("Setting autocommit=0")
+			ctx.SetSessionVariable(ctx, "autocommit", 0)
+		} else {
+			ctx.GetLogger().Tracef("Setting autocommit=1")
+			ctx.SetSessionVariable(ctx, "autocommit", 1)
+		}
+
+		if query.Options&mysql.QFlagOptionNoForeignKeyChecks > 0 {
+			ctx.GetLogger().Tracef("Setting foreign_key_checks=0")
+			ctx.SetSessionVariable(ctx, "foreign_key_checks", 0)
+		} else {
+			ctx.GetLogger().Tracef("Setting foreign_key_checks=1")
+			ctx.SetSessionVariable(ctx, "foreign_key_checks", 1)
+		}
+
+		// NOTE: unique_checks is not currently honored by Dolt
+		if query.Options&mysql.QFlagOptionRelaxedUniqueChecks > 0 {
+			ctx.GetLogger().Tracef("Setting unique_checks=0")
+			ctx.SetSessionVariable(ctx, "unique_checks", 0)
+		} else {
+			ctx.GetLogger().Tracef("Setting unique_checks=1")
+			ctx.SetSessionVariable(ctx, "unique_checks", 1)
+		}
+
+		ctx.SetCurrentDatabase(query.Database)
+		executeQueryWithEngine(ctx, engine, query.SQL)
+		createCommit = strings.ToLower(query.SQL) != "begin"
+
+	case event.IsRotate():
+		// When a binary log file exceeds the configured size limit, a ROTATE_EVENT is written at the end of the file,
+		// pointing to the next file in the sequence. ROTATE_EVENT is generated locally and written to the binary log
+		// on the source server and it's also written when a FLUSH LOGS statement occurs on the source server.
+		// For more details, see: https://mariadb.com/kb/en/rotate_event/
+		ctx.GetLogger().Trace("Received binlog event: Rotate")
+
+	case event.IsFormatDescription():
+		// This is a descriptor event that is written to the beginning of a binary log file, at position 4 (after
+		// the 4 magic number bytes). For more details, see: https://mariadb.com/kb/en/format_description_event/
+		format, err := event.Format()
+		if err != nil {
+			return err
+		}
+		a.format = &format
+		ctx.GetLogger().WithFields(logrus.Fields{
+			"format":        a.format,
+			"formatVersion": a.format.FormatVersion,
+			"serverVersion": a.format.ServerVersion,
+			"checksum":      a.format.ChecksumAlgorithm,
+		}).Trace("Received binlog event: FormatDescription")
+
+	case event.IsPreviousGTIDs():
+		// Logged in every binlog to record the current replication state. Consists of the last GTID seen for each
+		// replication domain. For more details, see: https://mariadb.com/kb/en/gtid_list_event/
+		position, err := event.PreviousGTIDs(*a.format)
+		if err != nil {
+			return err
+		}
+		ctx.GetLogger().WithFields(logrus.Fields{
+			"previousGtids": position.GTIDSet.String(),
+		}).Trace("Received binlog event: PreviousGTIDs")
+
+	case event.IsGTID():
+		// For global transaction ID, used to start a new transaction event group, instead of the old BEGIN query event,
+		// and also to mark stand-alone (ddl). For more details, see: https://mariadb.com/kb/en/gtid_event/
+		gtid, isBegin, err := event.GTID(*a.format)
+		if err != nil {
+			return err
+		}
+		if isBegin {
+			ctx.GetLogger().Errorf("unsupported binlog protocol message: GTID event with 'isBegin' set to true")
+		}
+		ctx.GetLogger().WithFields(logrus.Fields{
+			"gtid":    gtid,
+			"isBegin": isBegin,
+		}).Trace("Received binlog event: GTID")
+		a.currentGtid = gtid
+		// if the source's UUID hasn't been set yet, set it and persist it
+		if a.replicationSourceUuid == "" {
+			uuid := fmt.Sprintf("%v", gtid.SourceServer())
+			err = persistSourceUuid(ctx, uuid, a.engine.Analyzer.Catalog.MySQLDb)
+			if err != nil {
+				return err
+			}
+			a.replicationSourceUuid = uuid
+		}
+
+	case event.IsTableMap():
+		// Used for row-based binary logging beginning (binlog_format=ROW or MIXED). This event precedes each row
+		// operation event and maps a table definition to a number, where the table definition consists of database
+		// and table names. For more details, see: https://mariadb.com/kb/en/table_map_event/
+		// Note: TableMap events are sent before each row event, so there is no need to persist them between restarts.
+		tableId := event.TableID(*a.format)
+		tableMap, err := event.TableMap(*a.format)
+		if err != nil {
+			return err
+		}
+		ctx.GetLogger().WithFields(logrus.Fields{
+			"id":        tableId,
+			"tableName": tableMap.Name,
+			"database":  tableMap.Database,
+			"flags":     convertToHexString(tableMap.Flags),
+			"metadata":  tableMap.Metadata,
+			"types":     tableMap.Types,
+		}).Trace("Received binlog event: TableMap")
+
+		if tableId == 0xFFFFFF {
+			// Table ID 0xFFFFFF is a special value that indicates table maps can be freed.
+			ctx.GetLogger().Infof("binlog protocol message: table ID '0xFFFFFF'; clearing table maps")
+			a.tableMapsById = make(map[uint64]*mysql.TableMap)
+		} else {
+			flags := tableMap.Flags
+			if flags&rowFlag_endOfStatement == rowFlag_endOfStatement {
+				// nothing to be done for end of statement; just clear the flag
+				flags = flags &^ rowFlag_endOfStatement
+			}
+			if flags&rowFlag_noForeignKeyChecks == rowFlag_noForeignKeyChecks {
+				flags = flags &^ rowFlag_noForeignKeyChecks
+			}
+			if flags != 0 {
+				msg := fmt.Sprintf("unsupported binlog protocol message: TableMap event with unsupported flags '%x'", flags)
+				ctx.GetLogger().Errorf(msg)
+				DoltBinlogReplicaController.setSqlError(mysql.ERUnknownError, msg)
+			}
+			a.tableMapsById[tableId] = tableMap
+		}
+
+	case event.IsDeleteRows(), event.IsWriteRows(), event.IsUpdateRows():
+		// A ROWS_EVENT is written for row based replication if data is inserted, deleted or updated.
+		// For more details, see: https://mariadb.com/kb/en/rows_event_v1v2-rows_compressed_event_v1/
+		err = a.processRowEvent(ctx, event, engine)
+		if err != nil {
+			return err
+		}
+
+	default:
+		// We can't access the bytes directly because these non-interface types in Vitess are not exposed.
+		// Having a Bytes() or Type() method on the Vitess interface would let us clean this up.
+		byteString := fmt.Sprintf("%v", event)
+		if strings.HasPrefix(byteString, "{[0 0 0 0 27 ") {
+			// Type 27 is a Heartbeat event. This event does not appear in the binary log. It's only sent over the
+			// network by a primary to a replica to let it know that the primary is still alive, and is only sent
+			// when the primary has no binlog events to send to replica servers.
+			// For more details, see: https://mariadb.com/kb/en/heartbeat_log_event/
+			ctx.GetLogger().Trace("Received binlog event: Heartbeat")
+		} else {
+			return fmt.Errorf("received unknown event: %v", event)
+		}
+	}
+
+	if createCommit {
+		var databasesToCommit []string
+		if commitToAllDatabases {
+			databasesToCommit = getAllUserDatabaseNames(ctx, engine)
+			for _, database := range databasesToCommit {
+				executeQueryWithEngine(ctx, engine, "use `"+database+"`;")
+				executeQueryWithEngine(ctx, engine, "commit;")
+			}
+		}
+
+		// Record the last GTID processed after the commit
+		a.currentPosition.GTIDSet = a.currentPosition.GTIDSet.AddGTID(a.currentGtid)
+		err := sql.SystemVariables.AssignValues(map[string]interface{}{"gtid_executed": a.currentPosition.GTIDSet.String()})
+		if err != nil {
+			ctx.GetLogger().Errorf("unable to set @@GLOBAL.gtid_executed: %s", err.Error())
+		}
+		err = positionStore.Save(ctx, a.currentPosition)
+		if err != nil {
+			return fmt.Errorf("unable to store GTID executed metadata to disk: %s", err.Error())
+		}
+
+		// For now, create a Dolt commit from every data update. Eventually, we'll want to make this configurable.
+		ctx.GetLogger().Trace("Creating Dolt commit(s)")
+		for _, database := range databasesToCommit {
+			executeQueryWithEngine(ctx, engine, "use `"+database+"`;")
+			executeQueryWithEngine(ctx, engine,
+				fmt.Sprintf("call dolt_commit('-Am', 'Dolt binlog replica commit: GTID %s');", a.currentGtid))
+		}
+	}
+
+	return nil
+}
+
+// processRowEvent processes a WriteRows, DeleteRows, or UpdateRows binlog event and returns an error if any problems
+// were encountered.
+func (a *binlogReplicaApplier) processRowEvent(ctx *sql.Context, event mysql.BinlogEvent, engine *gms.Engine) error {
+	var eventType string
+	switch {
+	case event.IsDeleteRows():
+		eventType = "DeleteRows"
+	case event.IsWriteRows():
+		eventType = "WriteRows"
+	case event.IsUpdateRows():
+		eventType = "UpdateRows"
+	default:
+		return fmt.Errorf("unsupported event type: %v", event)
+	}
+	ctx.GetLogger().Tracef("Received binlog event: %s", eventType)
+
+	tableId := event.TableID(*a.format)
+	tableMap, ok := a.tableMapsById[tableId]
+	if !ok {
+		return fmt.Errorf("unable to find replication metadata for table ID: %d", tableId)
+	}
+
+	if a.filters.isTableFilteredOut(ctx, tableMap) {
+		return nil
+	}
+
+	rows, err := event.Rows(*a.format, tableMap)
+	if err != nil {
+		return err
+	}
+
+	ctx.GetLogger().WithFields(logrus.Fields{
+		"flags": fmt.Sprintf("%x", rows.Flags),
+	}).Tracef("Processing rows from %s event", eventType)
+
+	flags := rows.Flags
+	foreignKeyChecksDisabled := false
+	if flags&rowFlag_endOfStatement > 0 {
+		// nothing to be done for end of statement; just clear the flag and move on
+		flags = flags &^ rowFlag_endOfStatement
+	}
+	if flags&rowFlag_noForeignKeyChecks > 0 {
+		foreignKeyChecksDisabled = true
+		flags = flags &^ rowFlag_noForeignKeyChecks
+	}
+	if flags != 0 {
+		msg := fmt.Sprintf("unsupported binlog protocol message: row event with unsupported flags '%x'", flags)
+		ctx.GetLogger().Errorf(msg)
+		DoltBinlogReplicaController.setSqlError(mysql.ERUnknownError, msg)
+	}
+	schema, tableName, err := getTableSchema(ctx, engine, tableMap.Name, tableMap.Database)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case event.IsDeleteRows():
+		ctx.GetLogger().Tracef(" - Deleted Rows (table: %s)", tableMap.Name)
+	case event.IsUpdateRows():
+		ctx.GetLogger().Tracef(" - Updated Rows (table: %s)", tableMap.Name)
+	case event.IsWriteRows():
+		ctx.GetLogger().Tracef(" - Inserted Rows (table: %s)", tableMap.Name)
+	}
+
+	writeSession, tableWriter, err := getTableWriter(ctx, engine, tableName, tableMap.Database, foreignKeyChecksDisabled)
+	if err != nil {
+		return err
+	}
+
+	for _, row := range rows.Rows {
+		var identityRow, dataRow sql.Row
+		if len(row.Identify) > 0 {
+			identityRow, err = parseRow(ctx, engine, tableMap, schema, rows.IdentifyColumns, row.NullIdentifyColumns, row.Identify)
+			if err != nil {
+				return err
+			}
+			ctx.GetLogger().Tracef("     - Identity: %v ", sql.FormatRow(identityRow))
+		}
+
+		if len(row.Data) > 0 {
+			dataRow, err = parseRow(ctx, engine, tableMap, schema, rows.DataColumns, row.NullColumns, row.Data)
+			if err != nil {
+				return err
+			}
+			ctx.GetLogger().Tracef("     - Data: %v ", sql.FormatRow(dataRow))
+		}
+
+		switch {
+		case event.IsDeleteRows():
+			err = tableWriter.Delete(ctx, identityRow)
+		case event.IsWriteRows():
+			err = tableWriter.Insert(ctx, dataRow)
+		case event.IsUpdateRows():
+			err = tableWriter.Update(ctx, identityRow, dataRow)
+		}
+		if err != nil {
+			return err
+		}
+
+	}
+
+	err = closeWriteSession(ctx, engine, tableMap.Database, writeSession)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//
+// Helper functions
+//
+
+// closeWriteSession flushes and closes the specified |writeSession| and returns an error if anything failed.
+func closeWriteSession(ctx *sql.Context, engine *gms.Engine, databaseName string, writeSession WriteSession) error {
+	// TO BE IMPLEMENTED
+	return nil
+}
+
+// getTableSchema returns a sql.Schema for the case-insensitive |tableName| in the database named
+// |databaseName|, along with the exact, case-sensitive table name.
+func getTableSchema(ctx *sql.Context, engine *gms.Engine, tableName, databaseName string) (sql.Schema, string, error) {
+	database, err := engine.Analyzer.Catalog.Database(ctx, databaseName)
+	if err != nil {
+		return nil, "", err
+	}
+	table, ok, err := database.GetTableInsensitive(ctx, tableName)
+	if err != nil {
+		return nil, "", err
+	}
+	if !ok {
+		return nil, "", fmt.Errorf("unable to find table %q", tableName)
+	}
+
+	return table.Schema(), table.Name(), nil
+}
+
+// getTableWriter returns a WriteSession and a TableWriter for writing to the specified |table| in the specified |database|.
+func getTableWriter(ctx *sql.Context, engine *gms.Engine, tableName, databaseName string, foreignKeyChecksDisabled bool) (WriteSession, TableWriter, error) {
+	database, err := engine.Analyzer.Catalog.Database(ctx, databaseName)
+	if err != nil {
+		return nil, nil, err
+	}
+	if privDatabase, ok := database.(mysql_db.PrivilegedDatabase); ok {
+		database = privDatabase.Unwrap()
+	}
+	return nil, nil, nil
+}
+
+// parseRow parses the binary row data from a MySQL binlog event and converts it into a go-mysql-server Row using the
+// |schema| information provided. |columnsPresentBitmap| indicates which column values are present in |data| and
+// |nullValuesBitmap| indicates which columns have null values and are NOT present in |data|.
+func parseRow(ctx *sql.Context, engine *gms.Engine, tableMap *mysql.TableMap, schema sql.Schema, columnsPresentBitmap, nullValuesBitmap mysql.Bitmap, data []byte) (sql.Row, error) {
+	var parsedRow sql.Row
+	pos := 0
+
+	for i, typ := range tableMap.Types {
+		column := schema[i]
+
+		if columnsPresentBitmap.Bit(i) == false {
+			parsedRow = append(parsedRow, nil)
+			continue
+		}
+
+		var value sqltypes.Value
+		var err error
+		if nullValuesBitmap.Bit(i) {
+			value, err = sqltypes.NewValue(vquery.Type_NULL_TYPE, nil)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			var length int
+			value, length, err = mysql.CellValue(data, pos, typ, tableMap.Metadata[i], getSignedType(column))
+			if err != nil {
+				return nil, err
+			}
+			pos += length
+		}
+
+		convertedValue, err := convertSqlTypesValue(ctx, engine, value, column)
+		if err != nil {
+			return nil, err
+		}
+		parsedRow = append(parsedRow, convertedValue)
+	}
+
+	return parsedRow, nil
+}
+
+// getSignedType returns a Vitess query.Type that can be used with the Vitess mysql.CellValue function to correctly
+// parse the value of a signed or unsigned integer value. The mysql.TableMap structure provides information about the
+// type, but it doesn't indicate if an integer type is signed or unsigned, so we have to look at the column type in the
+// replica's schema and then choose any signed/unsigned query.Type to pass into mysql.CellValue to instruct it whether
+// to treat a value as signed or unsigned – the actual type does not matter, only the signed/unsigned property.
+func getSignedType(column *sql.Column) vquery.Type {
+	switch column.Type.Type() {
+	case vquery.Type_UINT8, vquery.Type_UINT16, vquery.Type_UINT24, vquery.Type_UINT32, vquery.Type_UINT64:
+		// For any unsigned integer value, we just need to return any unsigned numeric type to signal to Vitess to treat
+		// the value as unsigned. The actual type returned doesn't matter – only the signed/unsigned property is used.
+		return vquery.Type_UINT64
+	default:
+		return vquery.Type_INT64
+	}
+}
+
+// convertSqlTypesValues converts a sqltypes.Value instance (from vitess) into a sql.Type value (for go-mysql-server).
+func convertSqlTypesValue(ctx *sql.Context, engine *gms.Engine, value sqltypes.Value, column *sql.Column) (interface{}, error) {
+	if value.IsNull() {
+		return nil, nil
+	}
+
+	var convertedValue interface{}
+	var err error
+	switch {
+	case types.IsEnum(column.Type), types.IsSet(column.Type):
+		atoi, err := strconv.Atoi(value.ToString())
+		if err != nil {
+			return nil, err
+		}
+		convertedValue, _, err = column.Type.Convert(atoi)
+	case types.IsDecimal(column.Type):
+		// Decimal values need to have any leading/trailing whitespace trimmed off
+		// TODO: Consider moving this into DecimalType_.Convert; if DecimalType_.Convert handled trimming
+		//       leading/trailing whitespace, this special case for Decimal types wouldn't be needed.
+		convertedValue, _, err = column.Type.Convert(strings.TrimSpace(value.ToString()))
+	case types.IsJSON(column.Type):
+		convertedValue, err = convertVitessJsonExpressionString(ctx, engine, value)
+	default:
+		convertedValue, _, err = column.Type.Convert(value.ToString())
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert value %q, for column of type %T: %v", value.ToString(), column.Type, err.Error())
+	}
+
+	return convertedValue, nil
+}
+
+// convertVitessJsonExpressionString extracts a JSON value from the specified |value| instance, which Vitess has
+// encoded as a SQL expression string. Vitess parses the binary JSON representation from an incoming binlog event,
+// and converts it into an expression string containing JSON_OBJECT and JSON_ARRAY function calls. Because we don't
+// have access to the raw JSON string or JSON bytes, we have to do extra work to translate from Vitess' SQL
+// expression syntax into a raw JSON string value that we can pass to the storage layer. If Vitess kept around the
+// raw string representation and returned it from value.ToString, this logic would not be necessary.
+func convertVitessJsonExpressionString(ctx *sql.Context, engine *gms.Engine, value sqltypes.Value) (interface{}, error) {
+	if value.Type() != vquery.Type_EXPRESSION {
+		return nil, fmt.Errorf("invalid sqltypes.Value specified; expected a Value instance with an Expression type")
+	}
+
+	strValue := value.String()
+	if strings.HasPrefix(strValue, "EXPRESSION(") {
+		strValue = strValue[len("EXPRESSION(") : len(strValue)-1]
+	}
+
+	node, err := planbuilder.Parse(ctx, engine.Analyzer.Catalog, "SELECT "+strValue)
+	if err != nil {
+		return nil, err
+	}
+
+	analyze, err := engine.Analyzer.Analyze(ctx, node, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	rowIter, err := rowexec.DefaultBuilder.Build(ctx, analyze, nil)
+	if err != nil {
+		return nil, err
+	}
+	row, err := rowIter.Next(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return row[0], nil
+}
+
+func getAllUserDatabaseNames(ctx *sql.Context, engine *gms.Engine) []string {
+	allDatabases := engine.Analyzer.Catalog.AllDatabases(ctx)
+	userDatabaseNames := make([]string, 0, len(allDatabases))
+	for _, database := range allDatabases {
+		switch database.Name() {
+		case "information_schema", "mysql":
+		default:
+			userDatabaseNames = append(userDatabaseNames, database.Name())
+		}
+	}
+	return userDatabaseNames
+}
+
+// loadReplicaServerId loads the @@GLOBAL.server_id system variable needed to register the replica with the source,
+// and returns an error specific to replication configuration if the variable is not set to a valid value.
+func loadReplicaServerId() (uint32, error) {
+	serverIdVar, value, ok := sql.SystemVariables.GetGlobal("server_id")
+	if !ok {
+		return 0, fmt.Errorf("no server_id global system variable set")
+	}
+
+	// Persisted values stored in .dolt/config.json can cause string values to be stored in
+	// system variables, so attempt to convert the value if we can't directly cast it to a uint32.
+	serverId, ok := value.(uint32)
+	if !ok {
+		var err error
+		value, _, err = serverIdVar.GetType().Convert(value)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	serverId, ok = value.(uint32)
+	if !ok || serverId == 0 {
+		return 0, fmt.Errorf("invalid server ID configured for @@GLOBAL.server_id (%v); "+
+			"must be an integer greater than zero and less than 4,294,967,296", serverId)
+	}
+
+	return serverId, nil
+}
+
+func executeQueryWithEngine(ctx *sql.Context, engine *gms.Engine, query string) {
+	// Create a sub-context when running queries against the engine, so that we get an accurate query start time.
+	queryCtx := sql.NewContext(ctx, sql.WithSession(ctx.Session))
+
+	if queryCtx.GetCurrentDatabase() == "" {
+		ctx.GetLogger().WithFields(logrus.Fields{
+			"query": query,
+		}).Warn("No current database selected")
+	}
+
+	_, iter, err := engine.Query(queryCtx, query)
+	if err != nil {
+		// Log any errors, except for commits with "nothing to commit"
+		if err.Error() != "nothing to commit" {
+			queryCtx.GetLogger().WithFields(logrus.Fields{
+				"error": err.Error(),
+				"query": query,
+			}).Errorf("Error executing query")
+			msg := fmt.Sprintf("Error executing query: %v", err.Error())
+			DoltBinlogReplicaController.setSqlError(mysql.ERUnknownError, msg)
+		}
+		return
+	}
+	for {
+		_, err := iter.Next(queryCtx)
+		if err != nil {
+			if err != io.EOF {
+				queryCtx.GetLogger().Errorf("ERROR reading query results: %v ", err.Error())
+			}
+			return
+		}
+	}
+}
+
+//
+// Generic util functions...
+//
+
+// convertToHexString returns a lower-case hex string representation of the specified uint16 value |v|.
+func convertToHexString(v uint16) string {
+	return fmt.Sprintf("%x", v)
+}
+
+// keys returns a slice containing the keys in the specified map |m|.
+func keys[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/binlogreplication/binlog_replica_controller.go
+++ b/binlogreplication/binlog_replica_controller.go
@@ -1,0 +1,495 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binlogreplication
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	sqle "github.com/dolthub/go-mysql-server"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/binlogreplication"
+	"github.com/dolthub/go-mysql-server/sql/mysql_db"
+)
+
+var DoltBinlogReplicaController = newDoltBinlogReplicaController()
+
+// binlogApplierUser is the locked, super user account that is used to execute replicated SQL statements.
+// We cannot always assume the root account will exist, so we automatically create this account that is
+// specific to binlog replication and lock it so that it cannot be used to login.
+const binlogApplierUser = "dolt-binlog-applier"
+
+// ErrServerNotConfiguredAsReplica is returned when replication is started without enough configuration provided.
+var ErrServerNotConfiguredAsReplica = fmt.Errorf(
+	"server is not configured as a replica; fix with CHANGE REPLICATION SOURCE TO")
+
+// ErrEmptyHostname is returned when replication is started without a hostname configured.
+var ErrEmptyHostname = fmt.Errorf("fatal error: Invalid (empty) hostname when attempting to connect " +
+	"to the source server. Connection attempt terminated")
+
+// ErrEmptyUsername is returned when replication is started without a username configured.
+var ErrEmptyUsername = fmt.Errorf("fatal error: Invalid (empty) username when attempting to connect " +
+	"to the source server. Connection attempt terminated")
+
+// ErrReplicationStopped is an internal error that is not returned to users, and signals that STOP REPLICA was called.
+var ErrReplicationStopped = fmt.Errorf("replication stop requested")
+
+// doltBinlogReplicaController implements the BinlogReplicaController interface for a Dolt database in order to
+// provide support for a Dolt server to be a replica of a MySQL primary.
+//
+// This type is used concurrently – multiple sessions on the DB can call this interface concurrently,
+// so all state that the controller tracks MUST be protected with a mutex.
+type doltBinlogReplicaController struct {
+	status  binlogreplication.ReplicaStatus
+	filters *filterConfiguration
+	applier *binlogReplicaApplier
+	ctx     *sql.Context
+
+	// statusMutex blocks concurrent access to the ReplicaStatus struct
+	statusMutex *sync.Mutex
+
+	// operationMutex blocks concurrent access to the START/STOP/RESET REPLICA operations
+	operationMutex *sync.Mutex
+	engine         *sqle.Engine
+}
+
+var _ binlogreplication.BinlogReplicaController = (*doltBinlogReplicaController)(nil)
+
+// newDoltBinlogReplicaController creates a new doltBinlogReplicaController instance.
+func newDoltBinlogReplicaController() *doltBinlogReplicaController {
+	controller := doltBinlogReplicaController{
+		filters:        newFilterConfiguration(),
+		statusMutex:    &sync.Mutex{},
+		operationMutex: &sync.Mutex{},
+	}
+	controller.status.ConnectRetry = 60
+	controller.status.SourceRetryCount = 86400
+	controller.status.AutoPosition = true
+	controller.status.ReplicaIoRunning = binlogreplication.ReplicaIoNotRunning
+	controller.status.ReplicaSqlRunning = binlogreplication.ReplicaSqlNotRunning
+	controller.applier = newBinlogReplicaApplier(controller.filters)
+	return &controller
+}
+
+// StartReplica implements the BinlogReplicaController interface.
+func (d *doltBinlogReplicaController) StartReplica(ctx *sql.Context) error {
+	d.operationMutex.Lock()
+	defer d.operationMutex.Unlock()
+
+	// START REPLICA may be called multiple times, but if replication is already running,
+	// it will log a warning and not start up new threads.
+	if d.applier.IsRunning() {
+		ctx.Warn(3083, "Replication thread(s) for channel '' are already running.")
+		return nil
+	}
+
+	if false {
+		// TODO: If the database is already configured for Dolt replication/clustering, then error out.
+		//       Add a (BATS?) test to cover this case
+		return fmt.Errorf("dolt replication already enabled; unable to use binlog replication with other replication modes. " +
+			"Disable Dolt replication first before starting binlog replication")
+	}
+
+	// If we aren't running in a sql-server context, it would be nice to return a helpful, Dolt-specific
+	// error message. Currently, this case would trigger an error from the GMS layer, so we can't give
+	// a specific error message about needing to run Dolt in sql-server mode yet.
+
+	_, err := loadReplicaServerId()
+	if err != nil {
+		return fmt.Errorf("unable to start replication: %s", err.Error())
+	}
+
+	configuration, err := loadReplicationConfiguration(ctx, d.engine.Analyzer.Catalog.MySQLDb)
+	if err != nil {
+		return err
+	} else if configuration == nil {
+		return ErrServerNotConfiguredAsReplica
+	} else if configuration.Host == "" {
+		DoltBinlogReplicaController.setIoError(ERFatalReplicaError, ErrEmptyHostname.Error())
+		return ErrEmptyHostname
+	} else if configuration.User == "" {
+		DoltBinlogReplicaController.setIoError(ERFatalReplicaError, ErrEmptyUsername.Error())
+		return ErrEmptyUsername
+	}
+
+	if d.ctx == nil {
+		return fmt.Errorf("no execution context set for the replica controller")
+	}
+
+	err = d.configureReplicationUser(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Set execution context's user to the binlog replication user
+	d.ctx.SetClient(sql.Client{
+		User:    binlogApplierUser,
+		Address: "localhost",
+	})
+
+	ctx.GetLogger().Info("starting binlog replication...")
+	d.applier.Go(d.ctx)
+
+	// Attempt to record that the replica has started replication so that it will
+	// start automatically the next time the replica server is started.
+	if err := persistReplicaRunningState(ctx, running); err != nil {
+		ctx.GetLogger().Errorf("unable to persist replica running state: %s", err.Error())
+	}
+
+	return nil
+}
+
+// configureReplicationUser creates or configures the super user account needed to apply replication
+// changes and execute DDL statements on the running server. If the account doesn't exist, it will be
+// created and locked to disable log ins, and if it does exist, but is missing super privs or is not
+// locked, it will be given super user privs and locked.
+func (d *doltBinlogReplicaController) configureReplicationUser(ctx *sql.Context) error {
+	mySQLDb := d.engine.Analyzer.Catalog.MySQLDb
+	ed := mySQLDb.Editor()
+	defer ed.Close()
+
+	replicationUser := mySQLDb.GetUser(ed, binlogApplierUser, "localhost", false)
+	if replicationUser == nil {
+		// If the replication user doesn't exist yet, create it and lock it
+		mySQLDb.AddSuperUser(ed, binlogApplierUser, "localhost", "")
+		replicationUser := mySQLDb.GetUser(ed, binlogApplierUser, "localhost", false)
+		if replicationUser == nil {
+			return fmt.Errorf("unable to load replication user")
+		}
+		// Make sure this account is locked so that it cannot be used to log in
+		replicationUser.Locked = true
+		ed.PutUser(replicationUser)
+	} else if replicationUser.IsSuperUser == false || replicationUser.Locked == false {
+		// Fix the replication user if it has been modified
+		replicationUser.IsSuperUser = true
+		replicationUser.Locked = true
+		ed.PutUser(replicationUser)
+	}
+
+	return nil
+}
+
+// SetExecutionContext sets the unique |ctx| for the replica's applier to use when applying changes from binlog events
+// to a database. The applier cannot reuse any existing context, because it executes in a separate routine and would
+// cause race conditions.
+func (d *doltBinlogReplicaController) SetExecutionContext(ctx *sql.Context) {
+	d.ctx = ctx
+}
+
+// SetEngine sets the SQL engine this replica will use when running replicated statements and
+// when loading the Catalog to find the "mysql" database.
+func (d *doltBinlogReplicaController) SetEngine(engine *sqle.Engine) {
+	d.engine = engine
+	d.applier.engine = engine
+}
+
+// StopReplica implements the BinlogReplicaController interface.
+func (d *doltBinlogReplicaController) StopReplica(ctx *sql.Context) error {
+	if d.applier.IsRunning() == false {
+		ctx.Warn(3084, "Replication thread(s) for channel '' are already stopped.")
+		return nil
+	}
+
+	d.applier.stopReplicationChan <- struct{}{}
+
+	d.updateStatus(func(status *binlogreplication.ReplicaStatus) {
+		status.ReplicaIoRunning = binlogreplication.ReplicaIoNotRunning
+		status.ReplicaSqlRunning = binlogreplication.ReplicaSqlNotRunning
+	})
+
+	// Attempt to record that the replica has stopped replication so that it will not
+	// start automatically the next time the replica server is started.
+	if err := persistReplicaRunningState(ctx, notRunning); err != nil {
+		ctx.GetLogger().Errorf("unable to persist replica running state: %s", err.Error())
+	}
+
+	return nil
+}
+
+// SetReplicationSourceOptions implements the BinlogReplicaController interface.
+func (d *doltBinlogReplicaController) SetReplicationSourceOptions(ctx *sql.Context, options []binlogreplication.ReplicationOption) error {
+	replicaSourceInfo, err := loadReplicationConfiguration(ctx, d.engine.Analyzer.Catalog.MySQLDb)
+	if err != nil {
+		return err
+	}
+
+	if replicaSourceInfo == nil {
+		replicaSourceInfo = mysql_db.NewReplicaSourceInfo()
+	}
+
+	for _, option := range options {
+		switch strings.ToUpper(option.Name) {
+		case "SOURCE_HOST":
+			value, err := getOptionValueAsString(option)
+			if err != nil {
+				return err
+			}
+			replicaSourceInfo.Host = value
+		case "SOURCE_USER":
+			value, err := getOptionValueAsString(option)
+			if err != nil {
+				return err
+			}
+			replicaSourceInfo.User = value
+		case "SOURCE_PASSWORD":
+			value, err := getOptionValueAsString(option)
+			if err != nil {
+				return err
+			}
+			replicaSourceInfo.Password = value
+		case "SOURCE_PORT":
+			intValue, err := getOptionValueAsInt(option)
+			if err != nil {
+				return err
+			}
+			replicaSourceInfo.Port = uint16(intValue)
+		case "SOURCE_CONNECT_RETRY":
+			intValue, err := getOptionValueAsInt(option)
+			if err != nil {
+				return err
+			}
+			replicaSourceInfo.ConnectRetryInterval = uint32(intValue)
+		case "SOURCE_RETRY_COUNT":
+			intValue, err := getOptionValueAsInt(option)
+			if err != nil {
+				return err
+			}
+			replicaSourceInfo.ConnectRetryCount = uint64(intValue)
+		case "SOURCE_AUTO_POSITION":
+			intValue, err := getOptionValueAsInt(option)
+			if err != nil {
+				return err
+			}
+			if intValue < 1 {
+				return fmt.Errorf("SOURCE_AUTO_POSITION cannot be disabled")
+			}
+		default:
+			return fmt.Errorf("unknown replication source option: %s", option.Name)
+		}
+	}
+
+	// Persist the updated replica source configuration to disk
+	return persistReplicationConfiguration(ctx, replicaSourceInfo, d.engine.Analyzer.Catalog.MySQLDb)
+}
+
+// SetReplicationFilterOptions implements the BinlogReplicaController interface.
+func (d *doltBinlogReplicaController) SetReplicationFilterOptions(_ *sql.Context, options []binlogreplication.ReplicationOption) error {
+	for _, option := range options {
+		switch strings.ToUpper(option.Name) {
+		case "REPLICATE_DO_TABLE":
+			value, err := getOptionValueAsTableNames(option)
+			if err != nil {
+				return err
+			}
+			err = d.filters.setDoTables(value)
+			if err != nil {
+				return err
+			}
+		case "REPLICATE_IGNORE_TABLE":
+			value, err := getOptionValueAsTableNames(option)
+			if err != nil {
+				return err
+			}
+			err = d.filters.setIgnoreTables(value)
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported replication filter option: %s", option.Name)
+		}
+	}
+
+	// TODO: Consider persisting filter settings. MySQL doesn't actually do this... unlike CHANGE REPLICATION SOURCE,
+	//       CHANGE REPLICATION FILTER requires users to re-apply the filter options every time a server is restarted,
+	//       or to pass them to mysqld on the command line or in configuration. Since we don't want to force users
+	//       to specify these on the command line, we should consider diverging from MySQL behavior here slightly and
+	//       persisting the filter configuration options if customers want this.
+
+	return nil
+}
+
+// GetReplicaStatus implements the BinlogReplicaController interface
+func (d *doltBinlogReplicaController) GetReplicaStatus(ctx *sql.Context) (*binlogreplication.ReplicaStatus, error) {
+	replicaSourceInfo, err := loadReplicationConfiguration(ctx, d.engine.Analyzer.Catalog.MySQLDb)
+	if err != nil {
+		return nil, err
+	}
+
+	// Lock to read status consistently
+	d.statusMutex.Lock()
+	defer d.statusMutex.Unlock()
+	var copy = d.status
+
+	if replicaSourceInfo == nil {
+		return &copy, nil
+	}
+
+	copy.SourceUser = replicaSourceInfo.User
+	copy.SourceHost = replicaSourceInfo.Host
+	copy.SourcePort = uint(replicaSourceInfo.Port)
+	copy.SourceServerUuid = replicaSourceInfo.Uuid
+	copy.ConnectRetry = replicaSourceInfo.ConnectRetryInterval
+	copy.SourceRetryCount = replicaSourceInfo.ConnectRetryCount
+	copy.ReplicateDoTables = d.filters.getDoTables()
+	copy.ReplicateIgnoreTables = d.filters.getIgnoreTables()
+
+	if d.applier.currentPosition != nil {
+		copy.ExecutedGtidSet = d.applier.currentPosition.GTIDSet.String()
+		copy.RetrievedGtidSet = copy.ExecutedGtidSet
+	}
+
+	return &copy, nil
+}
+
+// ResetReplica implements the BinlogReplicaController interface
+func (d *doltBinlogReplicaController) ResetReplica(ctx *sql.Context, resetAll bool) error {
+	d.operationMutex.Lock()
+	defer d.operationMutex.Unlock()
+
+	if d.applier.IsRunning() {
+		return fmt.Errorf("unable to reset replica while replication is running; stop replication and try again")
+	}
+
+	// Reset error status
+	d.updateStatus(func(status *binlogreplication.ReplicaStatus) {
+		status.LastIoErrNumber = 0
+		status.LastSqlErrNumber = 0
+		status.LastIoErrorTimestamp = nil
+		status.LastSqlErrorTimestamp = nil
+		status.LastSqlError = ""
+		status.LastIoError = ""
+	})
+
+	if resetAll {
+		err := deleteReplicationConfiguration(ctx, d.engine.Analyzer.Catalog.MySQLDb)
+		if err != nil {
+			return err
+		}
+
+		d.filters = newFilterConfiguration()
+	}
+
+	return nil
+}
+
+// updateStatus allows the caller to safely update the replica controller's status. The controller locks it's mutex
+// before the specified function |f| is called, and unlocks it after |f| is finished running. The current status is
+// passed into the callback function |f| and the caller can safely update or copy any fields they need.
+func (d *doltBinlogReplicaController) updateStatus(f func(status *binlogreplication.ReplicaStatus)) {
+	d.statusMutex.Lock()
+	defer d.statusMutex.Unlock()
+	f(&d.status)
+}
+
+// setIoError updates the current replication status with the specific |errno| and |message| to describe an IO error.
+func (d *doltBinlogReplicaController) setIoError(errno uint, message string) {
+	d.statusMutex.Lock()
+	defer d.statusMutex.Unlock()
+
+	// truncate the message to avoid errors when reporting replica status
+	if len(message) > 256 {
+		message = message[:256]
+	}
+
+	currentTime := time.Now()
+	d.status.LastIoErrorTimestamp = &currentTime
+	d.status.LastIoErrNumber = errno
+	d.status.LastIoError = message
+}
+
+// setSqlError updates the current replication status with the specific |errno| and |message| to describe an SQL error.
+func (d *doltBinlogReplicaController) setSqlError(errno uint, message string) {
+	d.statusMutex.Lock()
+	defer d.statusMutex.Unlock()
+
+	// truncate the message to avoid errors when reporting replica status
+	if len(message) > 256 {
+		message = message[:256]
+	}
+
+	currentTime := time.Now()
+	d.status.LastSqlErrorTimestamp = &currentTime
+	d.status.LastSqlErrNumber = errno
+	d.status.LastSqlError = message
+}
+
+// AutoStart starts up replication if replication was running before the server was shutdown. If
+// replication is not configured, hasn't been started, or has been stopped before the server was
+// shutdown, then this method will not start replication. This method should only be called during
+// the server startup process and should not be invoked after that.
+func (d *doltBinlogReplicaController) AutoStart(_ context.Context) error {
+	runningState, err := loadReplicationRunningState(d.ctx)
+	if err != nil {
+		logrus.Errorf("Unable to load replication running state: %s", err.Error())
+		return err
+	}
+
+	if runningState == notRunning {
+		logrus.Trace("no previous replication running state; not auto starting replication")
+		return nil
+	}
+
+	logrus.Info("auto-starting binlog replication from source...")
+	return d.StartReplica(d.ctx)
+}
+
+//
+// Helper functions
+//
+
+func getOptionValueAsString(option binlogreplication.ReplicationOption) (string, error) {
+	stringOptionValue, ok := option.Value.(binlogreplication.StringReplicationOptionValue)
+	if ok {
+		return stringOptionValue.GetValueAsString(), nil
+	}
+
+	return "", fmt.Errorf("unsupported value type for option %q; found %T, "+
+		"but expected a string", option.Name, option.Value.GetValue())
+}
+
+func getOptionValueAsInt(option binlogreplication.ReplicationOption) (int, error) {
+	integerOptionValue, ok := option.Value.(binlogreplication.IntegerReplicationOptionValue)
+	if ok {
+		return integerOptionValue.GetValueAsInt(), nil
+	}
+
+	return 0, fmt.Errorf("unsupported value type for option %q; found %T, "+
+		"but expected an integer", option.Name, option.Value.GetValue())
+}
+
+func getOptionValueAsTableNames(option binlogreplication.ReplicationOption) ([]sql.UnresolvedTable, error) {
+	tableNamesOptionValue, ok := option.Value.(binlogreplication.TableNamesReplicationOptionValue)
+	if ok {
+		return tableNamesOptionValue.GetValueAsTableList(), nil
+	}
+
+	return nil, fmt.Errorf("unsupported value type for option %q; found %T, "+
+		"but expected a list of tables", option.Name, option.Value.GetValue())
+}
+
+func verifyAllTablesAreQualified(urts []sql.UnresolvedTable) error {
+	for _, urt := range urts {
+		if urt.Database().Name() == "" {
+			return fmt.Errorf("no database specified for table '%s'; "+
+				"all filter table names must be qualified with a database name", urt.Name())
+		}
+	}
+	return nil
+}

--- a/binlogreplication/binlog_replica_event_producer.go
+++ b/binlogreplication/binlog_replica_event_producer.go
@@ -1,0 +1,96 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binlogreplication
+
+import (
+	"sync/atomic"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/vitess/go/mysql"
+)
+
+// binlogEventProducer is responsible for reading binlog events from an established connection and sending them back to
+// a consumer over a channel. This is necessary because calls to conn.ReadBinlogEvent() block until a binlog event is
+// received. If the source isn't sending more events, then the applier is blocked on reading events, and the user
+// can't issue a call to STOP REPLICA. Reading binlog events in a thread and communicating with the applier via
+// channels for events and errors decouples this.
+type binlogEventProducer struct {
+	conn      *mysql.Conn
+	errorChan chan error
+	eventChan chan mysql.BinlogEvent
+	running   atomic.Bool
+}
+
+// newBinlogEventProducer creates a new binlog event producer that reads from the specified, established MySQL
+// connection |conn|. The returned binlogEventProducer owns the communication channels
+// and is responsible for closing them when the binlogEventProducer is stopped.
+func newBinlogEventProducer(conn *mysql.Conn) *binlogEventProducer {
+	producer := &binlogEventProducer{
+		conn:      conn,
+		eventChan: make(chan mysql.BinlogEvent),
+		errorChan: make(chan error),
+	}
+	producer.running.Store(true)
+	return producer
+}
+
+// EventChan returns the event channel through which this event
+// producer sends binlog events.
+func (p *binlogEventProducer) EventChan() <-chan mysql.BinlogEvent {
+	return p.eventChan
+}
+
+// ErrorChan returns the error channel through which this event
+// producer sends any errors.
+func (p *binlogEventProducer) ErrorChan() <-chan error {
+	return p.errorChan
+}
+
+// Go starts this binlogEventProducer in a new goroutine. Right before this routine exits, it will close the
+// two communication channels it owns.
+func (p *binlogEventProducer) Go(_ *sql.Context) {
+	go func() {
+		for p.IsRunning() {
+			// ReadBinlogEvent blocks until a binlog event can be read and returned, so this has to be done on a
+			// separate thread, otherwise the applier would be blocked and wouldn't be able to handle the STOP
+			// REPLICA signal.
+			event, err := p.conn.ReadBinlogEvent()
+
+			// If this binlogEventProducer has been stopped while we were blocked waiting to read the next
+			// binlog event, abort processing it and just return instead.
+			if p.IsRunning() == false {
+				break
+			}
+
+			if err != nil {
+				p.errorChan <- err
+			} else {
+				p.eventChan <- event
+			}
+		}
+		close(p.errorChan)
+		close(p.eventChan)
+	}()
+}
+
+// IsRunning returns true if this instance is processing binlog events and has not been stopped.
+func (p *binlogEventProducer) IsRunning() bool {
+	return p.running.Load()
+}
+
+// Stop requests for this binlogEventProducer to stop processing events as soon as possible.
+func (p *binlogEventProducer) Stop() {
+	p.running.Store(false)
+}

--- a/binlogreplication/binlog_replica_filtering.go
+++ b/binlogreplication/binlog_replica_filtering.go
@@ -1,0 +1,168 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binlogreplication
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/vitess/go/mysql"
+)
+
+// filterConfiguration defines the binlog filtering rules applied on the replica.
+type filterConfiguration struct {
+	// doTables holds a map of database name to map of table names, indicating tables that SHOULD be replicated.
+	doTables map[string]map[string]struct{}
+	// ignoreTables holds a map of database name to map of table names, indicating tables that should NOT be replicated.
+	ignoreTables map[string]map[string]struct{}
+	// mu guards against concurrent access to the filter configuration data.
+	mu *sync.Mutex
+}
+
+// newFilterConfiguration creates a new filterConfiguration instance and initializes members.
+func newFilterConfiguration() *filterConfiguration {
+	return &filterConfiguration{
+		doTables:     make(map[string]map[string]struct{}),
+		ignoreTables: make(map[string]map[string]struct{}),
+		mu:           &sync.Mutex{},
+	}
+}
+
+// setDoTables sets the tables that are allowed to replicate and returns an error if any problems were
+// encountered, such as unqualified tables being specified in |urts|. If any DoTables were previously configured,
+// they are cleared out before the new tables are set as the value of DoTables.
+func (fc *filterConfiguration) setDoTables(urts []sql.UnresolvedTable) error {
+	err := verifyAllTablesAreQualified(urts)
+	if err != nil {
+		return err
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	// Setting new replication filters clears out any existing filters
+	fc.doTables = make(map[string]map[string]struct{})
+
+	for _, urt := range urts {
+		table := strings.ToLower(urt.Name())
+		db := strings.ToLower(urt.Database().Name())
+		if fc.doTables[db] == nil {
+			fc.doTables[db] = make(map[string]struct{})
+		}
+		tableMap := fc.doTables[db]
+		tableMap[table] = struct{}{}
+	}
+	return nil
+}
+
+// setIgnoreTables sets the tables that are NOT allowed to replicate and returns an error if any problems were
+// encountered, such as unqualified tables being specified in |urts|. If any IgnoreTables were previously configured,
+// they are cleared out before the new tables are set as the value of IgnoreTables.
+func (fc *filterConfiguration) setIgnoreTables(urts []sql.UnresolvedTable) error {
+	err := verifyAllTablesAreQualified(urts)
+	if err != nil {
+		return err
+	}
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	// Setting new replication filters clears out any existing filters
+	fc.ignoreTables = make(map[string]map[string]struct{})
+
+	for _, urt := range urts {
+		table := strings.ToLower(urt.Name())
+		db := strings.ToLower(urt.Database().Name())
+		if fc.ignoreTables[db] == nil {
+			fc.ignoreTables[db] = make(map[string]struct{})
+		}
+		tableMap := fc.ignoreTables[db]
+		tableMap[table] = struct{}{}
+	}
+	return nil
+}
+
+// isTableFilteredOut returns true if the table identified by |tableMap| has been filtered out on this replica and
+// should not have any updates applied from binlog messages.
+func (fc *filterConfiguration) isTableFilteredOut(ctx *sql.Context, tableMap *mysql.TableMap) bool {
+	if fc == nil {
+		return false
+	}
+
+	table := strings.ToLower(tableMap.Name)
+	db := strings.ToLower(tableMap.Database)
+
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	// If any filter doTable options are specified, then a table MUST be listed in the set
+	// for it to be replicated. doTables options are processed BEFORE ignoreTables options.
+	// If a table appears in both doTable and ignoreTables, it is ignored.
+	// https://dev.mysql.com/doc/refman/8.0/en/replication-rules-table-options.html
+	if len(fc.doTables) > 0 {
+		if doTables, ok := fc.doTables[db]; ok {
+			if _, ok := doTables[table]; !ok {
+				ctx.GetLogger().Tracef("skipping table %s.%s (not in doTables) ", tableMap.Database, tableMap.Name)
+				return true
+			}
+		}
+	}
+
+	if len(fc.ignoreTables) > 0 {
+		if ignoredTables, ok := fc.ignoreTables[db]; ok {
+			if _, ok := ignoredTables[table]; ok {
+				// If this table is being ignored, don't process any further
+				ctx.GetLogger().Tracef("skipping table %s.%s (in ignoreTables)", tableMap.Database, tableMap.Name)
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// getDoTables returns a slice of qualified table names that are configured to be replicated.
+func (fc *filterConfiguration) getDoTables() []string {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	return convertFilterMapToStringSlice(fc.doTables)
+}
+
+// getIgnoreTables returns a slice of qualified table names that are configured to be filtered out of replication.
+func (fc *filterConfiguration) getIgnoreTables() []string {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	return convertFilterMapToStringSlice(fc.ignoreTables)
+}
+
+// convertFilterMapToStringSlice converts the specified |filterMap| into a string slice, by iterating over every
+// key in the top level map, which stores a database name, and for each of those keys, iterating over every key
+// in the inner map, which stores a table name. Each table name is qualified with the matching database name and the
+// results are returned as a slice of qualified table names.
+func convertFilterMapToStringSlice(filterMap map[string]map[string]struct{}) []string {
+	if filterMap == nil {
+		return nil
+	}
+
+	tableNames := make([]string, 0, len(filterMap))
+	for dbName, tableMap := range filterMap {
+		for tableName, _ := range tableMap {
+			tableNames = append(tableNames, fmt.Sprintf("%s.%s", dbName, tableName))
+		}
+	}
+	return tableNames
+}

--- a/binlogreplication/system_variable_utils.go
+++ b/binlogreplication/system_variable_utils.go
@@ -1,0 +1,58 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binlogreplication
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// getServerId returns the @@server_id global system variable value. If the value of @@server_id is 0 or is not a
+// uint32 value, then an error is returned.
+func getServerId() (uint32, error) {
+	_, value, ok := sql.SystemVariables.GetGlobal("server_id")
+	if !ok {
+		return 0, fmt.Errorf("global variable 'server_id' not found")
+	}
+
+	if i, ok := value.(uint32); ok {
+		if i == 0 {
+			return 0, fmt.Errorf("@@server_id is zero – must be set to a non-zero value")
+		}
+		return i, nil
+	}
+
+	return 0, fmt.Errorf("@@server_id is not a valid uint32 – must be set to a non-zero value")
+}
+
+// getServerUuid returns the global @@server_uuid system variable value. If the value of @@server_uuid
+// is empty or is not a string, then an error is returned.
+func getServerUuid(_ context.Context) (string, error) {
+	_, serverUuidValue, ok := sql.SystemVariables.GetGlobal("server_uuid")
+	if !ok {
+		return "", fmt.Errorf("global variable 'server_uuid' not found")
+	}
+
+	if s, ok := serverUuidValue.(string); ok {
+		if len(s) == 0 {
+			return "", fmt.Errorf("@@server_uuid is empty – must be set to a valid UUID")
+		}
+		return s, nil
+	}
+
+	return "", fmt.Errorf("@@server_uuid is not a string – must be set to a valid UUID")
+}

--- a/binlogreplication/writer.go
+++ b/binlogreplication/writer.go
@@ -1,0 +1,13 @@
+package binlogreplication
+
+import "github.com/dolthub/go-mysql-server/sql"
+
+type WriteSession interface {
+	Close() error
+}
+
+type TableWriter interface {
+	Insert(ctx *sql.Context, row sql.Row) error
+	Delete(ctx *sql.Context, row sql.Row) error
+	Update(ctx *sql.Context, row sql.Row, values sql.Row) error
+}


### PR DESCRIPTION
Ref: #7 

This PR copies the binlog subscription logic from Dolt to this repo and eliminates all the dependencies on Dolt Core. The remaining work is to implement the `TableWriter` interface.