### PR TITLE
fix: enable null padding in DuckDB's `read_csv` function

### DIFF
--- a/backend/loaddata.go
+++ b/backend/loaddata.go
@@ -152,6 +152,7 @@ func (db *DuckBuilder) executeLoadData(ctx *sql.Context, insert *plan.InsertInto
 
 	b.WriteString(", auto_detect = false")
 	b.WriteString(", header = false")
+	b.WriteString(", null_padding = true")
 
 	b.WriteString(", new_line = ")
 	if len(load.LinesTerminatedBy) == 1 {

--- a/main_test.go
+++ b/main_test.go
@@ -918,7 +918,6 @@ func TestLoadData(t *testing.T) {
 	harness := NewDefaultDuckHarness()
 	harness.QueriesToSkip(
 		"create table loadtable(pk int primary key, check (pk > 1))",
-		"create table loadtable(pk int primary key, c1 int)", // Table has more columns than import.
 		"CREATE TABLE test1 (pk BIGINT PRIMARY KEY, v1 BIGINT DEFAULT (v2 * 10), v2 BIGINT DEFAULT 5);",
 		"CREATE TABLE test1 (pk BIGINT PRIMARY KEY, v1 BIGINT DEFAULT (v2 * 10), v2 BIGINT DEFAULT 5);",
 		"CREATE TABLE inmate_population_snapshots (id char(21) NOT NULL, snapshot_date date NOT NULL, total int,"+


### PR DESCRIPTION
This allows us to pass one more LOAD DATA test case.