### PR TITLE
fix: ignore ROWS_QUERY binlog events during replication

### DIFF
--- a/binlogreplication/binlog_replica_applier.go
+++ b/binlogreplication/binlog_replica_applier.go
@@ -750,16 +750,25 @@ func (a *binlogReplicaApplier) processBinlogEvent(ctx *sql.Context, engine *gms.
 
 	default:
 		// https://mariadb.com/kb/en/2-binlog-event-header/
+		// MySQL include/mysql/binlog_event.h: byte 4 is Log_event_type.
 		bytes := event.Bytes()
+		if len(bytes) < 5 {
+			return fmt.Errorf("received unknown event: %v", event)
+		}
 		switch bytes[4] {
-		case 0x1b:
+		case binlogEventHeartbeat:
 			// Type 27 is a Heartbeat event. This event does not appear in the binary log. It's only sent over the
 			// network by a primary to a replica to let it know that the primary is still alive, and is only sent
 			// when the primary has no binlog events to send to replica servers.
 			// For more details, see: https://mariadb.com/kb/en/heartbeat_log_event/
 			ctx.GetLogger().Trace("Received binlog event: Heartbeat")
-		case 0x03:
+		case binlogEventStop:
 			ctx.GetLogger().Trace("Received binlog event: Stop")
+		case binlogEventIgnorable, binlogEventRowsQuery:
+			// ROWS_QUERY is the original SQL text when binlog_rows_query_log_events=ON.
+			// It is informational only; the following WRITE/UPDATE/DELETE_ROWS events apply the change.
+			// Treating it as unknown aborted replication (#359).
+			ctx.GetLogger().Trace("Received binlog event: Ignorable/Rows_query")
 		default:
 			return fmt.Errorf("received unknown event: %v", event)
 		}

--- a/binlogreplication/ignorable_event.go
+++ b/binlogreplication/ignorable_event.go
@@ -1,0 +1,19 @@
+package binlogreplication
+
+// MySQL binlog event types that are safe to ignore at the replica.
+// Header byte 4 is Log_event_type. See include/mysql/binlog_event.h
+const (
+	binlogEventStop      = 0x03 // STOP_EVENT
+	binlogEventHeartbeat = 0x1b // HEARTBEAT_LOG_EVENT (network only)
+	binlogEventIgnorable = 0x1c // IGNORABLE_LOG_EVENT
+	binlogEventRowsQuery = 0x1d // ROWS_QUERY_LOG_EVENT
+)
+
+func isIgnorableHeaderEventType(eventType byte) bool {
+	switch eventType {
+	case binlogEventStop, binlogEventHeartbeat, binlogEventIgnorable, binlogEventRowsQuery:
+		return true
+	default:
+		return false
+	}
+}

--- a/binlogreplication/ignorable_event_test.go
+++ b/binlogreplication/ignorable_event_test.go
@@ -1,0 +1,26 @@
+package binlogreplication
+
+import "testing"
+
+func TestIgnorableBinlogEventTypes(t *testing.T) {
+	// Header layout: 4-byte timestamp + 1-byte type.
+	cases := []struct {
+		typ     byte
+		ignore  bool
+		comment string
+	}{
+		{0x03, true, "STOP"},
+		{0x1b, true, "HEARTBEAT"},
+		{0x1c, true, "IGNORABLE"},
+		{0x1d, true, "ROWS_QUERY (#359)"},
+		{0x02, false, "QUERY must still be classified by the typed switch"},
+		{0xff, false, "unknown"},
+	}
+	for _, tc := range cases {
+		if got := isIgnorableHeaderEventType(tc.typ); got != tc.ignore {
+			t.Fatalf("type 0x%02x (%s): ignore=%v, want %v", tc.typ, tc.comment, got, tc.ignore)
+		}
+	}
+}
+
+


### PR DESCRIPTION
## Summary
When the source has `binlog_rows_query_log_events=ON`, MySQL sends event type `0x1d` (`ROWS_QUERY_LOG_EVENT`) with the original SQL text. That event is informational; the following `WRITE`/`UPDATE`/`DELETE_ROWS` events apply the change.

The replica previously treated `0x1d` as unknown and aborted (`received unknown event`), which matches #359 (`SHOW SLAVE STATUS` last error contained the original `INSERT` text).

This PR ignores:
- `0x1c` `IGNORABLE_LOG_EVENT`
- `0x1d` `ROWS_QUERY_LOG_EVENT`

Heartbeat (`0x1b`) and Stop (`0x03`) stay ignored as before.

Fixes #359

## Test plan
- [x] `go test ./binlogreplication -run TestIgnorableBinlogEventTypes`