### PR TITLE
perf: speedup replication

### DIFF
--- a/binlogreplication/writer.go
+++ b/binlogreplication/writer.go
@@ -25,6 +25,11 @@ type DeltaAppender interface {
 	TxnGroup() *array.BinaryDictionaryBuilder
 	TxnSeqNumber() *array.Uint64Builder
 	TxnStmtOrdinal() *array.Uint64Builder
+	IncInsertEventCount()
+	IncDeleteEventCount()
+	GetInsertEventCount() int
+	GetDeleteEventCount() int
+	ResetEventCounts()
 }
 
 type TableWriterProvider interface {

--- a/delta/delta.go
+++ b/delta/delta.go
@@ -17,8 +17,10 @@ type tableIdentifier struct {
 }
 
 type DeltaAppender struct {
-	schema   sql.Schema
-	appender myarrow.ArrowAppender
+	schema           sql.Schema
+	appender         myarrow.ArrowAppender
+	insertEventCount int
+	deleteEventCount int
 }
 
 // Create a new appender.
@@ -114,4 +116,25 @@ func (a *DeltaAppender) Grow(n int) {
 
 func (a *DeltaAppender) Release() {
 	a.appender.Release()
+}
+
+func (a *DeltaAppender) IncInsertEventCount() {
+	a.insertEventCount++
+}
+
+func (a *DeltaAppender) IncDeleteEventCount() {
+	a.deleteEventCount++
+}
+
+func (a *DeltaAppender) GetInsertEventCount() int {
+	return a.insertEventCount
+}
+
+func (a *DeltaAppender) GetDeleteEventCount() int {
+	return a.deleteEventCount
+}
+
+func (a *DeltaAppender) ResetEventCounts() {
+	a.insertEventCount = 0
+	a.deleteEventCount = 0
 }


### PR DESCRIPTION
This commit improves replication in two ways:

1. Cache table schema in binary log applier instead of querying it from duckdb for each row even

2. Ingest delta using simple INSERT statement when there are no deletes or updates in the batch


Replication lag during TPC-H prepare using 1 thread (before this change):

```
./go-tpc --host 127.0.0.1 --user root -P 3306 --sf=2 --db test --threads 1 tpch prepare
```

![before](https://github.com/user-attachments/assets/bc34839f-eca7-449e-b755-ec834cb27f6b)


Replication lag is completely gone after this change (4 prepare threads):

```
./go-tpc --host 127.0.0.1 --user root -P 3306 --sf=2 --db test --threads 4 tpch prepare
```

![after](https://github.com/user-attachments/assets/b809b020-6cf5-4d6e-ad8f-2d6a0faecbcb)

