### PR TITLE
fix: translate MySQL MD5, SHA, and ASCII

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -287,7 +287,7 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_ASIN(i)_from_mytable_order_by_i_limit_1",
 		"SELECT_ACOS(i)_from_mytable_order_by_i_limit_1",
 		"SELECT_CRC32(i)_from_mytable_order_by_i_limit_1",
-		"SELECT_ASCII(s)_from_mytable_order_by_i_limit_1",
+
 
 		"select_date_format(datetime_col,_'%D')_from_datetime_table_order_by_1",
 		"select_time_format(time_col,_'%h%p')_from_datetime_table_order_by_1",
@@ -298,9 +298,7 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_s,_i_FROM_mytable_GROUP_BY_i_ORDER_BY_SUBSTRING(s,_1,_1)_DESC",
 		"SELECT_s,_i_FROM_mytable_GROUP_BY_i_HAVING_count(*)_>_0_ORDER_BY_SUBSTRING(s,_1,_1)_DESC",
 		"SELECT_GREATEST(i,_s)_FROM_mytable",
-		"select_md5(i)_from_mytable_order_by_1",
-		"select_sha1(i)_from_mytable_order_by_1",
-		"select_sha2(i,_256)_from_mytable_order_by_1",
+
 
 		"select_locate(upper(\"roW\"),_upper(s),_power(10,_0))_from_mytable_order_by_i",
 		"select_log2(i)_from_mytable_order_by_i",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -294,6 +294,29 @@ def rewrite_mysql_for_duckdb(node):
     # MySQL UNHEX -> DuckDB from_hex.
     if isinstance(node, exp.Unhex):
         return exp.Anonymous(this="from_hex", expressions=[node.this])
+    def _as_text(e):
+        if isinstance(e, exp.Cast):
+            return e
+        return exp.Cast(this=e, to=exp.DataType.build("TEXT"))
+    # MySQL MD5/SHA* hash strings; integers must be cast first.
+    if isinstance(node, exp.MD5):
+        return exp.MD5(this=_as_text(node.this))
+    if isinstance(node, exp.SHA):
+        return exp.Anonymous(this="sha1", expressions=[_as_text(node.this)])
+    if isinstance(node, exp.SHA2):
+        length = node.args.get("length")
+        bits = int(length.this) if isinstance(length, exp.Literal) and length.is_int else 256
+        fn = {224: "sha224", 256: "sha256", 384: "sha384", 512: "sha512"}.get(bits, "sha256")
+        return exp.Anonymous(this=fn, expressions=[_as_text(node.this)])
+    # MySQL ASCII is the first byte, not the Unicode code point.
+    if isinstance(node, exp.Ascii):
+        return exp.Anonymous(
+            this="get_byte",
+            expressions=[
+                exp.Cast(this=node.this, to=exp.DataType.build("BLOB")),
+                exp.Literal.number(0),
+            ],
+        )
     # MySQL allows SELECT pk, SUM(c) without GROUP BY when ONLY_FULL_GROUP_BY is off.
     # DuckDB requires the extra columns to be aggregated; ANY_VALUE matches that mode.
     if isinstance(node, exp.Select) and node.args.get("group") is None:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -146,6 +146,21 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT UNHEX(s) FROM mytable",
 			expected: "SELECT FROM_HEX(s) FROM mytable",
 		},
+		{
+			name:     "MD5 casts integers to text",
+			input:    "SELECT MD5(i) FROM mytable",
+			expected: "SELECT MD5(CAST(i AS TEXT)) FROM mytable",
+		},
+		{
+			name:     "SHA2 256 becomes sha256 of text",
+			input:    "SELECT SHA2(i, 256) FROM mytable",
+			expected: "SELECT SHA256(CAST(i AS TEXT)) FROM mytable",
+		},
+		{
+			name:     "ASCII is first byte",
+			input:    "SELECT ASCII(s) FROM mytable",
+			expected: "SELECT GET_BYTE(CAST(s AS BLOB), 0) FROM mytable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
- `MD5(x)` / `SHA1(x)` / `SHA2(x, n)` cast `x` to `TEXT` then hash.
- `ASCII(s)` is the first byte: `GET_BYTE(CAST(s AS BLOB), 0)`. Not a Unicode code point.

Unskip the matching `TestQueriesSimple` cases.

## Test plan
- [x] `go test ./transpiler/`