### PR TITLE
ci: release the main branch as the `latest` docker image

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -11,7 +11,7 @@ jobs:
     uses: apecloud/apecloud-cd/.github/workflows/release-image-cache.yml@v0.1.79
     with:
       IMG: "apecloud/myduckserver"
-      VERSION: "main"
+      VERSION: "latest"
       GO_VERSION: "1.23"
       DOCKERFILE_PATH: "./docker/Dockerfile"
     secrets: inherit


### PR DESCRIPTION
Fix #131 