### PR TITLE
feat: add support for the BIT type

### DIFF
--- a/binlogreplication/binlog_replication_alltypes_test.go
+++ b/binlogreplication/binlog_replication_alltypes_test.go
@@ -169,20 +169,20 @@ func (td *typeDescription) IsStringType() bool {
 // test cases we need to cover (e.g. NULL values).
 var allTypes = []typeDescription{
 	// Bit types
-	// {
-	// 	TypeDefinition: "bit",
-	// 	Assertions: [2]typeDescriptionAssertion{
-	// 		newTypeDescriptionAssertionWithExpectedValue("0", []uint8{0}),
-	// 		newTypeDescriptionAssertionWithExpectedValue("1", []uint8{1}),
-	// 	},
-	// },
-	// {
-	// 	TypeDefinition: "bit(64)",
-	// 	Assertions: [2]typeDescriptionAssertion{
-	// 		newTypeDescriptionAssertionWithExpectedValue("0", []byte{0, 0, 0, 0, 0, 0, 0, 0}),
-	// 		newTypeDescriptionAssertionWithExpectedValue("1", []byte{0, 0, 0, 0, 0, 0, 0, 1}),
-	// 	},
-	// },
+	{
+		TypeDefinition: "bit",
+		Assertions: [2]typeDescriptionAssertion{
+			newTypeDescriptionAssertionWithExpectedValue("0", []uint8{0}),
+			newTypeDescriptionAssertionWithExpectedValue("1", []uint8{1}),
+		},
+	},
+	{
+		TypeDefinition: "bit(64)",
+		Assertions: [2]typeDescriptionAssertion{
+			newTypeDescriptionAssertionWithExpectedValue("0", []byte{0, 0, 0, 0, 0, 0, 0, 0}),
+			newTypeDescriptionAssertionWithExpectedValue("1", []byte{0, 0, 0, 0, 0, 0, 0, 1}),
+		},
+	},
 
 	// Integer types
 	{

--- a/meta/type_mapping.go
+++ b/meta/type_mapping.go
@@ -101,8 +101,6 @@ func newSetType(typ sql.SetType) AnnotatedDuckType {
 const DuckDBDecimalTypeMaxPrecision = 38
 
 func duckdbDataType(mysqlType sql.Type) (AnnotatedDuckType, error) {
-
-	// ugly ? no, AI helps us
 	switch mysqlType.Type() {
 	case sqltypes.Int8:
 		return newNumberType("TINYINT", mysqlType.(sql.NumberType).DisplayWidth()), nil
@@ -165,7 +163,9 @@ func duckdbDataType(mysqlType sql.Type) (AnnotatedDuckType, error) {
 	case sqltypes.Binary:
 		return newStringType("BLOB", "BINARY", mysqlType.(sql.StringType)), nil
 	case sqltypes.Bit:
-		return newPrecisionType("BIT", "BIT", mysqlType.(types.BitType).NumberOfBits()), nil
+		// https://dev.mysql.com/doc/refman/8.4/en/bit-type.html
+		// We store it as a 64-bit unsigned integer because the BIT type is not supported by go-duckdb currently.
+		return newPrecisionType("UBIGINT", "BIT", mysqlType.(types.BitType).NumberOfBits()), nil
 	case sqltypes.TypeJSON:
 		return newCommonType("JSON"), nil
 	case sqltypes.Enum:
@@ -220,6 +220,9 @@ func mysqlDataType(duckType AnnotatedDuckType, numericPrecision uint8, numericSc
 	case "BIGINT":
 		intBaseType = sqltypes.Int64
 	case "UBIGINT":
+		if mysqlName == "BIT" {
+			return types.MustCreateBitType(duckType.mysql.Precision)
+		}
 		intBaseType = sqltypes.Uint64
 	}
 
@@ -288,12 +291,6 @@ func mysqlDataType(duckType AnnotatedDuckType, numericPrecision uint8, numericSc
 			return types.MustCreateBinary(sqltypes.Binary, length)
 		}
 		return types.Blob
-
-	case "BIT":
-		if mysqlName == "BIT" {
-			return types.MustCreateBitType(uint8(length))
-		}
-		return types.MustCreateBitType(types.BitTypeMaxBits)
 
 	case "JSON":
 		return types.JSON


### PR DESCRIPTION
Since the BIT type is not supported by go-duckdb, we map it to DuckDB's `UBIGINT`.