### PR TITLE
fix: map OCTET_LENGTH to DuckDB octet_length

### DIFF
--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -288,9 +288,9 @@ def rewrite_mysql_for_duckdb(node):
             ),
             expression=exp.Literal.number(8),
         )
-    # MySQL OCTET_LENGTH is bytes.
+    # MySQL OCTET_LENGTH is bytes. DuckDB STRLEN counts characters.
     if isinstance(node, exp.Anonymous) and str(node.this).upper() == "OCTET_LENGTH" and node.expressions:
-        return exp.Anonymous(this="strlen", expressions=[node.expressions[0]])
+        return exp.Anonymous(this="octet_length", expressions=[node.expressions[0]])
     # MySQL UNHEX -> DuckDB from_hex.
     if isinstance(node, exp.Unhex):
         return exp.Anonymous(this="from_hex", expressions=[node.this])

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -132,9 +132,14 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT STRLEN(CAST(i AS TEXT)) * 8 FROM mytable",
 		},
 		{
-			name:     "OCTET_LENGTH becomes strlen",
+			name:     "OCTET_LENGTH becomes octet_length",
 			input:    "SELECT OCTET_LENGTH(s) FROM mytable",
-			expected: "SELECT STRLEN(s) FROM mytable",
+			expected: "SELECT OCTET_LENGTH(s) FROM mytable",
+		},
+		{
+			name:     "OCTET_LENGTH keeps UTF-8 as bytes",
+			input:    "SELECT OCTET_LENGTH('中') FROM mytable",
+			expected: "SELECT OCTET_LENGTH('中') FROM mytable",
 		},
 		{
 			name:     "UNHEX becomes from_hex",


### PR DESCRIPTION
## Summary
#373 rewrote `OCTET_LENGTH` to `STRLEN`. DuckDB `STRLEN` is character count; MySQL `OCTET_LENGTH` is bytes. ASCII tests passed, UTF-8 would be wrong.

Map to DuckDB `octet_length` instead.

## Test plan
- [x] `go test ./transpiler/ -run TestTranslate`