### PR TITLE
fix: translate MySQL SUBSTRING_INDEX to DuckDB list_slice

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -255,10 +255,7 @@ func TestQueriesSimple(t *testing.T) {
 		"select_i_from_datetime_table_where_datetime_col_>_datetime('2020-01-01T12:00:00')_order_by_1",
 		"select_i_from_datetime_table_where_timestamp_col_=_datetime('2020-01-02T12:00:00')",
 		"select_i_from_datetime_table_where_timestamp_col_>_datetime('2020-01-02T12:00:00')_order_by_1",
-		"SELECT_SUBSTRING_INDEX(mytable.s,_\"d\",_1)_AS_s_FROM_mytable_INNER_JOIN_othertable_ON_(SUBSTRING_INDEX(mytable.s,_\"d\",_1)_=_SUBSTRING_INDEX(othertable.s2,_\"d\",_1))_GROUP_BY_1_HAVING_s_=_'secon';",
-		"SELECT_SUBSTRING_INDEX(mytable.s,_\"d\",_1)_AS_s_FROM_mytable_INNER_JOIN_othertable_ON_(SUBSTRING_INDEX(mytable.s,_\"d\",_1)_=_SUBSTRING_INDEX(othertable.s2,_\"d\",_1))_GROUP_BY_s_HAVING_s_=_'secon';",
-		"SELECT_SUBSTRING_INDEX(mytable.s,_\"d\",_1)_AS_ss_FROM_mytable_INNER_JOIN_othertable_ON_(SUBSTRING_INDEX(mytable.s,_\"d\",_1)_=_SUBSTRING_INDEX(othertable.s2,_\"d\",_1))_GROUP_BY_s_HAVING_s_=_'secon';",
-		"SELECT_SUBSTRING_INDEX(mytable.s,_\"d\",_1)_AS_ss_FROM_mytable_INNER_JOIN_othertable_ON_(SUBSTRING_INDEX(mytable.s,_\"d\",_1)_=_SUBSTRING_INDEX(othertable.s2,_\"d\",_1))_GROUP_BY_ss_HAVING_ss_=_'secon';",
+
 		"SELECT_TRIM(mytable.s_from_\"first_row\")_AS_s_FROM_mytable",
 		"SELECT_HOUR('2007-12-11_20:21:22')_FROM_mytable",
 		"SELECT_MINUTE('2007-12-11_20:21:22')_FROM_mytable",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -195,6 +195,44 @@ def rewrite_mysql_for_duckdb(node):
                 exp.Literal.number(0),
             ],
         )
+    # MySQL SUBSTRING_INDEX(str, delim, n): first/last n delimited parts.
+    if isinstance(node, exp.SubstringIndex):
+        src = node.args.get("this")
+        delim = node.args.get("delimiter")
+        count = node.args.get("count")
+        parts = exp.Anonymous(this="string_split", expressions=[src, delim])
+        parts_len = exp.Anonymous(this="len", expressions=[parts])
+        pos = exp.Anonymous(
+            this="array_to_string",
+            expressions=[
+                exp.Anonymous(
+                    this="list_slice",
+                    expressions=[parts, exp.Literal.number(1), count],
+                ),
+                delim,
+            ],
+        )
+        neg = exp.Anonymous(
+            this="array_to_string",
+            expressions=[
+                exp.Anonymous(
+                    this="list_slice",
+                    expressions=[
+                        parts,
+                        exp.Add(this=parts_len, expression=exp.Add(this=count, expression=exp.Literal.number(1))),
+                        parts_len,
+                    ],
+                ),
+                delim,
+            ],
+        )
+        return exp.Case(
+            ifs=[
+                exp.If(this=exp.EQ(this=count, expression=exp.Literal.number(0)), true=exp.Literal.string("")),
+                exp.If(this=exp.GT(this=count, expression=exp.Literal.number(0)), true=pos),
+            ],
+            default=neg,
+        )
     # MySQL allows SELECT pk, SUM(c) without GROUP BY when ONLY_FULL_GROUP_BY is off.
     # DuckDB requires the extra columns to be aggregated; ANY_VALUE matches that mode.
     if isinstance(node, exp.Select) and node.args.get("group") is None:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -91,6 +91,11 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT FIND_IN_SET(s, 'first_row,second_row,third_row') FROM mytable",
 			expected: "SELECT COALESCE(LIST_POSITION(STRING_SPLIT('first_row,second_row,third_row', ','), s), 0) FROM mytable",
 		},
+		{
+			name:     "SUBSTRING_INDEX positive count",
+			input:    "SELECT SUBSTRING_INDEX(s, 'd', 1) FROM mytable",
+			expected: "SELECT CASE WHEN 1 = 0 THEN '' WHEN 1 > 0 THEN ARRAY_TO_STRING(LIST_SLICE(STRING_SPLIT(s, 'd'), 1, 1), 'd') ELSE ARRAY_TO_STRING(LIST_SLICE(STRING_SPLIT(s, 'd'), LEN(STRING_SPLIT(s, 'd')) + 1 + 1, LEN(STRING_SPLIT(s, 'd'))), 'd') END FROM mytable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
MySQL `SUBSTRING_INDEX(str, delim, n)` has no DuckDB builtin.

Rewrite to `STRING_SPLIT` + `LIST_SLICE` + `ARRAY_TO_STRING`:
- `n > 0`: first n parts
- `n < 0`: last n parts
- `n = 0`: empty string

Unskip the matching `TestQueriesSimple` cases.

## Test plan
- [x] `go test ./transpiler/`