### PR TITLE
fix: support enum columns for mysqlsh copy-instance utility

### DIFF
--- a/.github/workflows/mysql-copy-tests.yml
+++ b/.github/workflows/mysql-copy-tests.yml
@@ -51,12 +51,16 @@ jobs:
             USE testdb;
             CREATE TABLE users (
               id INT AUTO_INCREMENT PRIMARY KEY,
-              name VARCHAR(100)
+              name VARCHAR(100),
+              status ENUM('active', 'inactive', 'pending') DEFAULT 'pending'
             );
-            INSERT INTO users (name) VALUES ('test1'), ('test2'), ('test3');
+            INSERT INTO users (name, status) VALUES
+              ('test1', 'active'),
+              ('test2', 'inactive'),
+              ('test3', 'pending');
             -- Make a gap in the id sequence
-            INSERT INTO users VALUES (100, 'test100');
-            INSERT INTO users (name) VALUES ('test101');
+            INSERT INTO users VALUES (100, 'test100', 'active');
+            INSERT INTO users (name, status) VALUES ('test101', 'inactive');
 
             -- A table with non-default starting auto_increment value
             CREATE TABLE items (
@@ -96,4 +100,4 @@ jobs:
             diff source_data_$table.tsv copied_data_$table.tsv
           done
 
-          
+

--- a/.github/workflows/mysql-copy-tests.yml
+++ b/.github/workflows/mysql-copy-tests.yml
@@ -49,6 +49,7 @@ jobs:
           mysqlsh -hlocalhost -P13306 -uroot -proot --sql -e "
             CREATE DATABASE testdb;
             USE testdb;
+            -- Normal table, which should be copied to MyDuck via duckdb's csv import
             CREATE TABLE users (
               id INT AUTO_INCREMENT PRIMARY KEY,
               name VARCHAR(100),
@@ -70,6 +71,20 @@ jobs:
             ) AUTO_INCREMENT=1000;
 
             INSERT INTO items (v, name) VALUES (1, 'item1'), (2, 'item2'), (3, 'item3');
+
+            -- Table with UUID primary key
+            -- For such tables, MySQL Shell generates nontrivial LOAD DATA statements
+            -- to copy the data to MyDuck: `LOAD DATA ... (@id, title, created_at) SET id = FROM_BASE64(@id)`,
+            -- which can only be executed by the go-mysql-server framework for now.
+            CREATE TABLE documents (
+              id BINARY(16) PRIMARY KEY,
+              title VARCHAR(200),
+              created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+
+            INSERT INTO documents (id, title) VALUES
+              (UUID_TO_BIN(UUID()), 'Document 1'),
+              (UUID_TO_BIN(UUID()), 'Document 2');
           "
 
       - name: Build and start MyDuck Server
@@ -89,7 +104,7 @@ jobs:
             --users false --ignore-version true
 
           # Verify the data was copied
-          for table in users items; do
+          for table in users items documents; do
             mysqlsh -hlocalhost -P13306 -uroot -proot --sql -e "
               SELECT * FROM testdb.$table ORDER BY id;
             " | tee source_data_$table.tsv

--- a/.github/workflows/mysql-copy-tests.yml
+++ b/.github/workflows/mysql-copy-tests.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup test data in source MySQL
         run: |
-          mysqlsh -hlocalhost -P13306 -uroot -proot --sql -e "
+          mysqlsh -hlocalhost -P13306 -uroot -proot --sql <<'EOF'
             CREATE DATABASE testdb;
             USE testdb;
             -- Normal table, which should be copied to MyDuck via duckdb's csv import
@@ -74,18 +74,19 @@ jobs:
 
             -- Table with UUID primary key
             -- For such tables, MySQL Shell generates nontrivial LOAD DATA statements
-            -- to copy the data to MyDuck: `LOAD DATA ... (@id, title, created_at) SET id = FROM_BASE64(@id)`,
+            -- to copy the data to MyDuck: LOAD DATA ... (@id, title, created_at) SET id = FROM_BASE64(@id),
             -- which can only be executed by the go-mysql-server framework for now.
             CREATE TABLE documents (
               id BINARY(16) PRIMARY KEY,
               title VARCHAR(200),
+              status ENUM('draft', 'published', 'archived') DEFAULT 'draft',
               created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );
 
-            INSERT INTO documents (id, title) VALUES
-              (UUID_TO_BIN(UUID()), 'Document 1'),
-              (UUID_TO_BIN(UUID()), 'Document 2');
-          "
+            INSERT INTO documents (id, title, status) VALUES
+              (UUID_TO_BIN(UUID()), 'Document 1', 'published'),
+              (UUID_TO_BIN(UUID()), 'Document 2', 'draft');
+          EOF
 
       - name: Build and start MyDuck Server
         run: |


### PR DESCRIPTION
This PR addresses an issue encountered when using MySQL Shell to copy a table containing both a `UUID` column and an `ENUM` column:

```
MySQL Error 1105 (HY000): Conversion Error: Unimplemented type for cast (BIGINT -> ENUM('draft', 'published', 'archived')): LOAD DATA LOCAL INFILE 'memory/testdb@documents@@0.tsv' REPLACE INTO TABLE `testdb`.`documents` CHARACTER SET 'utf8mb4' FIELDS TERMINATED BY '	' ESCAPED BY '\\' LINES STARTING BY '' TERMINATED BY '\n' (@`id`, `title`, `status`, `created_at`) SET `id` = FROM_BASE64(@`id`)
```

The root cause is that the `go-mysql-server` framework parses `ENUM` fields into ordinal values, whereas DuckDB does not support inserting ordinals directly into `ENUM` columns.

Ref: #329
