### PR TITLE
fix: translate MySQL BIT_LENGTH, OCTET_LENGTH, and UNHEX

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -288,8 +288,7 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_ACOS(i)_from_mytable_order_by_i_limit_1",
 		"SELECT_CRC32(i)_from_mytable_order_by_i_limit_1",
 		"SELECT_ASCII(s)_from_mytable_order_by_i_limit_1",
-		"SELECT_UNHEX(s)_from_mytable_order_by_i_limit_1",
-		"SELECT_BIT_LENGTH(i)_from_mytable_order_by_i_limit_1",
+
 		"select_date_format(datetime_col,_'%D')_from_datetime_table_order_by_1",
 		"select_time_format(time_col,_'%h%p')_from_datetime_table_order_by_1",
 		"select_from_unixtime(i)_from_mytable_order_by_1",
@@ -302,7 +301,7 @@ func TestQueriesSimple(t *testing.T) {
 		"select_md5(i)_from_mytable_order_by_1",
 		"select_sha1(i)_from_mytable_order_by_1",
 		"select_sha2(i,_256)_from_mytable_order_by_1",
-		"select_octet_length(s)_from_mytable_order_by_i",
+
 		"select_locate(upper(\"roW\"),_upper(s),_power(10,_0))_from_mytable_order_by_i",
 		"select_log2(i)_from_mytable_order_by_i",
 		"select_ln(i)_from_mytable_order_by_i",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -279,6 +279,21 @@ def rewrite_mysql_for_duckdb(node):
                     this="format",
                     expressions=[exp.Literal.string(spec), value],
                 )
+    # MySQL BIT_LENGTH is bits; DuckDB STRLEN is bytes.
+    if isinstance(node, exp.BitLength):
+        return exp.Mul(
+            this=exp.Anonymous(
+                this="strlen",
+                expressions=[exp.Cast(this=node.this, to=exp.DataType.build("TEXT"))],
+            ),
+            expression=exp.Literal.number(8),
+        )
+    # MySQL OCTET_LENGTH is bytes.
+    if isinstance(node, exp.Anonymous) and str(node.this).upper() == "OCTET_LENGTH" and node.expressions:
+        return exp.Anonymous(this="strlen", expressions=[node.expressions[0]])
+    # MySQL UNHEX -> DuckDB from_hex.
+    if isinstance(node, exp.Unhex):
+        return exp.Anonymous(this="from_hex", expressions=[node.this])
     # MySQL allows SELECT pk, SUM(c) without GROUP BY when ONLY_FULL_GROUP_BY is off.
     # DuckDB requires the extra columns to be aggregated; ANY_VALUE matches that mode.
     if isinstance(node, exp.Select) and node.args.get("group") is None:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -126,6 +126,21 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT CONV(i, 10, 2) FROM mytable",
 			expected: "SELECT FORMAT('{:b}', i) FROM mytable",
 		},
+		{
+			name:     "BIT_LENGTH is strlen times 8",
+			input:    "SELECT BIT_LENGTH(i) FROM mytable",
+			expected: "SELECT STRLEN(CAST(i AS TEXT)) * 8 FROM mytable",
+		},
+		{
+			name:     "OCTET_LENGTH becomes strlen",
+			input:    "SELECT OCTET_LENGTH(s) FROM mytable",
+			expected: "SELECT STRLEN(s) FROM mytable",
+		},
+		{
+			name:     "UNHEX becomes from_hex",
+			input:    "SELECT UNHEX(s) FROM mytable",
+			expected: "SELECT FROM_HEX(s) FROM mytable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
- `BIT_LENGTH(x)` -> `STRLEN(CAST(x AS TEXT)) * 8`
- `OCTET_LENGTH(s)` -> `STRLEN(s)`
- `UNHEX(s)` -> `FROM_HEX(s)`

Unskip the matching `TestQueriesSimple` cases.

## Test plan
- [x] `go test ./transpiler/`