### PR TITLE
fix: translate MySQL HOUR/MINUTE/SECOND, ELT, and FIELD

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -257,10 +257,7 @@ func TestQueriesSimple(t *testing.T) {
 		"select_i_from_datetime_table_where_timestamp_col_>_datetime('2020-01-02T12:00:00')_order_by_1",
 
 		"SELECT_TRIM(mytable.s_from_\"first_row\")_AS_s_FROM_mytable",
-		"SELECT_HOUR('2007-12-11_20:21:22')_FROM_mytable",
-		"SELECT_MINUTE('2007-12-11_20:21:22')_FROM_mytable",
-		"SELECT_SECOND('2007-12-11_20:21:22')_FROM_mytable",
-		"SELECT_SECOND('2007-12-11T20:21:22Z')_FROM_mytable",
+
 		"SELECT_DAYOFYEAR('20071211')_FROM_mytable",
 		"SELECT_DISTINCT_CAST(i_AS_DECIMAL)_from_mytable;",
 		"SELECT_SUM(_DISTINCT_CAST(i_AS_DECIMAL))_from_mytable;",
@@ -353,8 +350,7 @@ func TestQueriesSimple(t *testing.T) {
 		"select_concat(space(i),_'a')_from_mytable;",
 		"select_space(i_*_2)_from_mytable;",
 		"select_atan(i),_atan2(i,_i_+_2)_from_mytable;",
-		"select_elt(i,_'a',_'b')_from_mytable;",
-		"select_field(i,_'1',_'2',_'3')_from_mytable;",
+
 		"select_char(i,_i_+_10,_pi())_from_mytable;",
 		"select_length(random_bytes(i))_from_mytable;",
 	}

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -233,6 +233,34 @@ def rewrite_mysql_for_duckdb(node):
             ],
             default=neg,
         )
+    # MySQL HOUR/MINUTE/SECOND accept datetime strings; DuckDB needs a timestamp.
+    if isinstance(node, (exp.Hour, exp.Minute, exp.Second)):
+        inner = node.this
+        if not isinstance(inner, exp.Cast):
+            inner = exp.Cast(this=inner, to=exp.DataType.build("TIMESTAMP"))
+        return node.__class__(this=inner)
+    # MySQL ELT(n, a, b, ...) is 1-based; out of range is NULL.
+    if isinstance(node, exp.Elt):
+        idx = node.this
+        items = list(node.expressions or [])
+        return exp.Anonymous(
+            this="list_extract",
+            expressions=[exp.Array(expressions=items), idx],
+        )
+    # MySQL FIELD(str, a, b, ...) is 1-based index or 0.
+    if isinstance(node, exp.Anonymous) and str(node.this).lower() == "field" and len(node.expressions) >= 2:
+        needle = node.expressions[0]
+        items = list(node.expressions[1:])
+        return exp.Anonymous(
+            this="coalesce",
+            expressions=[
+                exp.Anonymous(
+                    this="list_position",
+                    expressions=[exp.Array(expressions=items), needle],
+                ),
+                exp.Literal.number(0),
+            ],
+        )
     # MySQL allows SELECT pk, SUM(c) without GROUP BY when ONLY_FULL_GROUP_BY is off.
     # DuckDB requires the extra columns to be aggregated; ANY_VALUE matches that mode.
     if isinstance(node, exp.Select) and node.args.get("group") is None:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -96,6 +96,21 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT SUBSTRING_INDEX(s, 'd', 1) FROM mytable",
 			expected: "SELECT CASE WHEN 1 = 0 THEN '' WHEN 1 > 0 THEN ARRAY_TO_STRING(LIST_SLICE(STRING_SPLIT(s, 'd'), 1, 1), 'd') ELSE ARRAY_TO_STRING(LIST_SLICE(STRING_SPLIT(s, 'd'), LEN(STRING_SPLIT(s, 'd')) + 1 + 1, LEN(STRING_SPLIT(s, 'd'))), 'd') END FROM mytable",
 		},
+		{
+			name:     "HOUR casts datetime string to timestamp",
+			input:    "SELECT HOUR('2007-12-11 20:21:22') FROM mytable",
+			expected: "SELECT HOUR(CAST('2007-12-11 20:21:22' AS TIMESTAMP)) FROM mytable",
+		},
+		{
+			name:     "ELT becomes list_extract",
+			input:    "SELECT ELT(i, 'a', 'b') FROM mytable",
+			expected: "SELECT LIST_EXTRACT(['a', 'b'], i) FROM mytable",
+		},
+		{
+			name:     "FIELD becomes list_position",
+			input:    "SELECT FIELD(i, '1', '2', '3') FROM mytable",
+			expected: "SELECT COALESCE(LIST_POSITION(['1', '2', '3'], i), 0) FROM mytable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
- `HOUR` / `MINUTE` / `SECOND` on datetime strings now `CAST(... AS TIMESTAMP)` first.
- `ELT(n, ...)` -> `LIST_EXTRACT([...], n)`
- `FIELD(str, ...)` -> `COALESCE(LIST_POSITION([...], str), 0)`

Unskip the matching `TestQueriesSimple` cases.

## Test plan
- [x] `go test ./transpiler/`