### PR TITLE
feat: replicate Postgres array types

### DIFF
--- a/pgserver/duck_handler.go
+++ b/pgserver/duck_handler.go
@@ -527,7 +527,7 @@ func (h *DuckHandler) executeBoundPlan(ctx *sql.Context, query string, _ tree.St
 			rows.Close()
 			break
 		}
-		iter, err = backend.NewSQLRowIter(rows, schema)
+		iter, err = NewSqlRowIter(rows, schema)
 		if err != nil {
 			rows.Close()
 			break

--- a/pgserver/iter.go
+++ b/pgserver/iter.go
@@ -1,11 +1,15 @@
 package pgserver
 
 import (
+	stdsql "database/sql"
 	"database/sql/driver"
+	"fmt"
 	"io"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/marcboeker/go-duckdb"
 	"github.com/sirupsen/logrus"
 )
 
@@ -24,21 +28,27 @@ func NewDriverRowIter(rows driver.Rows, schema sql.Schema) (*DriverRowIter, erro
 	buf := make([]driver.Value, width)
 	row := make([]any, width)
 
+	iter := &DriverRowIter{rows, columns, schema, buf, row}
+	if logrus.GetLevel() >= logrus.DebugLevel {
+		logrus.Debugf("New " + iter.String() + "\n")
+	}
+	return iter, nil
+}
+
+func (iter *DriverRowIter) String() string {
 	var sb strings.Builder
-	for i, col := range schema {
+	for i, col := range iter.schema {
 		if i > 0 {
 			sb.WriteString(" ")
 		}
 		sb.WriteString(col.Type.String())
 	}
-	logrus.Debugf("New DriverRowIter: columns=%v, schema=[%s]\n", columns, sb.String())
-
-	return &DriverRowIter{rows, columns, schema, buf, row}, nil
+	return fmt.Sprintf("DriverRowIter: columns=%v, schema=[%s]", iter.columns, formatSchema(iter.schema))
 }
 
 // Next retrieves the next row. It will return io.EOF if it's the last row.
 func (iter *DriverRowIter) Next(ctx *sql.Context) (sql.Row, error) {
-	if err := iter.rows.Next(iter.buffer); err != nil {
+	if err := iter.rows.Next(iter.buffer[:len(iter.columns)]); err != nil {
 		if err == io.EOF {
 			return nil, io.EOF
 		}
@@ -65,4 +75,148 @@ func (iter *DriverRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 // Close closes the underlying driver.Rows.
 func (iter *DriverRowIter) Close(ctx *sql.Context) error {
 	return iter.rows.Close()
+}
+
+// SqlRowIter wraps a standard sql.Rows as a RowIter.
+type SqlRowIter struct {
+	rows     *stdsql.Rows
+	columns  []*stdsql.ColumnType
+	schema   sql.Schema
+	buffer   []any // pre-allocated buffer for scanning values
+	pointers []any // pointers to the buffer
+
+	decimals []int
+	lists    []int
+}
+
+func NewSqlRowIter(rows *stdsql.Rows, schema sql.Schema) (*SqlRowIter, error) {
+	columns, err := rows.ColumnTypes()
+	if err != nil {
+		return nil, err
+	}
+
+	width := max(len(columns), len(schema))
+	buf := make([]any, width)
+	ptrs := make([]any, width)
+	for i := range buf {
+		ptrs[i] = &buf[i]
+	}
+
+	var decimals []int
+	for i, c := range columns {
+		if strings.HasPrefix(c.DatabaseTypeName(), "DECIMAL") {
+			decimals = append(decimals, i)
+		}
+	}
+
+	var lists []int
+	for i, t := range columns {
+		if strings.HasSuffix(t.DatabaseTypeName(), "[]") {
+			lists = append(lists, i)
+		}
+	}
+
+	iter := &SqlRowIter{rows, columns, schema, buf, ptrs, decimals, lists}
+	if logrus.GetLevel() >= logrus.DebugLevel {
+		logrus.Debugf("New " + iter.String() + "\n")
+	}
+	return iter, nil
+}
+
+func (iter *SqlRowIter) String() string {
+	return fmt.Sprintf("SqlRowIter: columns=[%s], schema=[%s]", formatColumnTypes(iter.columns), formatSchema(iter.schema))
+}
+
+// Next retrieves the next row. It will return io.EOF if it's the last row.
+func (iter *SqlRowIter) Next(ctx *sql.Context) (sql.Row, error) {
+	if !iter.rows.Next() {
+		if err := iter.rows.Err(); err != nil {
+			return nil, err
+		}
+		return nil, io.EOF
+	}
+
+	// Scan the values into the buffer
+	if err := iter.rows.Scan(iter.pointers[:len(iter.columns)]...); err != nil {
+		return nil, err
+	}
+
+	// logrus.Debugf("iter.decimals=%v, iter.lists=%v iter.buffer=%#v\n", iter.decimals, iter.lists, iter.buffer)
+
+	// Process decimal values
+	for _, idx := range iter.decimals {
+		switch v := iter.buffer[idx].(type) {
+		case nil:
+			continue
+		case duckdb.Decimal:
+			iter.buffer[idx] = pgtype.Numeric{Int: v.Value, Exp: -int32(v.Scale), Valid: true}
+		case string:
+			var n pgtype.Numeric
+			if err := n.Scan(v); err != nil {
+				return nil, err
+			}
+			iter.buffer[idx] = n
+		default:
+			return nil, fmt.Errorf("unexpected type %T for decimal value", v)
+		}
+	}
+
+	// Process list values
+	for _, idx := range iter.lists {
+		var list []any
+		switch v := iter.buffer[idx].(type) {
+		case nil:
+			list = nil
+		case []any:
+			list = v
+		case duckdb.Composite[[]any]:
+			list = v.Get()
+		default:
+			return nil, fmt.Errorf("unexpected type %T for list value", v)
+		}
+		iter.buffer[idx] = pgtype.FlatArray[any](list)
+	}
+
+	// Prune or fill the values to match the schema
+	width := len(iter.schema) // the desired width
+	if width == 0 {
+		width = len(iter.columns)
+	} else if len(iter.columns) < width {
+		for i := len(iter.columns); i < width; i++ {
+			iter.buffer[i] = nil
+		}
+	}
+
+	return sql.NewRow(iter.buffer[:width]...), nil
+}
+
+// Close closes the underlying sql.Rows.
+func (iter *SqlRowIter) Close(ctx *sql.Context) error {
+	return iter.rows.Close()
+}
+
+func formatSchema(schema sql.Schema) string {
+	var sb strings.Builder
+	for i, col := range schema {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(col.Name)
+		sb.WriteString(": ")
+		sb.WriteString(col.Type.String())
+	}
+	return sb.String()
+}
+
+func formatColumnTypes(columns []*stdsql.ColumnType) string {
+	var sb strings.Builder
+	for i, col := range columns {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(col.Name())
+		sb.WriteString(": ")
+		sb.WriteString(col.DatabaseTypeName())
+	}
+	return sb.String()
 }

--- a/pgserver/logrepl/replication.go
+++ b/pgserver/logrepl/replication.go
@@ -715,7 +715,7 @@ func (r *LogicalReplicator) processMessage(
 		schema := make(sql.Schema, len(logicalMsg.Columns))
 		var keys []uint16
 		for i, col := range logicalMsg.Columns {
-			pgType, err := pgtypes.NewPostgresType(col.DataType, col.TypeModifier)
+			pgType, err := pgtypes.NewPostgresType(state.typeMap, col.DataType, col.TypeModifier)
 			if err != nil {
 				return false, err
 			}

--- a/pgserver/logrepl/replication_test.go
+++ b/pgserver/logrepl/replication_test.go
@@ -610,6 +610,29 @@ var replicationTests = []ReplicationTest{
 			},
 		},
 	},
+	{
+		Name: "Truncate table",
+		SetUpScript: []string{
+			dropReplicationSlot,
+			createReplicationSlot,
+			startReplication,
+			"/* replica */ drop table if exists public.test",
+			"drop table if exists public.test",
+			"CREATE TABLE public.test (id INT primary key, name varchar(10))",
+			"INSERT INTO public.test VALUES (1, 'one'), (2, 'two'), (3, 'three')",
+			"TRUNCATE TABLE public.test",
+			"INSERT INTO public.test VALUES (4, 'four')",
+			waitForCatchup,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "/* replica */ SELECT * FROM public.test order by id",
+				Expected: []sql.Row{
+					{int32(4), "four"},
+				},
+			},
+		},
+	},
 }
 
 func TestReplication(t *testing.T) {

--- a/pgserver/logrepl/replication_test.go
+++ b/pgserver/logrepl/replication_test.go
@@ -542,7 +542,7 @@ var replicationTests = []ReplicationTest{
 				"'2021-02-02', '13:00:00.123456', '2021-02-02 13:00:00.123456', '2021-02-02 05:00:00.123456-8', " +
 				"98765432.1, " +
 				`'\xDEADBEEF', 'another description', 'XYZ', ` +
-				"ARRAY['tag3', 'tag4'], ARRAY[4, 5, 6], ARRAY[4.4, 5.5, 6.6]::real[], " +
+				"ARRAY['tag3', 'tag4', NULL, 'NULL'], ARRAY[4, 5, 6, 7, NULL], ARRAY[NULL, 4.4, 5.5, 6.6, 7.7]::real[], " +
 				`-123, -9223372036854775808, '{"array": [1, 2, 3]}')`,
 			"UPDATE public.test SET name = 'three' WHERE id = 2",
 			`UPDATE public.test SET json_data = jsonb_set(json_data, '{key}', '"new_value"') WHERE id = 1`,
@@ -559,9 +559,9 @@ var replicationTests = []ReplicationTest{
 						pgtest.Numeric("12345678.9"),
 						[]byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF},
 						"long text description", "ABC",
-						[]string{"tag1", "tag2"},
-						[]int32{1, 2, 3},
-						[]float32{1.1, 2.2, 3.3},
+						`{tag1,tag2}`,
+						`{1,2,3}`,
+						`{1.1,2.2,3.3}`,
 						int16(123),
 						int64(9223372036854775807),
 						`{"key": "new_value"}`,
@@ -574,9 +574,9 @@ var replicationTests = []ReplicationTest{
 						pgtest.Numeric("98765432.1"),
 						[]byte{0xDE, 0xAD, 0xBE, 0xEF},
 						"another description", "XYZ",
-						[]string{"tag3", "tag4"},
-						[]int32{4, 5, 6},
-						[]float32{4.4, 5.5, 6.6},
+						`{tag3,tag4,NULL,"NULL"}`,
+						`{4,5,6,7,NULL}`,
+						`{NULL,4.4,5.5,6.6,7.7}`,
 						int16(-123),
 						int64(-9223372036854775808),
 						`{"array": [1, 2, 3]}`,

--- a/pgserver/logrepl/replication_test.go
+++ b/pgserver/logrepl/replication_test.go
@@ -503,9 +503,9 @@ var replicationTests = []ReplicationTest{
 				"binary_data BYTEA, " +
 				"description TEXT, " +
 				"code CHAR(3), " +
-				// "tags TEXT[], " +
-				// "scores INTEGER[], " +
-				// "real_nums REAL[], " +
+				"tags TEXT[], " +
+				"scores INTEGER[], " +
+				"real_nums REAL[], " +
 				"small_num SMALLINT, " +
 				"big_num BIGINT, " +
 				"json_data JSON)",
@@ -524,9 +524,9 @@ var replicationTests = []ReplicationTest{
 				"binary_data BYTEA, " +
 				"description TEXT, " +
 				"code CHAR(3), " +
-				// "tags TEXT[], " +
-				// "scores INTEGER[], " +
-				// "real_nums REAL[], " +
+				"tags TEXT[], " +
+				"scores INTEGER[], " +
+				"real_nums REAL[], " +
 				"small_num SMALLINT, " +
 				"big_num BIGINT, " +
 				"json_data JSONB)",
@@ -535,14 +535,14 @@ var replicationTests = []ReplicationTest{
 				"'2021-01-01', '12:00:00', '2021-01-01 12:00:00', '2021-01-01 20:00:00+8', " +
 				"12345678.9, " +
 				`'\x0123456789ABCDEF', 'long text description', 'ABC', ` +
-				// "ARRAY['tag1', 'tag2'], ARRAY[1, 2, 3], ARRAY[1.1, 2.2, 3.3]::real[], " +
+				"ARRAY['tag1', 'tag2'], ARRAY[1, 2, 3], ARRAY[1.1, 2.2, 3.3]::real[], " +
 				`123, 9223372036854775807, '{"key": "value"}')`,
 			"INSERT INTO public.test VALUES (2, " +
 				"'two', 2, false, 2.2, " +
 				"'2021-02-02', '13:00:00.123456', '2021-02-02 13:00:00.123456', '2021-02-02 05:00:00.123456-8', " +
 				"98765432.1, " +
 				`'\xDEADBEEF', 'another description', 'XYZ', ` +
-				// "ARRAY['tag3', 'tag4'], ARRAY[4, 5, 6], ARRAY[4.4, 5.5, 6.6]::real[], " +
+				"ARRAY['tag3', 'tag4'], ARRAY[4, 5, 6], ARRAY[4.4, 5.5, 6.6]::real[], " +
 				`-123, -9223372036854775808, '{"array": [1, 2, 3]}')`,
 			"UPDATE public.test SET name = 'three' WHERE id = 2",
 			`UPDATE public.test SET json_data = jsonb_set(json_data, '{key}', '"new_value"') WHERE id = 1`,
@@ -559,9 +559,9 @@ var replicationTests = []ReplicationTest{
 						pgtest.Numeric("12345678.9"),
 						[]byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF},
 						"long text description", "ABC",
-						// []string{"tag1", "tag2"},
-						// []int32{1, 2, 3},
-						// []float32{1.1, 2.2, 3.3},
+						[]string{"tag1", "tag2"},
+						[]int32{1, 2, 3},
+						[]float32{1.1, 2.2, 3.3},
 						int16(123),
 						int64(9223372036854775807),
 						`{"key": "new_value"}`,
@@ -574,9 +574,9 @@ var replicationTests = []ReplicationTest{
 						pgtest.Numeric("98765432.1"),
 						[]byte{0xDE, 0xAD, 0xBE, 0xEF},
 						"another description", "XYZ",
-						// []string{"tag3", "tag4"},
-						// []int32{4, 5, 6},
-						// []float32{4.4, 5.5, 6.6},
+						[]string{"tag3", "tag4"},
+						[]int32{4, 5, 6},
+						[]float32{4.4, 5.5, 6.6},
 						int16(-123),
 						int64(-9223372036854775808),
 						`{"array": [1, 2, 3]}`,

--- a/pgserver/logrepl/replication_test.go
+++ b/pgserver/logrepl/replication_test.go
@@ -931,7 +931,7 @@ func waitForCaughtUp(r *logrepl.LogicalReplicator) error {
 		}
 
 		log.Println("replication not caught up, waiting")
-		if time.Since(start) >= 10*time.Second {
+		if time.Since(start) >= 30*time.Second {
 			return errors.New("Replication did not catch up")
 		}
 		time.Sleep(1 * time.Second)

--- a/pgserver/logrepl/replication_test.go
+++ b/pgserver/logrepl/replication_test.go
@@ -506,6 +506,7 @@ var replicationTests = []ReplicationTest{
 				"tags TEXT[], " +
 				"scores INTEGER[], " +
 				"real_nums REAL[], " +
+				"decimal_nums DECIMAL(8,3)[], " +
 				"small_num SMALLINT, " +
 				"big_num BIGINT, " +
 				"json_data JSON)",
@@ -527,6 +528,7 @@ var replicationTests = []ReplicationTest{
 				"tags TEXT[], " +
 				"scores INTEGER[], " +
 				"real_nums REAL[], " +
+				"decimal_nums DECIMAL(8,3)[], " +
 				"small_num SMALLINT, " +
 				"big_num BIGINT, " +
 				"json_data JSONB)",
@@ -535,14 +537,14 @@ var replicationTests = []ReplicationTest{
 				"'2021-01-01', '12:00:00', '2021-01-01 12:00:00', '2021-01-01 20:00:00+8', " +
 				"12345678.9, " +
 				`'\x0123456789ABCDEF', 'long text description', 'ABC', ` +
-				"ARRAY['tag1', 'tag2'], ARRAY[1, 2, 3], ARRAY[1.1, 2.2, 3.3]::real[], " +
+				"ARRAY['tag1', 'tag2'], ARRAY[1, 2, 3], ARRAY[1.1, 2.2, 3.3]::real[], ARRAY[1.1, 22.22, 333.333], " +
 				`123, 9223372036854775807, '{"key": "value"}')`,
 			"INSERT INTO public.test VALUES (2, " +
 				"'two', 2, false, 2.2, " +
 				"'2021-02-02', '13:00:00.123456', '2021-02-02 13:00:00.123456', '2021-02-02 05:00:00.123456-8', " +
 				"98765432.1, " +
 				`'\xDEADBEEF', 'another description', 'XYZ', ` +
-				"ARRAY['tag3', 'tag4', NULL, 'NULL'], ARRAY[4, 5, 6, 7, NULL], ARRAY[NULL, 4.4, 5.5, 6.6, 7.7]::real[], " +
+				"ARRAY['tag3', 'tag4', NULL, 'NULL'], ARRAY[4, 5, 6, 7, NULL], ARRAY[NULL, 4.4, 5.5, 6.6, 7.7]::real[], ARRAY[4.4, 55.55, NULL, 66.66, 777.777], " +
 				`-123, -9223372036854775808, '{"array": [1, 2, 3]}')`,
 			"UPDATE public.test SET name = 'three' WHERE id = 2",
 			`UPDATE public.test SET json_data = jsonb_set(json_data, '{key}', '"new_value"') WHERE id = 1`,
@@ -562,6 +564,7 @@ var replicationTests = []ReplicationTest{
 						`{tag1,tag2}`,
 						`{1,2,3}`,
 						`{1.1,2.2,3.3}`,
+						`{1.1,22.22,333.333}`,
 						int16(123),
 						int64(9223372036854775807),
 						`{"key": "new_value"}`,
@@ -577,6 +580,7 @@ var replicationTests = []ReplicationTest{
 						`{tag3,tag4,NULL,"NULL"}`,
 						`{4,5,6,7,NULL}`,
 						`{NULL,4.4,5.5,6.6,7.7}`,
+						`{4.4,55.55,NULL,66.66,777.777}`,
 						int16(-123),
 						int64(-9223372036854775808),
 						`{"array": [1, 2, 3]}`,

--- a/pgtest/framework.go
+++ b/pgtest/framework.go
@@ -228,7 +228,7 @@ func NormalizeValToString(typ *pgtype.Type, v any) any {
 		} else if !val.Valid {
 			return nil
 		} else {
-			decStr := decimal.NewFromBigInt(val.Int, val.Exp).StringFixed(val.Exp * -1)
+			decStr := decimal.NewFromBigInt(val.Int, val.Exp).String()
 			return Numeric(decStr)
 		}
 	case []any:
@@ -286,7 +286,10 @@ func NormalizeVal(typ *pgtype.Type, v any) any {
 		} else if !val.Valid {
 			return nil
 		} else {
-			return decimal.NewFromBigInt(val.Int, val.Exp)
+			d := decimal.NewFromBigInt(val.Int, val.Exp)
+			s := d.String() // trim trailing zeros
+			d, _ = decimal.NewFromString(s)
+			return d
 		}
 	case pgtype.Time:
 		// This value type is used for TIME type.

--- a/pgtypes/pgtypes.go
+++ b/pgtypes/pgtypes.go
@@ -22,7 +22,7 @@ func init() {
 	DefaultTypeMap = pgtype.NewMap()
 }
 
-var DuckdbTypeStrToPostgresTypeStr = map[string]string{
+var duckdbTypeNameToPostgresTypeName = map[string]string{
 	"INVALID":      "unknown",
 	"BOOLEAN":      "bool",
 	"TINYINT":      "int2",
@@ -93,6 +93,7 @@ var DuckdbTypeToPostgresOID = map[duckdb.Type]uint32{
 var PostgresOIDToDuckDBTypeName = map[uint32]string{
 	pgtype.BoolOID:        "BOOLEAN",
 	pgtype.ByteaOID:       "BLOB",
+	pgtype.QCharOID:       "UTINYINT",
 	pgtype.Int2OID:        "SMALLINT",
 	pgtype.Int4OID:        "INTEGER",
 	pgtype.Int8OID:        "BIGINT",
@@ -102,6 +103,7 @@ var PostgresOIDToDuckDBTypeName = map[uint32]string{
 	pgtype.TextOID:        "VARCHAR",
 	pgtype.VarcharOID:     "VARCHAR",
 	pgtype.BPCharOID:      "VARCHAR",
+	pgtype.NameOID:        "VARCHAR",
 	pgtype.DateOID:        "DATE",
 	pgtype.TimeOID:        "TIME",
 	pgtype.TimetzOID:      "TIMETZ",
@@ -113,61 +115,71 @@ var PostgresOIDToDuckDBTypeName = map[uint32]string{
 	pgtype.VarbitOID:      "BIT",
 	pgtype.JSONOID:        "JSON",
 	pgtype.JSONBOID:       "JSON",
-	pgtype.OIDOID:         "UBIGINT",
-	pgtype.RecordOID:      "STRUCT",
-	pgtype.BoolArrayOID:   "BOOLEAN[]",
-	pgtype.Int2ArrayOID:   "SMALLINT[]",
-	pgtype.Int4ArrayOID:   "INTEGER[]",
-	pgtype.Int8ArrayOID:   "BIGINT[]",
-	pgtype.Float4ArrayOID: "FLOAT[]",
-	pgtype.Float8ArrayOID: "DOUBLE[]",
-	pgtype.TextArrayOID:   "VARCHAR[]",
+	pgtype.OIDOID:         "UINTEGER",
+	pgtype.XIDOID:         "UINTEGER",
+	pgtype.CIDOID:         "UINTEGER",
+	pgtype.TIDOID:         "UBIGINT",
+	// Postgres one-dimensional ARRAY types -> DuckDB LIST types
+	pgtype.BoolArrayOID:        "BOOLEAN[]",
+	pgtype.QCharArrayOID:       "TINYINT[]",
+	pgtype.Int2ArrayOID:        "SMALLINT[]",
+	pgtype.Int4ArrayOID:        "INTEGER[]",
+	pgtype.Int8ArrayOID:        "BIGINT[]",
+	pgtype.Float4ArrayOID:      "FLOAT[]",
+	pgtype.Float8ArrayOID:      "DOUBLE[]",
+	pgtype.NumericArrayOID:     "DECIMAL[]",
+	pgtype.TextArrayOID:        "VARCHAR[]",
+	pgtype.VarcharArrayOID:     "VARCHAR[]",
+	pgtype.BPCharArrayOID:      "VARCHAR[]",
+	pgtype.NameArrayOID:        "VARCHAR[]",
+	pgtype.UUIDArrayOID:        "UUID[]",
+	pgtype.DateArrayOID:        "DATE[]",
+	pgtype.TimeArrayOID:        "TIME[]",
+	pgtype.TimetzArrayOID:      "TIMETZ[]",
+	pgtype.TimestampArrayOID:   "TIMESTAMP[]",
+	pgtype.TimestamptzArrayOID: "TIMESTAMPTZ[]",
+	pgtype.IntervalArrayOID:    "INTERVAL[]",
+	pgtype.JSONArrayOID:        "JSON[]",
+	pgtype.JSONBArrayOID:       "JSON[]",
+	pgtype.BitArrayOID:         "BIT[]",
 	// ...additional mappings as needed...
 }
 
-var PostgresTypeSizes = map[uint32]int32{
+var postgresTypeSizes = map[uint32]int32{
 	pgtype.BoolOID:        1,  // bool
-	pgtype.ByteaOID:       -1, // bytea
 	pgtype.NameOID:        64, // name
 	pgtype.Int8OID:        8,  // int8
 	pgtype.Int2OID:        2,  // int2
 	pgtype.Int4OID:        4,  // int4
-	pgtype.TextOID:        -1, // text
 	pgtype.OIDOID:         4,  // oid
 	pgtype.TIDOID:         6,  // tid
 	pgtype.XIDOID:         4,  // xid
 	pgtype.CIDOID:         4,  // cid
-	pgtype.JSONOID:        -1, // json
-	pgtype.XMLOID:         -1, // xml
 	pgtype.PointOID:       8,  // point
 	pgtype.Float4OID:      4,  // float4
 	pgtype.Float8OID:      8,  // float8
 	pgtype.UnknownOID:     -2, // unknown
 	pgtype.MacaddrOID:     6,  // macaddr
 	pgtype.Macaddr8OID:    8,  // macaddr8
-	pgtype.InetOID:        -1, // inet
-	pgtype.BoolArrayOID:   -1, // bool[]
-	pgtype.ByteaArrayOID:  -1, // bytea[]
-	pgtype.NameArrayOID:   -1, // name[]
-	pgtype.Int2ArrayOID:   -1, // int2[]
-	pgtype.Int4ArrayOID:   -1, // int4[]
-	pgtype.TextArrayOID:   -1, // text[]
-	pgtype.BPCharOID:      -1, // char(n)
-	pgtype.VarcharOID:     -1, // varchar
 	pgtype.DateOID:        4,  // date
 	pgtype.TimeOID:        8,  // time
 	pgtype.TimetzOID:      12, // timetz
 	pgtype.TimestampOID:   8,  // timestamp
 	pgtype.TimestamptzOID: 8,  // timestamptz
 	pgtype.IntervalOID:    16, // interval
-	pgtype.NumericOID:     -1, // numeric
 	pgtype.UUIDOID:        16, // uuid
 }
 
 func PostgresTypeToArrowType(p PostgresType) arrow.DataType {
-	switch p.PG.OID {
+	return pgTypeToArrowType(p.PG, p.Precision, p.Scale)
+}
+
+func pgTypeToArrowType(pt *pgtype.Type, precision, scale int32) arrow.DataType {
+	switch pt.OID {
 	case pgtype.BoolOID:
 		return arrow.FixedWidthTypes.Boolean
+	case pgtype.QCharOID:
+		return arrow.PrimitiveTypes.Uint8
 	case pgtype.ByteaOID:
 		return arrow.BinaryTypes.Binary
 	case pgtype.NameOID, pgtype.TextOID, pgtype.VarcharOID, pgtype.BPCharOID, pgtype.JSONOID, pgtype.JSONBOID, pgtype.XMLOID:
@@ -181,7 +193,7 @@ func PostgresTypeToArrowType(p PostgresType) arrow.DataType {
 	case pgtype.OIDOID:
 		return arrow.PrimitiveTypes.Uint32
 	case pgtype.TIDOID:
-		return &arrow.FixedSizeBinaryType{ByteWidth: 8}
+		return arrow.PrimitiveTypes.Uint64
 	case pgtype.Float4OID:
 		return arrow.PrimitiveTypes.Float32
 	case pgtype.Float8OID:
@@ -195,12 +207,12 @@ func PostgresTypeToArrowType(p PostgresType) arrow.DataType {
 	case pgtype.TimestamptzOID:
 		return arrow.FixedWidthTypes.Timestamp_us
 	case pgtype.NumericOID:
-		if p.Precision > 0 && p.Scale >= 0 {
-			if p.Precision <= 38 {
-				return &arrow.Decimal128Type{Precision: p.Precision, Scale: p.Scale}
+		if precision > 0 && scale >= 0 {
+			if precision <= 38 {
+				return &arrow.Decimal128Type{Precision: precision, Scale: scale}
 				// 256-bit decimal is not supported in DuckDB
-				// } else if p.Precision <= 76 {
-				// 	return &arrow.Decimal256Type{Precision: p.Precision, Scale: p.Scale}
+				// } else if precision <= 76 {
+				// 	return &arrow.Decimal256Type{Precision: precision, Scale: scale}
 			} else {
 				// Precision too large, default to string
 				return arrow.BinaryTypes.String
@@ -220,8 +232,53 @@ func PostgresTypeToArrowType(p PostgresType) arrow.DataType {
 			arrow.Field{Name: "y", Type: arrow.PrimitiveTypes.Float64},
 		)
 	default:
+		// Check for array types
+		if ac, ok := pt.Codec.(*pgtype.ArrayCodec); ok {
+			// Map the element type recursively
+			return arrow.ListOf(pgTypeToArrowType(ac.ElementType, precision, scale))
+		}
+
 		return arrow.BinaryTypes.Binary // fall back for unknown types
 	}
+}
+
+func PostgresTypeSize(oid uint32) int32 {
+	if s, ok := postgresTypeSizes[oid]; ok {
+		return s
+	}
+	return -1
+}
+
+// GoDuckDBTypeNameToPostgresType parses a type name reported by the go-duckdb driver
+// into a corresponding pgtype.Type and its precision and scale.
+//
+// TODO(fan): Make this function more rigorous for nested types.
+func GoDuckDBTypeNameToPostgresType(name string) (pt *pgtype.Type, precision, scale int32, err error) {
+	var list bool
+	if strings.HasSuffix(name, "[]") {
+		// LIST type
+		// Ref: logicalTypeNameList in go-duckdb
+		name = strings.TrimSuffix(name, "[]")
+		list = true
+	}
+
+	if strings.HasPrefix(name, "DECIMAL") {
+		// Scan precision and scale from the type name
+		// Ref: logicalTypeNameDecimal in go-duckdb
+		if _, err = fmt.Sscanf(name, "DECIMAL(%d,%d)", &precision, &scale); err != nil {
+			return
+		}
+		name = "DECIMAL"
+	}
+	pgTypeName, ok := duckdbTypeNameToPostgresTypeName[name]
+	if !ok {
+		return nil, 0, 0, fmt.Errorf("unsupported type %s", name)
+	}
+	pt, ok = DefaultTypeMap.TypeForName(pgTypeName)
+	if !ok {
+		return nil, 0, 0, fmt.Errorf("unsupported type %s", name)
+	}
+	return
 }
 
 func InferSchema(rows *stdsql.Rows) (sql.Schema, error) {
@@ -244,7 +301,7 @@ func InferSchema(rows *stdsql.Rows) (sql.Schema, error) {
 			}
 			dbTypeName = "DECIMAL"
 		}
-		pgTypeName, ok := DuckdbTypeStrToPostgresTypeStr[dbTypeName]
+		pgTypeName, ok := duckdbTypeNameToPostgresTypeName[dbTypeName]
 		if !ok {
 			return nil, fmt.Errorf("unsupported type %s", dbTypeName)
 		}
@@ -253,11 +310,6 @@ func InferSchema(rows *stdsql.Rows) (sql.Schema, error) {
 			return nil, fmt.Errorf("unsupported type %s", pgTypeName)
 		}
 		nullable, _ := t.Nullable()
-
-		size := int32(-1)
-		if s, ok := PostgresTypeSizes[pgType.OID]; ok {
-			size = s
-		}
 
 		if pgType.OID == pgtype.NumericOID {
 			if p, s, ok := t.DecimalSize(); ok {
@@ -270,7 +322,7 @@ func InferSchema(rows *stdsql.Rows) (sql.Schema, error) {
 			Name: t.Name(),
 			Type: PostgresType{
 				PG:        pgType,
-				Size:      size,
+				Size:      PostgresTypeSize(pgType.OID),
 				Precision: precision,
 				Scale:     scale,
 			},
@@ -299,7 +351,7 @@ func InferDriverSchema(rows driver.Rows) (sql.Schema, error) {
 				}
 				dbTypeName = "DECIMAL"
 			}
-			pgTypeName = DuckdbTypeStrToPostgresTypeStr[dbTypeName]
+			pgTypeName = duckdbTypeNameToPostgresTypeName[dbTypeName]
 		} else {
 			pgTypeName = "text" // Default to text if type name is not available
 		}
@@ -312,11 +364,6 @@ func InferDriverSchema(rows driver.Rows) (sql.Schema, error) {
 		nullable := true
 		if colNullable, ok := rows.(driver.RowsColumnTypeNullable); ok {
 			nullable, _ = colNullable.ColumnTypeNullable(i)
-		}
-
-		size := int32(-1)
-		if s, ok := PostgresTypeSizes[pgType.OID]; ok {
-			size = s
 		}
 
 		if pgType.OID == pgtype.NumericOID {
@@ -333,7 +380,7 @@ func InferDriverSchema(rows driver.Rows) (sql.Schema, error) {
 			Name: colName,
 			Type: PostgresType{
 				PG:        pgType,
-				Size:      size,
+				Size:      PostgresTypeSize(pgType.OID),
 				Precision: precision,
 				Scale:     scale,
 			},
@@ -356,14 +403,10 @@ func NewPostgresType(oid uint32, modifier int32) (PostgresType, error) {
 	if !ok {
 		return PostgresType{}, fmt.Errorf("unsupported type OID %d", oid)
 	}
-	size := int32(-1)
-	if s, ok := PostgresTypeSizes[oid]; ok {
-		size = s
-	}
 
 	var precision, scale int32
 	switch oid {
-	case pgtype.NumericOID:
+	case pgtype.NumericOID, pgtype.NumericArrayOID:
 		precision, scale, _ = DecodePrecisionScale(int(modifier))
 	}
 
@@ -371,7 +414,7 @@ func NewPostgresType(oid uint32, modifier int32) (PostgresType, error) {
 		PG:        t,
 		Precision: precision,
 		Scale:     scale,
-		Size:      size,
+		Size:      PostgresTypeSize(oid),
 	}, nil
 }
 

--- a/pgtypes/pgtypes.go
+++ b/pgtypes/pgtypes.go
@@ -460,6 +460,7 @@ func (p PostgresType) String() string {
 
 func DecodePrecisionScale(typmod int) (precision, scale int32, ok bool) {
 	if typmod > 0 {
+		typmod -= 4 // remove VARHDRSZ
 		precision = int32((typmod >> 16) & 0xFFFF)
 		scale = int32(typmod & 0xFFFF)
 		ok = true


### PR DESCRIPTION
In this PR, array-type columns in Postgres are replicated as DuckDB `LIST` columns (rather than `ARRAY` columns, as Postgres does not enforce fixed sizes or dimensions for array values). Additionally, querying `LIST` columns via the Postgres protocol is supported by mapping DuckDB's `LIST` types to Postgres' array types.

Resolves #229