### PR TITLE
fix: allow DuckDB's `SHOW ALL TABLES` command

### DIFF
--- a/pgserver/sess_params_test.go
+++ b/pgserver/sess_params_test.go
@@ -417,6 +417,16 @@ func TestSessParam(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Show all tables",
+			executions: []Execution{
+				{
+					SQL:      "SHOW ALL TABLES;",
+					Expected: [][]string{},
+					WantErr:  false,
+				},
+			},
+		},
 	}
 
 	// Setup MyDuck Server


### PR DESCRIPTION
Related to #281

Add support for `SHOW ALL TABLES` command in DuckDB.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/apecloud/myduckserver/pull/287?shareId=707f4e7e-17a6-4a7d-a3be-121bdfe03531).