### PR TITLE
fix: fix duplicate 'mysql' database issue

### DIFF
--- a/catalog/provider.go
+++ b/catalog/provider.go
@@ -168,7 +168,7 @@ func (prov *DatabaseProvider) AllDatabases(ctx *sql.Context) []sql.Database {
 		}
 
 		switch schemaName {
-		case "information_schema", "pg_catalog", "__sys__":
+		case "information_schema", "pg_catalog", "__sys__", "mysql":
 			continue
 		}
 

--- a/test/bats/mysql/unique_databases.bats
+++ b/test/bats/mysql/unique_databases.bats
@@ -1,0 +1,8 @@
+#!/usr/bin/env bats
+
+@test "Ensure every database reported by SHOW DATABASES is unique" {
+  run mysql -h 127.0.0.1 -u root --raw --batch --skip-column-names -e "SHOW DATABASES"
+  [ "$status" -eq 0 ]
+  unique_databases=$(echo "$output" | sort | uniq -d)
+  [ -z "$unique_databases" ]
+}


### PR DESCRIPTION
Fixes #283

Exclude the 'mysql' database from the `AllDatabases` method in `catalog/provider.go`.

* Add a condition to filter out the 'mysql' database in the switch statement.

By GitHub Copilot Workspace

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/apecloud/myduckserver/pull/284?shareId=ab6cd9c9-2ba3-4eee-a432-4df1f079c7bc).