### PR TITLE
chore(make): add total coverage summary and detailed coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ myduckserver
 *.log
 .replica/
 *.txt
+*.out

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,20 @@ clean:
 run: build
 	./$(BINARY_NAME)
 
-# Test target
-.PHONY: test-full
-test:
-	go test -cover ./...
 
-.PHONY: test
+# Test target
+.PHONY: test-full test cover
+
+TEST_CMD = go test -cover -coverprofile cover.out 
+SHOW_TOTAL_COVERAGE = go tool cover -func=cover.out | grep total | awk '{print "Total Coverage: " $$3 " (run '\''make cover'\'' for details)"}'
+
+test-full:
+	$(TEST_CMD) ./...
+	@$(SHOW_TOTAL_COVERAGE)
+
 test:
-	go test -cover $(shell go list ./... | grep -v './binlogreplication' | grep -v './transpiler')
+	$(TEST_CMD) $(shell go list ./... | grep -v './binlogreplication' | grep -v './transpiler')
+	@$(SHOW_TOTAL_COVERAGE)
+
+cover:
+	go tool cover -html=cover.out


### PR DESCRIPTION
```
 𝕏 make test
go test -cover -coverprofile cover.out  github.com/apecloud/myduckserver github.com/apecloud/myduckserver/configuration github.com/apecloud/myduckserver/meta
?   	github.com/apecloud/myduckserver/configuration	[no test files]
	github.com/apecloud/myduckserver/meta		coverage: 0.0% of statements
ok  	github.com/apecloud/myduckserver	102.855s	coverage: 41.2% of statements
Total Coverage: 49.6% (run 'make cover' for details)
```