### PR TITLE
fix: solve some compatibility issues with pgcli

### DIFF
--- a/catalog/internal_macro.go
+++ b/catalog/internal_macro.go
@@ -59,6 +59,23 @@ var InternalMacros = []InternalMacro{
 		},
 	},
 	{
+		Schema:       "pg_catalog",
+		Name:         "pg_get_expr",
+		IsTableMacro: false,
+		Definitions: []MacroDefinition{
+			{
+				Params: []string{"pg_node_tree", "relation_oid"},
+				// Do nothing currently
+				DDL: `pg_catalog.pg_get_expr(pg_node_tree, relation_oid)`,
+			},
+			{
+				Params: []string{"pg_node_tree", "relation_oid", "pretty_bool"},
+				// Do nothing currently
+				DDL: `pg_catalog.pg_get_expr(pg_node_tree, relation_oid)`,
+			},
+		},
+	},
+	{
 		Schema:       SchemaNameMyListContains,
 		Name:         MacroNameMyListContains,
 		IsTableMacro: false,

--- a/catalog/internal_macro.go
+++ b/catalog/internal_macro.go
@@ -7,6 +7,9 @@ type MacroDefinition struct {
 	DDL    string
 }
 
+var SchemaNameMyListContains string = "__sys__"
+var MacroNameMyListContains string = "my_list_contains"
+
 type InternalMacro struct {
 	Schema       string
 	Name         string
@@ -52,6 +55,22 @@ var InternalMacros = []InternalMacro{
 				Params: []string{"index_oid", "column_no", "pretty_bool"},
 				// Do nothing currently
 				DDL: `''`,
+			},
+		},
+	},
+	{
+		Schema:       SchemaNameMyListContains,
+		Name:         MacroNameMyListContains,
+		IsTableMacro: false,
+		Definitions: []MacroDefinition{
+			{
+				Params: []string{"l", "v"},
+				DDL: `CASE
+    WHEN typeof(l) = 'VARCHAR' THEN
+        list_contains(regexp_split_to_array(l::VARCHAR, '[{},\s]+'), v)
+    ELSE
+        list_contains(l::text[], v)
+    END`,
 			},
 		},
 	},

--- a/catalog/internal_macro.go
+++ b/catalog/internal_macro.go
@@ -7,8 +7,12 @@ type MacroDefinition struct {
 	DDL    string
 }
 
