### PR TITLE
feat: support lossless type mapping and table/column comments

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -64,9 +64,7 @@ func TestDebugHarness(t *testing.T) {
 	setupData := []setup.SetupScript{{
 		`create database if not exists mydb`,
 		`use mydb`,
-		`create table t0 (id int primary key, val int)`,
-		`insert into t0 values (0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9)`,
-		`create index t0_val on t0(val)`,
+		"create table mytable (i bigint primary key, s varchar(20) comment 'column s' NOT NULL)",
 	}}
 
 	harness.Setup(setupData)
@@ -77,7 +75,7 @@ func TestDebugHarness(t *testing.T) {
 	engine.EngineAnalyzer().Verbose = true
 
 	ctx := enginetest.NewContext(harness)
-	_, iter, _, err := engine.Query(ctx, "SHOW CREATE TABLE t0")
+	_, iter, _, err := engine.Query(ctx, "create index mytable_i_s on mytable (i,s)")
 	require.NoError(t, err)
 	defer iter.Close(ctx)
 

--- a/meta/comment.go
+++ b/meta/comment.go
@@ -1,0 +1,43 @@
+package meta
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type Comment struct {
+	Text string `json:"text,omitempty"`
+	Meta string `json:"meta,omitempty"` // extra information, e.g. the original MySQL column type, etc.
+}
+
+func DecodeComment(encodedOrRawText string) *Comment {
+	var c Comment
+	err := json.Unmarshal([]byte(encodedOrRawText), &c)
+	if err != nil {
+		// not a valid JSON, treat it as a raw text
+		// may be a legacy comment without meta field
+		// or the object is not managed by us
+		return NewComment(encodedOrRawText)
+	}
+	return &c
+}
+
+func NewComment(text string) *Comment {
+	return &Comment{Text: text}
+}
+
+func NewCommentWithMeta(text, meta string) *Comment {
+	return &Comment{Text: text, Meta: meta}
+}
+
+func (c *Comment) Encode() string {
+	jsonData, err := json.Marshal(c)
+	if err != nil {
+		panic(err)
+	}
+	return norm(string(jsonData))
+}
+
+func norm(text string) string {
+	return "'" + strings.ReplaceAll(text, "'", "''") + "'"
+}

--- a/meta/identifier.go
+++ b/meta/identifier.go
@@ -18,3 +18,7 @@ func FullTableName(catalog, schema, table string) string {
 func FullIndexName(catalog, schema, index string) string {
 	return FullTableName(catalog, schema, index)
 }
+
+func FullColumnName(catalog, schema, table, column string) string {
+	return FullTableName(catalog, schema, table) + `."` + column + `"`
+}

--- a/meta/index.go
+++ b/meta/index.go
@@ -8,7 +8,7 @@ type Index struct {
 	Exprs      []sql.Expression
 	Name       string
 	Unique     bool
-	CommentStr string
+	CommentObj *Comment
 	PrefixLens []uint16
 }
 
@@ -16,13 +16,13 @@ var _ sql.Index = (*Index)(nil)
 
 // TODO: DuckDB doesn't have a convenient way to get the expressions from an index
 // so we need to implement our own. Storing it in the index comment is a good idea.
-func NewIndex(dbName, tableName, name string, unique bool, comment string) *Index {
+func NewIndex(dbName, tableName, name string, unique bool, comment *Comment) *Index {
 	return &Index{
 		DbName:     dbName,
 		TableName:  tableName,
 		Name:       name,
 		Unique:     unique,
-		CommentStr: comment,
+		CommentObj: comment,
 	}
 }
 
@@ -69,7 +69,7 @@ func (idx *Index) IsFullText() bool {
 
 // Comment returns the comment for this index
 func (idx *Index) Comment() string {
-	return idx.CommentStr
+	return idx.CommentObj.Text
 }
 
 // IndexType returns the type of this index, e.g. BTREE


### PR DESCRIPTION
This PR introduces lossless type mapping by recording the original MySQL type in the column comment, such as `{"text":"hello duck", "meta":"VARCHAR(255)"}`. This approach addresses the fact that MySQL offers a broader range of types and type parameters compared to DuckDB. For example, MySQL supports `VARCHAR(length)`, `TINYTEXT`, `TEXT`, etc., while DuckDB handles types more dynamically, using a single dynamic-length VARCHAR for variable-length strings.  By storing the original MySQL type information in the comment (drawing inspiration from #4), we can easily maintain consistency and accurately restore the original MySQL type when needed.

```
D select column_name, data_type, comment from duckdb_columns() where table_name='t0' and column_name >= 'f';
┌─────────────┬───────────┬─────────────────────────────────────────────┐
│ column_name │ data_type │                   comment                   │
├─────────────┼───────────┼─────────────────────────────────────────────┤
│ f           │ VARCHAR   │ {"text":"hello duck","meta":"VARCHAR(255)"} │
│ g           │ INTEGER   │ {"text":"duck duck"}                        │
│ h           │ VARCHAR   │ {"text":"duck duck","meta":"TEXT(255)"}     │
└─────────────┴───────────┴─────────────────────────────────────────────┘
```

Additionally, this PR introduces support for both table and column comments.