### PR TITLE
fix: resolve index name conflict by ensuring unique names at schema scope for duckdb

### DIFF
--- a/meta/identifier.go
+++ b/meta/identifier.go
@@ -1,5 +1,9 @@
 package meta
 
+import (
+	"strings"
+)
+
 func FullSchemaName(catalog, schema string) string {
 	if catalog == "" {
 		return `"` + schema + `"`
@@ -21,4 +25,18 @@ func FullIndexName(catalog, schema, index string) string {
 
 func FullColumnName(catalog, schema, table, column string) string {
 	return FullTableName(catalog, schema, table) + `."` + column + `"`
+}
+
+// EncodeIndexName uses a simple encoding scheme (table$$index) for better visibility which is useful for debugging.
+func EncodeIndexName(table, index string) string {
+	return table + "$$" + index
+}
+
+func DecodeIndexName(encodedName string) (string, string) {
+	parts := strings.Split(encodedName, "$$")
+	// without "$$", the encodedName is the index name
+	if len(parts) != 2 {
+		return "", encodedName
+	}
+	return parts[0], parts[1]
 }

--- a/meta/provider.go
+++ b/meta/provider.go
@@ -50,6 +50,12 @@ func NewDBProvider(dataDir, dbFile string) (*DbProvider, error) {
 	if err != nil {
 		return nil, err
 	}
+	// load json extension
+	_, err = storage.Exec("load json")
+	if err != nil {
+		return nil, err
+	}
+
 	return &DbProvider{
 		mu:          &sync.RWMutex{},
 		storage:     storage,


### PR DESCRIPTION
This PR addresses the remaining issues needed to pass the setup stage in [TestQueries](https://github.com/apecloud/myduckserver/blob/f7a59b6e563f7f18baba48c4d585d3f4b3a53fa7/main_test.go#L97), enabling us to proceed with `SELECT`.