### PR TITLE
fix: translate MySQL CHAR and JSON_PRETTY

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -234,7 +234,7 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_JSON_OVERLAPS(c3,_'{\"a\":_2,_\"d\":_2}')_FROM_jsontable",
 		"SELECT_JSON_MERGE(c3,_'{\"a\":_1}')_FROM_jsontable",
 		"SELECT_JSON_MERGE_PRESERVE(c3,_'{\"a\":_1}')_FROM_jsontable",
-		"select_json_pretty(c3)_from_jsontable",
+
 		"SELECT_a.column_0,_mt.s_from_(values_row(1,\"1\"),_row(2,\"2\"),_row(4,\"4\"))_a____left_join_mytable_mt_on_column_0_=_mt.i____order_by_1",
 
 		"select_i+0.0/(lag(i)_over_(order_by_s))_from_mytable_order_by_1;",
@@ -339,7 +339,7 @@ func TestQueriesSimple(t *testing.T) {
 		"select_space(i_*_2)_from_mytable;",
 		"select_atan(i),_atan2(i,_i_+_2)_from_mytable;",
 
-		"select_char(i,_i_+_10,_pi())_from_mytable;",
+
 		"select_length(random_bytes(i))_from_mytable;",
 	}
 

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -317,6 +317,21 @@ def rewrite_mysql_for_duckdb(node):
                 exp.Literal.number(0),
             ],
         )
+    # MySQL CHAR(n, ...) concatenates code points. DuckDB CHR takes one argument.
+    if isinstance(node, exp.Chr):
+        args = list(node.expressions or [])
+        if not args:
+            return node
+        chrs = [exp.Anonymous(this="chr", expressions=[a]) for a in args]
+        if len(chrs) == 1:
+            return chrs[0]
+        return exp.Anonymous(this="concat", expressions=chrs)
+    # MySQL JSON_PRETTY -> DuckDB json_pretty on JSON values.
+    if isinstance(node, exp.Anonymous) and str(node.this).upper() == "JSON_PRETTY" and node.expressions:
+        return exp.Anonymous(
+            this="json_pretty",
+            expressions=[exp.Cast(this=node.expressions[0], to=exp.DataType.build("JSON"))],
+        )
     # MySQL allows SELECT pk, SUM(c) without GROUP BY when ONLY_FULL_GROUP_BY is off.
     # DuckDB requires the extra columns to be aggregated; ANY_VALUE matches that mode.
     if isinstance(node, exp.Select) and node.args.get("group") is None:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -161,6 +161,16 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT ASCII(s) FROM mytable",
 			expected: "SELECT GET_BYTE(CAST(s AS BLOB), 0) FROM mytable",
 		},
+		{
+			name:     "CHAR concatenates chr of each arg",
+			input:    "SELECT CHAR(i, i + 10) FROM mytable",
+			expected: "SELECT CONCAT(CHR(i), CHR(i + 10)) FROM mytable",
+		},
+		{
+			name:     "JSON_PRETTY casts to JSON",
+			input:    "SELECT JSON_PRETTY(c3) FROM jsontable",
+			expected: "SELECT JSON_PRETTY(CAST(c3 AS JSON)) FROM jsontable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
- `CHAR(n, m, ...)` concatenates `CHR` of each argument. DuckDB `CHR` only takes one value.
- `JSON_PRETTY(x)` -> `JSON_PRETTY(CAST(x AS JSON))`

Unskip the matching `TestQueriesSimple` cases.

## Test plan
- [x] `go test ./transpiler/`