### PR TITLE
fix: classify SELECT DATABASE() as non-pure data query in isPureDataQuery

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -264,6 +264,8 @@ func isPureDataQuery(n sql.Node) bool {
 		switch tn.Database().Name() {
 		case "mysql", "information_schema", "performance_schema", "sys":
 			return false
+		case "":
+			return false
 		}
 	}
 	return true


### PR DESCRIPTION
The classification is based on go-mysql-server creating a memory table without a database name when processing system functions.

Limitation:
`SELECT database() FROM tab` doesn’t work and requires further investigation.