### PR TITLE
feat: persist global system variables and binlog positions

### DIFF
--- a/binlogreplication/binlog_replica_applier.go
+++ b/binlogreplication/binlog_replica_applier.go
@@ -184,7 +184,7 @@ func (a *binlogReplicaApplier) startReplicationEventStream(ctx *sql.Context, con
 		return err
 	}
 
-	position, err := positionStore.Load()
+	position, err := positionStore.Load(a.engine)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 		Protocol: "tcp",
 		Address:  fmt.Sprintf("%s:%d", address, port),
 	}
-	s, err := server.NewServerWithHandler(config, engine, wrapSessionBuilder(provider), nil, wrapHandler(builder))
+	s, err := server.NewServerWithHandler(config, engine, NewSessionBuilder(provider), nil, wrapHandler(builder))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Resolves #21 

The global persistent variables are now written to a DuckDB table. With changes in this PR, the binlog replication feature can pass the `AutoRestartReplica` test, which means binlog replication will be resumed automatically after a crash.

```
$ go test -timeout 30s -run ^TestAutoRestartReplica$ github.com/apecloud/myduckserver/binlogreplication
ok  	github.com/apecloud/myduckserver/binlogreplication	24.610s
```