### PR TITLE
perf: optimize SQL transpile (93ms -> 81µs 🚀 )

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,13 +42,6 @@ var (
 	dbFilePath    string
 )
 
-func checkDependencies() {
-	_, err := translateWithSQLGlot("SELECT 1")
-	if err != nil {
-		panic("Python and SQLGlot are required to run the server. Please install them and try again.")
-	}
-}
-
 func init() {
 	flag.StringVar(&address, "address", address, "The address to bind to.")
 	flag.IntVar(&port, "port", port, "The port to bind to.")
@@ -59,7 +52,12 @@ func main() {
 	flag.Parse()
 	dbFilePath = filepath.Join(dataDirectory, dbFileName)
 
-	checkDependencies()
+	// start SQL translate service
+	err := startTranslationService()
+	if err != nil {
+		panic(err)
+	}
+	defer stopTranslationService()
 
 	provider, err := meta.NewDBProvider(dataDirectory, dbFileName)
 	if err != nil {

--- a/translate.go
+++ b/translate.go
@@ -11,32 +11,239 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (
+	"bufio"
 	"bytes"
+	"encoding/binary"
 	"fmt"
+	"io"
 	"os/exec"
+	"strings"
+
+	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 )
 
-func getPythonPath() (string, error) {
-	// Try to find python3 in the system PATH
-	pythonPath, err := exec.LookPath("python3")
-	if err == nil {
-		return pythonPath, nil
+const (
+	cmdExit = "CMD:EXIT"
+	cmdRun  = "CMD:RUN"
+
+	resultOK  = "OK:"
+	resultErr = "ERROR:"
+)
+
+var (
+	errPythonProcessUnhealthy = errors.NewKind("sqlglot python process is unhealthy: %s")
+)
+
+type translationRequest struct {
+	cmd string
+	sql string
+}
+
+type translationResponse struct {
+	result string
+	err    error
+}
+
+type translateService struct {
+	requestChan  chan translationRequest
+	responseChan chan translationResponse
+	pythonStdin  io.WriteCloser
+	pythonCmd    *exec.Cmd
+	stderrBuf    *bytes.Buffer
+}
+
+var translationSvc *translateService
+
+func newTranslateService() (*translateService, error) {
+	pythonPath, err := getPythonPath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Python path: %v", err)
 	}
 
-	// If python3 is not found, try to find python
-	pythonPath, err = exec.LookPath("python")
-	if err == nil {
-		return pythonPath, nil
+	pythonScript := fmt.Sprintf(`
+import sys
+import sqlglot
+
+CMD_EXIT = %q
+CMD_RUN = %q
+RESULT_OK = %q
+RESULT_ERR = %q
+
+def read_bytes(n: int):
+    bytes = []
+    while n > 0:
+        bytes += sys.stdin.buffer.read(n)
+        n -= len(bytes)
+    return bytes
+
+def read_string():
+    data = read_bytes(4)
+    length = int.from_bytes(data, byteorder='big')
+    data = sys.stdin.buffer.read(length)
+    return data.decode('utf-8')
+
+def write_string(s: str):
+    data = s.encode('utf-8')
+    # write the length of the string first
+    sys.stdout.buffer.write(len(data).to_bytes(4, byteorder='big'))
+    sys.stdout.buffer.write(data)
+    sys.stdout.flush()
+
+while True:
+    inp = read_string()
+    if inp == CMD_EXIT:
+        break
+    if inp.startswith(CMD_RUN):
+        sql = inp[len(CMD_RUN):]
+        try:
+            result = sqlglot.transpile(sql, read="mysql", write="duckdb")[0]
+            write_string(RESULT_OK + result)
+        except Exception as e:
+            write_string(RESULT_ERR + str(e))
+`, cmdExit, cmdRun, resultOK, resultErr)
+
+	pythonCmd := exec.Command(pythonPath, "-u", "-c", pythonScript)
+
+	pythonStdin, err := pythonCmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stdin pipe: %v", err)
 	}
 
-	// If neither python3 nor python is found, return an error
-	return "", fmt.Errorf("neither python3 nor python was found in PATH")
+	stdout, err := pythonCmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stdout pipe: %v", err)
+	}
+
+	var stderrBuf bytes.Buffer
+	pythonCmd.Stderr = &stderrBuf
+
+	err = pythonCmd.Start()
+	if err != nil {
+		return nil, fmt.Errorf("failed to start Python process: %v", err)
+	}
+
+	requestChan := make(chan translationRequest)
+	responseChan := make(chan translationResponse)
+
+	svc := &translateService{
+		requestChan:  requestChan,
+		responseChan: responseChan,
+		pythonStdin:  pythonStdin,
+		pythonCmd:    pythonCmd,
+		stderrBuf:    &stderrBuf,
+	}
+	go svc.handleTranslations(pythonStdin, bufio.NewReader(stdout))
+
+	// Test the translation service with a simple query
+	testSQL := "SELECT 1"
+	translatedSQL, err := svc.translate(testSQL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to test translation service: %v", err)
+	}
+	if translatedSQL != "SELECT 1" {
+		return nil, fmt.Errorf("unexpected translation result: %s", translatedSQL)
+	}
+
+	return svc, nil
+}
+
+func (svc *translateService) translate(sql string) (string, error) {
+	svc.requestChan <- translationRequest{cmd: cmdRun, sql: sql}
+	response := <-svc.responseChan
+
+	if errors.Is(response.err, errPythonProcessUnhealthy) {
+		svc.cleanup()
+		panic(fmt.Errorf("%v\ncmd:\n%s\nstderr:\n%s", response.err, svc.pythonCmd.String(), svc.stderrBuf.String()))
+	}
+
+	return response.result, response.err
+}
+
+func (svc *translateService) handleTranslations(stdin io.Writer, stdout *bufio.Reader) {
+	for req := range svc.requestChan {
+		if req.cmd == cmdExit {
+			sendString(stdin, cmdExit)
+			break
+		}
+
+		err := sendString(stdin, cmdRun+req.sql)
+		if err != nil {
+			svc.responseChan <- translationResponse{"", errPythonProcessUnhealthy.New(err)}
+			continue
+		}
+
+		result, err := recvString(stdout)
+		if err != nil {
+			svc.responseChan <- translationResponse{"", errPythonProcessUnhealthy.New(err)}
+			continue
+		}
+
+		result = strings.TrimSpace(result)
+
+		if strings.HasPrefix(result, resultErr) {
+			svc.responseChan <- translationResponse{"", fmt.Errorf(result[len(resultErr):])}
+		} else if strings.HasPrefix(result, resultOK) {
+			svc.responseChan <- translationResponse{strings.TrimSpace(result[len(resultOK):]), nil}
+		} else {
+			svc.responseChan <- translationResponse{"", fmt.Errorf("unexpected result: %s", result)}
+		}
+	}
+}
+
+// the schema is 4 bytes length + data
+func sendString(writer io.Writer, str string) error {
+	data := []byte(str)
+	length := len(data)
+	lengthBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(lengthBytes, uint32(length))
+	_, err := writer.Write(lengthBytes)
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(data)
+	return err
+}
+
+func recvString(reader *bufio.Reader) (string, error) {
+	lengthBytes := make([]byte, 4)
+	_, err := reader.Read(lengthBytes)
+	if err != nil {
+		return "", err
+	}
+	length := binary.BigEndian.Uint32(lengthBytes)
+	data := make([]byte, length)
+	_, err = reader.Read(data)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (svc *translateService) cleanup() {
+	svc.requestChan <- translationRequest{cmd: cmdExit}
+	svc.pythonCmd.Wait()
+	close(svc.requestChan)
+	close(svc.responseChan)
+}
+
+func startTranslationService() error {
+	svc, err := newTranslateService()
+	if err != nil {
+		return fmt.Errorf("failed to initialize translation service: %v", err)
+	}
+	translationSvc = svc
+	return nil
+}
+
+func stopTranslationService() {
+	translationSvc.cleanup()
 }
 
 func translate(node sql.Node, sql string) (string, error) {
@@ -60,39 +267,27 @@ func translateBuiltIn(sql string) (string, error) {
 	return translateWithSQLGlot(sql)
 }
 
-// translateSQL converts a MySQL query to a DuckDB query using SQLGlot.
-// For simplicity, we assume that Python and SQLGlot are installed on the system.
-// Then we can call the following shell command to convert the query.
-//
-// python -c 'import sys; import sqlglot; sql = sys.stdin.read(); print(sqlglot.transpile(sql, read="mysql", write="duckdb")[0])
-//
-// In the future, we can deploy a SQLGlot server and use the API to convert the query.
 func translateWithSQLGlot(sql string) (string, error) {
-	pythonPath, err := getPythonPath()
-	if err != nil {
-		fmt.Println("Error:", err)
-		return "", err
+	if translationSvc == nil {
+		return "", fmt.Errorf("translation service is not initialized")
 	}
 
-	// Prepare the command to be executed
-	cmd := exec.Command(pythonPath, "-c", `import sys; import sqlglot; sql = sys.stdin.read(); print(sqlglot.transpile(sql, read="mysql", write="duckdb")[0])`)
+	return translationSvc.translate(sql)
+}
 
-	// Set the input for the command
-	cmd.Stdin = bytes.NewBufferString(sql)
-
-	// Capture the output of the command
-	var out bytes.Buffer
-	var outErr bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &outErr
-
-	// Execute the command
-	if err := cmd.Run(); err != nil {
-		err = fmt.Errorf("failed to execute command(%s): %v\n%s", pythonPath, err, outErr.String())
-		fmt.Println(err)
-		return "", err
+func getPythonPath() (string, error) {
+	// Try to find python3 in the system PATH
+	pythonPath, err := exec.LookPath("python3")
+	if err == nil {
+		return pythonPath, nil
 	}
 
-	// Return the converted query
-	return out.String(), nil
+	// If python3 is not found, try to find python
+	pythonPath, err = exec.LookPath("python")
+	if err == nil {
+		return pythonPath, nil
+	}
+
+	// If neither python3 nor python is found, return an error
+	return "", fmt.Errorf("neither python3 nor python was found in PATH")
 }

--- a/translate_test.go
+++ b/translate_test.go
@@ -7,6 +7,12 @@ import (
 )
 
 func TestTranslate(t *testing.T) {
+	err := startTranslationService()
+	if err != nil {
+		t.Fatalf("Failed to start translation service: %v", err)
+	}
+	defer stopTranslationService()
+
 	// Define a slice of test cases
 	testCases := []struct {
 		name     string
@@ -35,7 +41,16 @@ func TestTranslate(t *testing.T) {
 			input:    "CREATE TABLE orders (order_id INT PRIMARY KEY, user_id INT, FOREIGN KEY (user_id) REFERENCES users(id))",
 			expected: "CREATE TABLE orders (order_id INT PRIMARY KEY, user_id INT, FOREIGN KEY (user_id) REFERENCES users (id))",
 		},
-		// Add more test cases as needed
+		{
+			name:     "SELECT with newlines",
+			input:    "SELECT '\n' FROM users WHERE id = 1\n",
+			expected: "SELECT '\n' FROM users WHERE id = 1",
+		},
+		{
+			name:     "multiple statements",
+			input:    "CREATE TABLE users (id INT AUTO_INCREMENT PRIMARY KEY); \n SELECT * FROM users WHERE id = 1",
+			expected: "CREATE TABLE users (id INT AUTO_INCREMENT PRIMARY KEY)",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
This PR optimizes SQL transpile by switching from a per-request Python process to a persistent subprocess using a simple text protocol over stdin/stdout, reducing operation time from 93ms to 81µs per SQL.