### PR TITLE
fix: BIT_LENGTH uses octet_length, not character length

### DIFF
--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -279,11 +279,11 @@ def rewrite_mysql_for_duckdb(node):
                     this="format",
                     expressions=[exp.Literal.string(spec), value],
                 )
-    # MySQL BIT_LENGTH is bits; DuckDB STRLEN is bytes.
+    # MySQL BIT_LENGTH is 8 * byte length, not character length.
     if isinstance(node, exp.BitLength):
         return exp.Mul(
             this=exp.Anonymous(
-                this="strlen",
+                this="octet_length",
                 expressions=[exp.Cast(this=node.this, to=exp.DataType.build("TEXT"))],
             ),
             expression=exp.Literal.number(8),

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -127,9 +127,9 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT FORMAT('{:b}', i) FROM mytable",
 		},
 		{
-			name:     "BIT_LENGTH is strlen times 8",
+			name:     "BIT_LENGTH is octet_length times 8",
 			input:    "SELECT BIT_LENGTH(i) FROM mytable",
-			expected: "SELECT STRLEN(CAST(i AS TEXT)) * 8 FROM mytable",
+			expected: "SELECT OCTET_LENGTH(CAST(i AS TEXT)) * 8 FROM mytable",
 		},
 		{
 			name:     "OCTET_LENGTH becomes strlen",


### PR DESCRIPTION
## Summary
#373 mapped `BIT_LENGTH` to `STRLEN(...) * 8`. `STRLEN` counts characters, so UTF-8 would be wrong.

This uses `OCTET_LENGTH(...) * 8` instead. OCTET_LENGTH itself is fixed in #374.

## Test plan
- [x] `go test ./transpiler/ -run TestTranslate`