### PR TITLE
feat: add support for MySQL TIME type

### DIFF
--- a/binlogreplication/binlog_replica_applier.go
+++ b/binlogreplication/binlog_replica_applier.go
@@ -811,6 +811,12 @@ func convertSqlTypesValue(ctx *sql.Context, engine *gms.Engine, value sqltypes.V
 		convertedValue, _, err = column.Type.Convert(strings.TrimSpace(value.ToString()))
 	case types.IsJSON(column.Type):
 		convertedValue, err = convertVitessJsonExpressionString(ctx, engine, value)
+	case types.IsTimespan(column.Type):
+		convertedValue, _, err = column.Type.Convert(value.ToString())
+		if err != nil {
+			return nil, err
+		}
+		convertedValue = convertedValue.(types.Timespan).String()
 	default:
 		convertedValue, _, err = column.Type.Convert(value.ToString())
 	}

--- a/binlogreplication/binlog_replication_alltypes_test.go
+++ b/binlogreplication/binlog_replication_alltypes_test.go
@@ -454,13 +454,13 @@ var allTypes = []typeDescription{
 			newTypeDescriptionAssertion("DATE('1981-02-16')"),
 		},
 	},
-	// {
-	// 	TypeDefinition: "time",
-	// 	Assertions: [2]typeDescriptionAssertion{
-	// 		newTypeDescriptionAssertion("TIME('01:02:03')"),
-	// 		newTypeDescriptionAssertion("TIME('01:02:03')"),
-	// 	},
-	// },
+	{
+		TypeDefinition: "time",
+		Assertions: [2]typeDescriptionAssertion{
+			newTypeDescriptionAssertion("TIME('01:02:03')"),
+			newTypeDescriptionAssertion("TIME('01:02:03')"),
+		},
+	},
 	{
 		TypeDefinition: "datetime",
 		Assertions: [2]typeDescriptionAssertion{

--- a/meta/type_mapping.go
+++ b/meta/type_mapping.go
@@ -133,7 +133,9 @@ func duckdbDataType(mysqlType sql.Type) (AnnotatedDuckType, error) {
 	case sqltypes.Date:
 		return newCommonType("DATE"), nil
 	case sqltypes.Time:
-		return newCommonType("TIME"), nil
+		// https://dev.mysql.com/doc/refman/8.4/en/time.html
+		// MySQL's TIME type can store a value within the range of '-838:59:59.000000' to '838:59:59.000000'.
+		return newSimpleType("INTERVAL", "TIME"), nil
 	case sqltypes.Datetime:
 		return newDateTimeType("DATETIME", mysqlType.(sql.DatetimeType).Precision()), nil
 	case sqltypes.Year:
@@ -245,7 +247,7 @@ func mysqlDataType(duckType AnnotatedDuckType, numericPrecision uint8, numericSc
 
 	case "DATE":
 		return types.Date
-	case "TIME":
+	case "INTERVAL", "TIME":
 		return types.Time
 
 	case "DECIMAL":


### PR DESCRIPTION
This PR maps [MySQL's TIME type](https://dev.mysql.com/doc/refman/8.4/en/time.html) to DuckDB's INTERVAL type and fix binlog replication & duckdb->go-mysql-server conversion for this type correspondingly.