### PR TITLE
fix: translate MySQL ADDDATE/SUBDATE and CONV base 10

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -261,16 +261,7 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_DAYOFYEAR('20071211')_FROM_mytable",
 		"SELECT_DISTINCT_CAST(i_AS_DECIMAL)_from_mytable;",
 		"SELECT_SUM(_DISTINCT_CAST(i_AS_DECIMAL))_from_mytable;",
-		"SELECT_id_FROM_typestable_WHERE_da_<_adddate('2020-01-01',_INTERVAL_1_DAY)",
-		"SELECT_id_FROM_typestable_WHERE_da_<_adddate('2020-01-01',_1)",
-		"SELECT_id_FROM_typestable_WHERE_da_>=_subdate('2020-01-01',_INTERVAL_1_DAY)",
-		"SELECT_id_FROM_typestable_WHERE_da_>=_subdate('2020-01-01',_1)",
-		"SELECT_adddate(da,_i32)_from_typestable;",
-		"SELECT_adddate(da,_concat(u32))_from_typestable;",
-		"SELECT_adddate(da,_f32/10)_from_typestable;",
-		"SELECT_subdate(da,_i32)_from_typestable;",
-		"SELECT_subdate(da,_concat(u32))_from_typestable;",
-		"SELECT_subdate(da,_f32/10)_from_typestable;",
+
 		"SELECT_i,v_from_stringandtable_WHERE_v",
 		"SELECT_i,v_from_stringandtable_WHERE_v_AND_v",
 		"SELECT_i,v_from_stringandtable_WHERE_v_OR_v",
@@ -336,7 +327,7 @@ func TestQueriesSimple(t *testing.T) {
 		"show_function_status",
 		"show_function_status_like_'foo'",
 		"show_function_status_where_Db='mydb'",
-		"SELECT_CONV(i,_10,_2)_FROM_mytable",
+
 
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_keyless_U0,_cte___WHERE_cte.j_=_keyless.c0____)_____ORDER_BY_c0;_",
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_cte,_keyless_U0____WHERE_cte.j_=_keyless.c0_____)_____ORDER_BY_c0;_",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -261,6 +261,24 @@ def rewrite_mysql_for_duckdb(node):
                 exp.Literal.number(0),
             ],
         )
+    # MySQL ADDDATE/SUBDATE -> date +/- INTERVAL. Bare numbers are days.
+    if isinstance(node, exp.Anonymous) and str(node.this).upper() in ("ADDDATE", "DATE_ADD", "SUBDATE", "DATE_SUB") and len(node.expressions) == 2:
+        base, delta = node.expressions
+        if not isinstance(delta, exp.Interval):
+            delta = exp.Interval(this=delta, unit=exp.Var(this="DAY"))
+        if str(node.this).upper() in ("ADDDATE", "DATE_ADD"):
+            return exp.Add(this=base, expression=delta)
+        return exp.Sub(this=base, expression=delta)
+    # MySQL CONV(n, from, to). Cover the common 10 -> 2/8/16 cases with {fmt}.
+    if isinstance(node, exp.Anonymous) and str(node.this).upper() == "CONV" and len(node.expressions) == 3:
+        value, frm, to = node.expressions
+        if isinstance(frm, exp.Literal) and frm.is_int and int(frm.this) == 10 and isinstance(to, exp.Literal) and to.is_int:
+            spec = {2: "{:b}", 8: "{:o}", 16: "{:X}"}.get(int(to.this))
+            if spec:
+                return exp.Anonymous(
+                    this="format",
+                    expressions=[exp.Literal.string(spec), value],
+                )
     # MySQL allows SELECT pk, SUM(c) without GROUP BY when ONLY_FULL_GROUP_BY is off.
     # DuckDB requires the extra columns to be aggregated; ANY_VALUE matches that mode.
     if isinstance(node, exp.Select) and node.args.get("group") is None:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -111,6 +111,21 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT FIELD(i, '1', '2', '3') FROM mytable",
 			expected: "SELECT COALESCE(LIST_POSITION(['1', '2', '3'], i), 0) FROM mytable",
 		},
+		{
+			name:     "ADDDATE interval becomes date plus interval",
+			input:    "SELECT ADDDATE(da, INTERVAL 1 DAY) FROM typestable",
+			expected: "SELECT da + INTERVAL '1' DAY FROM typestable",
+		},
+		{
+			name:     "ADDDATE days becomes date plus interval day",
+			input:    "SELECT ADDDATE(da, 1) FROM typestable",
+			expected: "SELECT da + INTERVAL 1 DAY FROM typestable",
+		},
+		{
+			name:     "CONV 10 to 2 uses fmt binary",
+			input:    "SELECT CONV(i, 10, 2) FROM mytable",
+			expected: "SELECT FORMAT('{:b}', i) FROM mytable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
- `ADDDATE` / `DATE_ADD` / `SUBDATE` / `DATE_SUB` become `date +/- INTERVAL`. A bare number is treated as days.
- `CONV(n, 10, 2|8|16)` becomes DuckDB `FORMAT('{:b|o|X}', n)`.

Unskip the matching `TestQueriesSimple` cases.

## Test plan
- [x] `go test ./transpiler/`