### PR TITLE
fix: translate MySQL FIND_IN_SET to DuckDB list_position

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -343,9 +343,7 @@ func TestQueriesSimple(t *testing.T) {
 		"show_function_status_like_'foo'",
 		"show_function_status_where_Db='mydb'",
 		"SELECT_CONV(i,_10,_2)_FROM_mytable",
-		"select_find_in_set('second_row',_s)_from_mytable;",
-		"select_find_in_set(s,_'first_row,second_row,third_row')_from_mytable;",
-		"select_i_from_mytable_where_find_in_set(s,_'first_row,second_row,third_row')_=_2;",
+
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_keyless_U0,_cte___WHERE_cte.j_=_keyless.c0____)_____ORDER_BY_c0;_",
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_cte,_keyless_U0____WHERE_cte.j_=_keyless.c0_____)_____ORDER_BY_c0;_",
 		"_select_*_from_mytable,__lateral_(__with_recursive_cte(a)_as_(___select_y_from_xy___union___select_x_from_cte___join___(____select_*_____from_xy____where_x_=_1____)_sqa1___on_x_=_a___limit_3___)__select_*_from_cte_)_sqa2_where_i_=_a_order_by_i;",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -179,6 +179,22 @@ def rewrite_mysql_for_duckdb(node):
                     ],
                 )
         return formatted
+    # MySQL FIND_IN_SET(str, list) -> 1-based index or 0. DuckDB has no native function.
+    if isinstance(node, exp.Anonymous) and str(node.this).lower() == "find_in_set" and len(node.expressions) == 2:
+        needle, hay = node.expressions
+        return exp.Anonymous(
+            this="coalesce",
+            expressions=[
+                exp.Anonymous(
+                    this="list_position",
+                    expressions=[
+                        exp.Anonymous(this="string_split", expressions=[hay, exp.Literal.string(",")]),
+                        needle,
+                    ],
+                ),
+                exp.Literal.number(0),
+            ],
+        )
     # MySQL allows SELECT pk, SUM(c) without GROUP BY when ONLY_FULL_GROUP_BY is off.
     # DuckDB requires the extra columns to be aggregated; ANY_VALUE matches that mode.
     if isinstance(node, exp.Select) and node.args.get("group") is None:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -86,6 +86,11 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT pk1, SUM(c1) FROM two_pk GROUP BY pk1",
 			expected: "SELECT pk1, SUM(c1) FROM two_pk GROUP BY pk1",
 		},
+		{
+			name:     "FIND_IN_SET becomes list_position",
+			input:    "SELECT FIND_IN_SET(s, 'first_row,second_row,third_row') FROM mytable",
+			expected: "SELECT COALESCE(LIST_POSITION(STRING_SPLIT('first_row,second_row,third_row', ','), s), 0) FROM mytable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
MySQL `FIND_IN_SET(str, csv)` returns a 1-based index or 0. DuckDB has no native function.

Rewrite to `COALESCE(LIST_POSITION(STRING_SPLIT(csv, ','), str), 0)` and unskip the matching `TestQueriesSimple` cases.

## Test plan
- [x] `go test ./transpiler/`