### PR TITLE
fix: improve error handling for schema switch to match MySQL behavior

### DIFF
--- a/meta/errors.go
+++ b/meta/errors.go
@@ -25,3 +25,8 @@ func IsDuckDBTableNotFoundError(err error) bool {
 func IsDuckDBViewNotFoundError(err error) bool {
 	return IsDuckDBCatalogError(err) && strings.Contains(err.Error(), "View with name") && strings.Contains(err.Error(), "does not exist")
 }
+
+// ERROR 1105 (HY000): unknown error: Catalog Error: SET schema: No catalog + schema named "mysql.db0" found.
+func IsDuckDBSetSchemaNotFoundError(err error) bool {
+	return IsDuckDBCatalogError(err) && strings.Contains(err.Error(), "SET schema: No catalog + schema named")
+}


### PR DESCRIPTION
Before
```
mysql> use db0;
ERROR 1105 (HY000): unknown error: Catalog Error: SET schema: No catalog + schema named "mysql.db0" found.
```
After
```
mysql> USE db0;
ERROR 1105 (HY000): unknown error: database not found: db0
```