-var SchemaNameMyListContains string = "__sys__"
-var MacroNameMyListContains string = "my_list_contains"
+var (
+	SchemaNameSYS           string = "__sys__"
+	MacroNameMyListContains string = "my_list_contains"
+
+	MacroNameMySplitListStr string = "my_split_list_str"
+)
 
 type InternalMacro struct {
 	Schema       string
@@ -76,7 +80,7 @@ var InternalMacros = []InternalMacro{
 		},
 	},
 	{
-		Schema:       SchemaNameMyListContains,
+		Schema:       SchemaNameSYS,
 		Name:         MacroNameMyListContains,
 		IsTableMacro: false,
 		Definitions: []MacroDefinition{
@@ -88,6 +92,17 @@ var InternalMacros = []InternalMacro{
     ELSE
         list_contains(l::text[], v)
     END`,
+			},
+		},
+	},
+	{
+		Schema:       SchemaNameSYS,
+		Name:         MacroNameMySplitListStr,
+		IsTableMacro: false,
+		Definitions: []MacroDefinition{
+			{
+				Params: []string{"l"},
+				DDL:    `regexp_split_to_array(l::VARCHAR, '[{},\s]+')`,
 			},
 		},
 	},

--- a/pgserver/in_place_handler.go
+++ b/pgserver/in_place_handler.go
@@ -246,6 +246,19 @@ var selectionConversions = []SelectionConversion{
 			return nil
 		},
 	},
+	{
+		needConvert: func(query *ConvertedStatement) bool {
+			sqlStr := RemoveComments(query.String)
+			// TODO: Evaluate the conditions by iterating over the AST.
+			return getPgAnyOpRegex().MatchString(sqlStr)
+		},
+		doConvert: func(h *ConnectionHandler, query *ConvertedStatement) error {
+			sqlStr := RemoveComments(query.String)
+			sqlStr = ConvertAnyOp(sqlStr)
+			query.String = sqlStr
+			return nil
+		},
+	},
 }
 
 // The key is the statement tag of the query.

--- a/pgserver/in_place_handler.go
+++ b/pgserver/in_place_handler.go
@@ -237,11 +237,11 @@ var selectionConversions = []SelectionConversion{
 		needConvert: func(query *ConvertedStatement) bool {
 			sqlStr := RemoveComments(query.String)
 			// TODO(sean): Evaluate the conditions by iterating over the AST.
-			return getTypeCastRegex().MatchString(sqlStr)
+			return getSimpleStringMatchingRegex().MatchString(sqlStr)
 		},
 		doConvert: func(h *ConnectionHandler, query *ConvertedStatement) error {
 			sqlStr := RemoveComments(query.String)
-			sqlStr = ConvertTypeCast(sqlStr)
+			sqlStr = SimpleStrReplacement(sqlStr)
 			query.String = sqlStr
 			return nil
 		},

--- a/pgserver/stmt.go
+++ b/pgserver/stmt.go
@@ -295,6 +295,25 @@ func ConvertToSys(sql string) string {
 }
 
 var (
+	pgAnyOpRegex     *regexp.Regexp
+	initPgAnyOpRegex sync.Once
+)
+
+// get the regex to match the operator 'ANY'
+func getPgAnyOpRegex() *regexp.Regexp {
+	initPgAnyOpRegex.Do(func() {
+		pgAnyOpRegex = regexp.MustCompile(`(?i)([^\s(]+)\s*=\s*any\s*\(\s*([^)]*)\s*\)`)
+	})
+	return pgAnyOpRegex
+}
+
+// Replace the operator 'ANY' with a function call.
+func ConvertAnyOp(sql string) string {
+	re := getPgAnyOpRegex()
+	return re.ReplaceAllString(sql, catalog.SchemaNameMyListContains+"."+catalog.MacroNameMyListContains+"($2, $1)")
+}
+
+var (
 	typeCastRegex     *regexp.Regexp
 	initTypeCastRegex sync.Once
 )

--- a/pgserver/stmt.go
+++ b/pgserver/stmt.go
@@ -310,36 +310,42 @@ func getPgAnyOpRegex() *regexp.Regexp {
 // Replace the operator 'ANY' with a function call.
 func ConvertAnyOp(sql string) string {
 	re := getPgAnyOpRegex()
-	return re.ReplaceAllString(sql, catalog.SchemaNameMyListContains+"."+catalog.MacroNameMyListContains+"($2, $1)")
+	return re.ReplaceAllString(sql, catalog.SchemaNameSYS+"."+catalog.MacroNameMyListContains+"($2, $1)")
 }
 
 var (
-	typeCastRegex     *regexp.Regexp
-	initTypeCastRegex sync.Once
+	simpleStrMatchingRegex     *regexp.Regexp
+	initSimpleStrMatchingRegex sync.Once
 )
 
+// TODO(sean): This is a temporary solution. We need to find a better way to handle type cast conversion and column conversion. e.g. Iterating the AST with a visitor pattern.
 // The Key must be in lowercase. Because the key used for value retrieval is in lowercase.
-var typeCastConversion = map[string]string{
+var simpleStringsConversion = map[string]string{
+	// type cast conversion
 	"::regclass": "::varchar",
-	"::regtype":  "::integer",
+	"::regtype":  "::varchar",
+
+	// column conversion
+	"proallargtypes": catalog.SchemaNameSYS + "." + catalog.MacroNameMySplitListStr + "(proallargtypes)",
+	"proargtypes":    catalog.SchemaNameSYS + "." + catalog.MacroNameMySplitListStr + "(proargtypes)",
 }
 
 // This function will return a regex that matches all type casts in the query.
-func getTypeCastRegex() *regexp.Regexp {
-	initTypeCastRegex.Do(func() {
-		var typeCasts []string
-		for typeCast := range typeCastConversion {
-			typeCasts = append(typeCasts, regexp.QuoteMeta(typeCast))
+func getSimpleStringMatchingRegex() *regexp.Regexp {
+	initSimpleStrMatchingRegex.Do(func() {
+		var simpleStrings []string
+		for simpleString := range simpleStringsConversion {
+			simpleStrings = append(simpleStrings, regexp.QuoteMeta(simpleString))
 		}
-		typeCastRegex = regexp.MustCompile(`(?i)(` + strings.Join(typeCasts, "|") + `)`)
+		simpleStrMatchingRegex = regexp.MustCompile(`(?i)(` + strings.Join(simpleStrings, "|") + `)`)
 	})
-	return typeCastRegex
+	return simpleStrMatchingRegex
 }
 
-// This function will replace all type casts in the query with the corresponding type cast in the typeCastConversion map.
-func ConvertTypeCast(sql string) string {
-	return getTypeCastRegex().ReplaceAllStringFunc(sql, func(m string) string {
-		return typeCastConversion[strings.ToLower(m)]
+// This function will replace all type casts in the query with the corresponding type cast in the simpleStringsConversion map.
+func SimpleStrReplacement(sql string) string {
+	return getSimpleStringMatchingRegex().ReplaceAllStringFunc(sql, func(m string) string {
+		return simpleStringsConversion[strings.ToLower(m)]
 	})
 }
 

--- a/pgserver/stmt.go
+++ b/pgserver/stmt.go
@@ -321,6 +321,7 @@ var (
 // The Key must be in lowercase. Because the key used for value retrieval is in lowercase.
 var typeCastConversion = map[string]string{
 	"::regclass": "::varchar",
+	"::regtype":  "::integer",
 }
 
 // This function will return a regex that matches all type casts in the query.


### PR DESCRIPTION
This PR solves the issues about compatibility with pgcli mentioned in #354.

```bash
% pgcli "postgresql://postgres@127.0.0.1:25555"
Server: PostgreSQL 16.1 (Homebrew)
Version: 4.1.0
Home: http://pgcli.com
postgres@127.0.0.1:postgres> select * from public.t;
+----+----+----+----+
| id | i0 | i1 | i2 |
|----+----+----+----|
| 1  | 1  | 1  | 11 |
| 2  | 2  | 2  | 12 |
| 3  | 3  | 3  | 13 |
| 4  | 4  | 4  | 14 |
| 5  | 5  | 5  | 15 |
| 6  | 6  | 6  | 16 |
| 7  | 7  | 7  | 17 |
| 8  | 8  | 8  | 18 |
| 9  | 9  | 9  | 19 |
| 10 | 10 | 10 | 20 |
+----+----+----+----+
SELECT 10
Time: 0.011s
```

* resolve #354 