### PR TITLE
fix: map MySQL CHAR_LENGTH and FORMAT to DuckDB

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -231,14 +231,13 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_NOT_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_emptytable);",
 		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_NOT_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_mytable_WHERE_false);",
 		"SELECT_pk1,_SUM(c1)_FROM_two_pk_WHERE_pk1_=_0",
-		"SELECT_FORMAT(i,_3)_FROM_mytable;",
-		"SELECT_FORMAT(i,_3,_'da_DK')_FROM_mytable;",
+
 		"SELECT_JSON_OVERLAPS(c3,_'{\"a\":_2,_\"d\":_2}')_FROM_jsontable",
 		"SELECT_JSON_MERGE(c3,_'{\"a\":_1}')_FROM_jsontable",
 		"SELECT_JSON_MERGE_PRESERVE(c3,_'{\"a\":_1}')_FROM_jsontable",
 		"select_json_pretty(c3)_from_jsontable",
 		"SELECT_a.column_0,_mt.s_from_(values_row(1,\"1\"),_row(2,\"2\"),_row(4,\"4\"))_a____left_join_mytable_mt_on_column_0_=_mt.i____order_by_1",
-		"WITH_mt_(s,i)_as_(select_char_length(s),_sum(i)_FROM_mytable_group_by_1)_SELECT_s,i_FROM_mt_order_by_1",
+
 		"select_i+0.0/(lag(i)_over_(order_by_s))_from_mytable_order_by_1;",
 		"select_f64/f32,_f32/(lag(i)_over_(order_by_f64))_from_floattable_order_by_1,2;",
 		"SELECT_s2,_i2,_i____FROM_(SELECT_*_FROM_mytable)_mytable____RIGHT_JOIN_____((SELECT_i2,_s2_FROM_othertable_ORDER_BY_i2_ASC)______UNION_ALL______SELECT_CAST(4_AS_SIGNED)_AS_i2,_\"not_found\"_AS_s2_FROM_DUAL)_othertable____ON_i2_=_i",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -121,6 +121,64 @@ def rewrite_mysql_for_duckdb(node):
                 kind=node.args.get("kind"),
                 constraints=kept,
             )
+    # MySQL CHAR_LENGTH / CHARACTER_LENGTH -> DuckDB LENGTH (character count).
+    # Without this, some paths still emit CHAR_LENGTH, which DuckDB does not have.
+    if isinstance(node, exp.Length) and not node.args.get("binary"):
+        return exp.Anonymous(this="length", expressions=[node.this])
+    # MySQL FORMAT(x, d[, locale]) is number-to-string with grouping.
+    # DuckDB FORMAT is {fmt}; map the scale and swap separators for common EU locales.
+    if isinstance(node, exp.NumberToStr):
+        value = node.this
+        digits = node.args.get("format")
+        culture = node.args.get("culture")
+        if isinstance(digits, exp.Literal) and digits.is_int:
+            fmt = "{:,." + str(int(digits.this)) + "f}"
+            formatted = exp.Anonymous(
+                this="format",
+                expressions=[exp.Literal.string(fmt), value],
+            )
+        else:
+            formatted = exp.Anonymous(
+                this="format",
+                expressions=[
+                    exp.Anonymous(
+                        this="concat",
+                        expressions=[
+                            exp.Literal.string("{:,."),
+                            exp.Cast(this=digits, to=exp.DataType.build("TEXT")),
+                            exp.Literal.string("f}"),
+                        ],
+                    ),
+                    value,
+                ],
+            )
+        if isinstance(culture, exp.Literal) and culture.is_string:
+            loc = str(culture.this).lower().replace("-", "_")
+            prefix = loc.split("_", 1)[0]
+            if prefix in ("da", "de", "nl", "es", "it", "pt"):
+                formatted = exp.Anonymous(
+                    this="replace",
+                    expressions=[
+                        exp.Anonymous(
+                            this="replace",
+                            expressions=[
+                                exp.Anonymous(
+                                    this="replace",
+                                    expressions=[
+                                        formatted,
+                                        exp.Literal.string(","),
+                                        exp.Literal.string("\x01"),
+                                    ],
+                                ),
+                                exp.Literal.string("."),
+                                exp.Literal.string(","),
+                            ],
+                        ),
+                        exp.Literal.string("\x01"),
+                        exp.Literal.string("."),
+                    ],
+                )
+        return formatted
     return node
 
 def transpile_mysql_to_duckdb(sql: str) -> str:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -56,6 +56,26 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT i XOR i XOR i FROM t",
 			expected: "SELECT (((i AND (NOT i)) OR ((NOT i) AND i)) AND NOT (i)) OR (NOT ((i AND (NOT i)) OR ((NOT i) AND i)) AND (i)) FROM t",
 		},
+		{
+			name:     "CHAR_LENGTH becomes DuckDB LENGTH",
+			input:    "SELECT CHAR_LENGTH(s) FROM t",
+			expected: "SELECT LENGTH(s) FROM t",
+		},
+		{
+			name:     "CHAR_LENGTH inside AVG does not emit CHAR_LENGTH",
+			input:    "SELECT FLOOR(i), AVG(CHAR_LENGTH(s)) FROM mytable mt GROUP BY 1 ORDER BY FLOOR(i) DESC",
+			expected: "SELECT FLOOR(i), AVG(LENGTH(s)) FROM mytable AS mt GROUP BY 1 ORDER BY FLOOR(i) DESC",
+		},
+		{
+			name:     "FORMAT two-arg uses DuckDB fmt grouping",
+			input:    "SELECT FORMAT(i, 3) FROM mytable",
+			expected: "SELECT FORMAT('{:,.3f}', i) FROM mytable",
+		},
+		{
+			name:     "FORMAT with da_DK swaps grouping separators",
+			input:    "SELECT FORMAT(i, 3, 'da_DK') FROM mytable",
+			expected: "SELECT REPLACE(REPLACE(REPLACE(FORMAT('{:,.3f}', i), ',', '\x01'), '.', ','), '\x01', '.') FROM mytable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
- Translate MySQL `CHAR_LENGTH` / `CHARACTER_LENGTH` to DuckDB `LENGTH`.
- Translate MySQL `FORMAT(x, d[, locale])` to DuckDB `{fmt}` grouping. For locales like `da_DK`, swap `,` / `.` separators.
- Unskip the matching `TestQueriesSimple` cases.

Fixes #58

## Test plan
- [x] `go test ./transpiler/`