### PR TITLE
fix: support datetime/timestamp fractional seconds

### DIFF
--- a/meta/database.go
+++ b/meta/database.go
@@ -100,7 +100,7 @@ func (d *Database) CreateTable(ctx *sql.Context, name string, schema sql.Primary
 		if err != nil {
 			return err
 		}
-		colDef := fmt.Sprintf(`"%s" %s`, col.Name, typ.str)
+		colDef := fmt.Sprintf(`"%s" %s`, col.Name, typ.name)
 		if col.Nullable {
 			colDef += " NULL"
 		} else {
@@ -113,10 +113,10 @@ func (d *Database) CreateTable(ctx *sql.Context, name string, schema sql.Primary
 
 		columns = append(columns, colDef)
 
-		if col.Comment != "" || typ.extra != "" {
+		if col.Comment != "" || typ.myType != "" {
 			columnCommentSQLs = append(columnCommentSQLs,
 				fmt.Sprintf(`COMMENT ON COLUMN %s IS %s`, FullColumnName(d.catalogName, d.name, name, col.Name),
-					NewCommentWithMeta(col.Comment, typ.extra).Encode()))
+					NewCommentWithMeta(col.Comment, typ.myType).Encode()))
 		}
 	}
 

--- a/meta/table.go
+++ b/meta/table.go
@@ -172,7 +172,7 @@ func (t *Table) AddColumn(ctx *sql.Context, column *sql.Column, order *sql.Colum
 		return err
 	}
 
-	sql := fmt.Sprintf(`ALTER TABLE %s ADD COLUMN "%s" %s`, FullTableName(t.db.catalogName, t.db.name, t.name), column.Name, typ.str)
+	sql := fmt.Sprintf(`ALTER TABLE %s ADD COLUMN "%s" %s`, FullTableName(t.db.catalogName, t.db.name, t.name), column.Name, typ.name)
 
 	if !column.Nullable {
 		sql += " NOT NULL"
@@ -183,7 +183,7 @@ func (t *Table) AddColumn(ctx *sql.Context, column *sql.Column, order *sql.Colum
 	}
 
 	// add comment
-	comment := NewCommentWithMeta(column.Comment, typ.extra)
+	comment := NewCommentWithMeta(column.Comment, typ.myType)
 	sql += fmt.Sprintf(`; COMMENT ON COLUMN %s IS %s`, FullColumnName(t.db.catalogName, t.db.name, t.name, column.Name), comment.Encode())
 
 	_, err = t.db.storage.Exec(sql)
@@ -221,7 +221,7 @@ func (t *Table) ModifyColumn(ctx *sql.Context, columnName string, column *sql.Co
 
 	baseSQL := fmt.Sprintf(`ALTER TABLE %s ALTER COLUMN "%s"`, FullTableName(t.db.catalogName, t.db.name, t.name), columnName)
 	sqls := []string{
-		fmt.Sprintf(`%s TYPE %s`, baseSQL, typ.str),
+		fmt.Sprintf(`%s TYPE %s`, baseSQL, typ.name),
 	}
 
 	if column.Nullable {
@@ -241,7 +241,7 @@ func (t *Table) ModifyColumn(ctx *sql.Context, columnName string, column *sql.Co
 	}
 
 	// alter comment
-	comment := NewCommentWithMeta(column.Comment, typ.extra)
+	comment := NewCommentWithMeta(column.Comment, typ.myType)
 	sqls = append(sqls, fmt.Sprintf(`COMMENT ON COLUMN %s IS %s`, FullColumnName(t.db.catalogName, t.db.name, t.name, column.Name), comment.Encode()))
 
 	joinedSQL := strings.Join(sqls, "; ")


### PR DESCRIPTION
This PR adds support for fractional seconds in `datetime` and `timestamp` types as described in the [MySQL documentation](https://dev.mysql.com/doc/refman/8.4/en/datetime.html).

>A DATETIME or TIMESTAMP value can include a trailing fractional seconds part in up to microseconds (6 digits) precision. In particular, any fractional part in a value inserted into a DATETIME or TIMESTAMP column is stored rather than discarded. With the fractional part included, the format for these values is 'YYYY-MM-DD hh:mm:ss[.fraction]', the range for DATETIME values is '1000-01-01 00:00:00.000000' to '9999-12-31 23:59:59.499999', and the range for TIMESTAMP values is '1970-01-01 00:00:01.000000' to '2038-01-19 03:14:07.499999'. The fractional part should always be separated from the rest of the time by a decimal point; no other fractional seconds delimiter is recognized. For information about fractional seconds support in MySQL, see [Section 13.2.6, “Fractional Seconds in Time Values”](https://dev.mysql.com/doc/refman/8.4/en/fractional-seconds.html).

The precision for these types can range from 0 to 6 in MySQL. However, DuckDB only supports second, millisecond, microsecond, and nanosecond precision, so setting a precision of 1, 2, 4 or 5 is impractical and not useful in practice. Therefore, I’ve rounded the precision to 3 in this implementation.

```
mysql> CREATE TABLE t1 (pk int primary key, d datetime);
Query OK, 0 rows affected (0,01 sec)

mysql> CREATE TABLE t2 (pk int primary key, d datetime(3));
Query OK, 0 rows affected (0,02 sec)

mysql> CREATE TABLE t3 (pk int primary key, d datetime(6));
Query OK, 0 rows affected (0,01 sec)

mysql> insert into t1 values (1, '2020-01-01 00:00:00.123456');
Query OK, 1 row affected (0,18 sec)

mysql> insert into t2 values (1, '2020-01-01 00:00:00.123456');
Query OK, 1 row affected (0,17 sec)

mysql> insert into t3 values (1, '2020-01-01 00:00:00.123456');
Query OK, 1 row affected (0,17 sec)

mysql> select * from t1;
+----+---------------------+
| pk | d                   |
+----+---------------------+
|  1 | 2020-01-01 00:00:00 |
+----+---------------------+
1 row in set (0,19 sec)

mysql> select * from t2;
+----+-------------------------+
| pk | d                       |
+----+-------------------------+
|  1 | 2020-01-01 00:00:00.123 |
+----+-------------------------+
1 row in set (0,19 sec)

mysql> select * from t3;
+----+----------------------------+
| pk | d                          |
+----+----------------------------+
|  1 | 2020-01-01 00:00:00.123456 |
+----+----------------------------+
1 row in set (0,19 sec)
```


fixes #40
fixes #39