### PR TITLE
fix: wrap non-aggregated columns when MySQL omits GROUP BY

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -230,7 +230,6 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_mytable_WHERE_false);",
 		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_NOT_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_emptytable);",
 		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_NOT_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_mytable_WHERE_false);",
-		"SELECT_pk1,_SUM(c1)_FROM_two_pk_WHERE_pk1_=_0",
 
 		"SELECT_JSON_OVERLAPS(c3,_'{\"a\":_2,_\"d\":_2}')_FROM_jsontable",
 		"SELECT_JSON_MERGE(c3,_'{\"a\":_1}')_FROM_jsontable",
@@ -349,7 +348,6 @@ func TestQueriesSimple(t *testing.T) {
 		"select_i_from_mytable_where_find_in_set(s,_'first_row,second_row,third_row')_=_2;",
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_keyless_U0,_cte___WHERE_cte.j_=_keyless.c0____)_____ORDER_BY_c0;_",
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_cte,_keyless_U0____WHERE_cte.j_=_keyless.c0_____)_____ORDER_BY_c0;_",
-		"SELECT_pk1,_SUM(c1)_FROM_two_pk",
 		"_select_*_from_mytable,__lateral_(__with_recursive_cte(a)_as_(___select_y_from_xy___union___select_x_from_cte___join___(____select_*_____from_xy____where_x_=_1____)_sqa1___on_x_=_a___limit_3___)__select_*_from_cte_)_sqa2_where_i_=_a_order_by_i;",
 		"_select____dayname(id),____dayname(i8),____dayname(i16),____dayname(i32),____dayname(i64),____dayname(u8),____dayname(u16),____dayname(u32),____dayname(u64),____dayname(f32),____dayname(f64),____dayname(ti),____dayname(da),____dayname(te),____dayname(bo),____dayname(js),____dayname(bl),____dayname(e1),____dayname(s1)_from_typestable",
 		"select_*_from_mytable_order_by_dayname(i)",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -179,6 +179,30 @@ def rewrite_mysql_for_duckdb(node):
                     ],
                 )
         return formatted
+    # MySQL allows SELECT pk, SUM(c) without GROUP BY when ONLY_FULL_GROUP_BY is off.
+    # DuckDB requires the extra columns to be aggregated; ANY_VALUE matches that mode.
+    if isinstance(node, exp.Select) and node.args.get("group") is None:
+        exprs = list(node.expressions or [])
+        def _has_agg(e):
+            return any(isinstance(x, exp.AggFunc) for x in e.walk())
+        def _already_any_value(e):
+            inner = e.this if isinstance(e, exp.Alias) else e
+            return isinstance(inner, exp.Anonymous) and str(inner.this).lower() == "any_value"
+        if exprs and any(_has_agg(e) for e in exprs) and any(not _has_agg(e) for e in exprs):
+            new_exprs = []
+            for e in exprs:
+                if _has_agg(e) or isinstance(e, exp.Star) or _already_any_value(e):
+                    new_exprs.append(e)
+                    continue
+                alias = e.alias if isinstance(e, exp.Alias) else None
+                inner = e.this if isinstance(e, exp.Alias) else e
+                wrapped = exp.Anonymous(this="any_value", expressions=[inner])
+                if alias:
+                    wrapped = exp.alias_(wrapped, alias)
+                new_exprs.append(wrapped)
+            updated = node.copy()
+            updated.set("expressions", new_exprs)
+            return updated
     return node
 
 def transpile_mysql_to_duckdb(sql: str) -> str:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -76,6 +76,16 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT FORMAT(i, 3, 'da_DK') FROM mytable",
 			expected: "SELECT REPLACE(REPLACE(REPLACE(FORMAT('{:,.3f}', i), ',', '\x01'), '.', ','), '\x01', '.') FROM mytable",
 		},
+		{
+			name:     "aggregate without GROUP BY wraps non-agg columns",
+			input:    "SELECT pk1, SUM(c1) FROM two_pk WHERE pk1 = 0",
+			expected: "SELECT ANY_VALUE(pk1), SUM(c1) FROM two_pk WHERE pk1 = 0",
+		},
+		{
+			name:     "explicit GROUP BY is left alone",
+			input:    "SELECT pk1, SUM(c1) FROM two_pk GROUP BY pk1",
+			expected: "SELECT pk1, SUM(c1) FROM two_pk GROUP BY pk1",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
MySQL without `ONLY_FULL_GROUP_BY` accepts `SELECT pk1, SUM(c1) FROM t WHERE pk1 = 0` with no `GROUP BY`. DuckDB rejects that.

This rewrite wraps the non-aggregated projections in `ANY_VALUE(...)` when a SELECT has aggregates and no GROUP BY. Explicit GROUP BY is left alone.

Fixes #59

## Test plan
- [x] `go test ./transpiler/`