### PR TITLE
fix: fix ddl sync issue between duckdb and memory engine

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -197,11 +197,6 @@ func (b *DuckBuilder) executeDML(ctx *sql.Context, n sql.Node, conn *stdsql.DB) 
 func (b *DuckBuilder) executeDDL(ctx *sql.Context, n sql.Node, table sql.Node, conn *stdsql.DB) (sql.RowIter, error) {
 	logrus.Infoln("Executing DDL...")
 
-	// Execute the DDL in the memory engine first
-	if err := b.executeBase(ctx, n, nil); err != nil {
-		return nil, err
-	}
-
 	var (
 		duckSQL string
 		err     error
@@ -232,6 +227,12 @@ func (b *DuckBuilder) executeDDL(ctx *sql.Context, n sql.Node, table sql.Node, c
 	// Execute the DuckDB query
 	_, err = conn.ExecContext(ctx.Context, duckSQL)
 	if err != nil {
+		logrus.Info("SQL to be executed in DuckDB: ", duckSQL)
+		return nil, err
+	}
+
+	// Execute the DDL in the memory engine as well
+	if err := b.executeBase(ctx, n, nil); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
There is a bug in SQLGlot that transforms the ALTER TABLE statement into a malformed DuckDB SQL, causing the memory update to succeed while the DuckDB update does not. This PR moves the memory update after the DuckDB update, as the memory update is less likely to fail.
```
>>> sqlglot.transpile("alter table t0 add column (a int)", read="mysql", write="duckdb")
['ALTER TABLE t0 (a AS int)']
```