### PR TITLE
test: enable additional CREATE TABLE tests after adding support for show index keys(#48)

### DIFF
--- a/harness/duck_harness.go
+++ b/harness/duck_harness.go
@@ -97,8 +97,7 @@ func NewDuckHarness(name string, parallelism int, numTablePartitions int, useNat
 
 func NewDefaultDuckHarness() *DuckHarness {
 	return NewDuckHarness("default", 1, TestNumPartitions, true, nil).SetupScriptsToSkip(
-		setup.Fk_tblData,     // Skip foreign key setup (not supported)
-		setup.TypestableData, // Skip enum/set type setup (not supported)
+		setup.Fk_tblData, // Skip foreign key setup (not supported)
 	)
 }
 


### PR DESCRIPTION
Thanks to PR #48 by @ddh-5230, we can now pass more CREATE TABLE cases.