### PR TITLE
refactor: make type annotations more structured

### DIFF
--- a/meta/comment.go
+++ b/meta/comment.go
@@ -1,43 +1,55 @@
 package meta
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
-type Comment struct {
+type Comment[T any] struct {
 	Text string `json:"text,omitempty"`
-	Meta string `json:"meta,omitempty"` // extra information, e.g. the original MySQL column type, etc.
+	Meta T      `json:"meta,omitempty"` // extra information, e.g. the original MySQL column type, etc.
 }
 
-func DecodeComment(encodedOrRawText string) *Comment {
-	var c Comment
-	err := json.Unmarshal([]byte(encodedOrRawText), &c)
+const ManagedCommentPrefix = "base64:"
+
+func DecodeComment[T any](encodedOrRawText string) *Comment[T] {
+	if !strings.HasPrefix(encodedOrRawText, ManagedCommentPrefix) {
+		return NewComment[T](encodedOrRawText)
+	}
+	encoded := []byte(encodedOrRawText[len(ManagedCommentPrefix):])
+	decoded := make([]byte, base64.StdEncoding.DecodedLen(len(encoded)))
+	n, err := base64.StdEncoding.Decode(decoded, encoded)
 	if err != nil {
+		logrus.Warn("failed to decode comment: ", err)
+		return NewComment[T](encodedOrRawText)
+	}
+	decoded = decoded[:n]
+
+	var c Comment[T]
+	if err = json.Unmarshal(decoded, &c); err != nil {
 		// not a valid JSON, treat it as a raw text
 		// may be a legacy comment without meta field
 		// or the object is not managed by us
-		return NewComment(encodedOrRawText)
+		return NewComment[T](encodedOrRawText)
 	}
 	return &c
 }
 
-func NewComment(text string) *Comment {
-	return &Comment{Text: text}
+func NewComment[T any](text string) *Comment[T] {
+	return &Comment[T]{Text: text}
 }
 
-func NewCommentWithMeta(text, meta string) *Comment {
-	return &Comment{Text: text, Meta: meta}
+func NewCommentWithMeta[T any](text string, meta T) *Comment[T] {
+	return &Comment[T]{Text: text, Meta: meta}
 }
 
-func (c *Comment) Encode() string {
+func (c *Comment[T]) Encode() string {
 	jsonData, err := json.Marshal(c)
 	if err != nil {
 		panic(err)
 	}
-	return norm(string(jsonData))
-}
-
-func norm(text string) string {
-	return "'" + strings.ReplaceAll(text, "'", "''") + "'"
+	return ManagedCommentPrefix + base64.StdEncoding.EncodeToString(jsonData)
 }

--- a/meta/index.go
+++ b/meta/index.go
@@ -8,7 +8,7 @@ type Index struct {
 	Exprs      []sql.Expression
 	Name       string
 	Unique     bool
-	CommentObj *Comment
+	CommentObj *Comment[any]
 	PrefixLens []uint16
 }
 
@@ -16,7 +16,7 @@ var _ sql.Index = (*Index)(nil)
 
 // TODO: DuckDB doesn't have a convenient way to get the expressions from an index
 // so we need to implement our own. Storing it in the index comment is a good idea.
-func NewIndex(dbName, tableName, name string, unique bool, comment *Comment) *Index {
+func NewIndex(dbName, tableName, name string, unique bool, comment *Comment[any]) *Index {
 	return &Index{
 		DbName:     dbName,
 		TableName:  tableName,


### PR DESCRIPTION
This PR employs a more structured approach to store MySQL column type details in DuckDB. By doing so, #42 & #36 will become easier to implement.