### PR TITLE
fix: skip the copy-instance step if the source is Dolt

### DIFF
--- a/.github/workflows/replication-test.yml
+++ b/.github/workflows/replication-test.yml
@@ -9,8 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # source: ['mysql', 'postgres', 'dolt', 'mariadb']
-        source: ['mysql', 'postgres', 'mariadb']
+        source: ['postgres', 'mysql', 'mariadb', 'dolt']
     steps:
       - uses: actions/checkout@v4
 

--- a/devtools/replica-setup-mysql/checker.sh
+++ b/devtools/replica-setup-mysql/checker.sh
@@ -105,21 +105,20 @@ check_mysql_config() {
     return 0
 }
 
-# Function to check if source MySQL server is empty
-check_if_source_mysql_is_empty() {
-    # Run the query using mysqlsh and capture the output
-    OUTPUT=$(mysqlsh --uri "$SOURCE_DSN" $SOURCE_PASSWORD_OPTION --sql -e "SHOW DATABASES;" 2>/dev/null)
+# Function to check if the source server could be copied using MySQL Shell
+check_if_source_supports_copying_instance() {
+    # Retrieve the MySQL version using mysqlsh
+    result=$(mysqlsh --uri="$SOURCE_DSN" $SOURCE_PASSWORD_OPTION --sql -e "SELECT @@global.version_comment")
+    check_command "retrieving MySQL version comment"
 
-    check_command "retrieving database list"
-
-    # Check if the output contains only the default databases
-    NON_DEFAULT_DBs=$(echo "$OUTPUT" | grep -cv -E "^(Database|information_schema|mysql|performance_schema|sys)$")
-
-    if [[ "$NON_DEFAULT_DBs" -gt 0 ]]; then
+    # Currently, Dolt does not support MySQL Shell's copy-instance utility.
+    # Check if the MySQL version string contains "Dolt"
+    if echo "$result" | grep -q "Dolt"; then
+        echo "MySQL Shell's copy-instance utility is not supported by Dolt yet."
         return 1
-    else
-        return 0
     fi
+
+    return 0
 }
 
 # Function to check if there is ongoing replication on MyDuck Server

--- a/devtools/replica-setup-mysql/replica_setup.sh
+++ b/devtools/replica-setup-mysql/replica_setup.sh
@@ -108,21 +108,17 @@ echo "Preparing MyDuck Server for replication..."
 source prepare.sh
 check_command "preparing MyDuck Server for replication"
 
-# Step 4: Check if the MySQL server is empty
-echo "Checking if source MySQL server is empty..."
-check_if_source_mysql_is_empty
-SOURCE_IS_EMPTY=$?
-
-# Step 5: Copy the existing data if the MySQL instance is not empty
-if [[ $SOURCE_IS_EMPTY -ne 0 ]]; then
+# Step 4: Copy the existing data from the source MySQL instance to MyDuck Server
+echo "Checking if source server supports MySQL Shell..."
+if check_if_source_supports_copying_instance; then
     echo "Copying a snapshot of the MySQL instance to MyDuck Server..."
     source snapshot.sh
     check_command "copying a snapshot of the MySQL instance"
 else
-    echo "This MySQL instance is empty. Skipping snapshot."
+    echo "The source server cannot be copied using MySQL Shell. The snapshot step has been skipped."
 fi
 
-# Step 6: Establish replication
+# Step 5: Establish replication
 echo "Starting replication..."
 source start_replication.sh
 check_command "starting replication"


### PR DESCRIPTION
This PR modifies the replication setup script to skip the copy-instance step if the source server is Dolt. Currently, MySQL Shell will query `@@report_host` and `@@report_port` on the source server, which are not implemented in Dolt yet.