### PR TITLE
fix: translate MySQL DAYOFYEAR compact dates, JSON_MERGE, TIME_FORMAT

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -232,7 +232,7 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_NOT_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_mytable_WHERE_false);",
 
 		"SELECT_JSON_OVERLAPS(c3,_'{\"a\":_2,_\"d\":_2}')_FROM_jsontable",
-		"SELECT_JSON_MERGE(c3,_'{\"a\":_1}')_FROM_jsontable",
+
 		"SELECT_JSON_MERGE_PRESERVE(c3,_'{\"a\":_1}')_FROM_jsontable",
 
 		"SELECT_a.column_0,_mt.s_from_(values_row(1,\"1\"),_row(2,\"2\"),_row(4,\"4\"))_a____left_join_mytable_mt_on_column_0_=_mt.i____order_by_1",
@@ -258,7 +258,7 @@ func TestQueriesSimple(t *testing.T) {
 
 		"SELECT_TRIM(mytable.s_from_\"first_row\")_AS_s_FROM_mytable",
 
-		"SELECT_DAYOFYEAR('20071211')_FROM_mytable",
+
 		"SELECT_DISTINCT_CAST(i_AS_DECIMAL)_from_mytable;",
 		"SELECT_SUM(_DISTINCT_CAST(i_AS_DECIMAL))_from_mytable;",
 
@@ -290,7 +290,7 @@ func TestQueriesSimple(t *testing.T) {
 
 
 		"select_date_format(datetime_col,_'%D')_from_datetime_table_order_by_1",
-		"select_time_format(time_col,_'%h%p')_from_datetime_table_order_by_1",
+
 		"select_from_unixtime(i)_from_mytable_order_by_1",
 		"SELECT_CASE_WHEN_i_>_2_THEN_i_WHEN_i_<_2_THEN_i_ELSE_'two'_END_FROM_mytable",
 		"SELECT_CASE_WHEN_i_>_2_THEN_'more_than_two'_WHEN_i_<_2_THEN_'less_than_two'_ELSE_2_END_FROM_mytable",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -332,6 +332,42 @@ def rewrite_mysql_for_duckdb(node):
             this="json_pretty",
             expressions=[exp.Cast(this=node.expressions[0], to=exp.DataType.build("JSON"))],
         )
+    # MySQL accepts YYYYMMDD date strings; DuckDB DATE needs YYYY-MM-DD.
+    def _compact_date_literal(e):
+        if isinstance(e, exp.Literal) and e.is_string:
+            s = str(e.this)
+            if len(s) == 8 and s.isdigit():
+                return exp.Literal.string(s[0:4] + "-" + s[4:6] + "-" + s[6:8])
+        return e
+    if isinstance(node, exp.DayOfYear):
+        inner = node.this
+        if isinstance(inner, exp.TsOrDsToDate):
+            updated = inner.copy()
+            updated.set("this", _compact_date_literal(inner.this))
+            return node.__class__(this=updated)
+        return node.__class__(this=_compact_date_literal(inner))
+    # MySQL JSON_MERGE is object merge; DuckDB json_merge_patch is the closest builtin.
+    if isinstance(node, exp.Anonymous) and str(node.this).upper() == "JSON_MERGE" and len(node.expressions) == 2:
+        a, b = node.expressions
+        return exp.Anonymous(
+            this="json_merge_patch",
+            expressions=[
+                exp.Cast(this=a, to=exp.DataType.build("JSON")),
+                exp.Cast(this=b, to=exp.DataType.build("JSON")),
+            ],
+        )
+    # MySQL TIME_FORMAT -> DuckDB strftime. %%h is 01-12 like DuckDB %%I.
+    if isinstance(node, exp.Anonymous) and str(node.this).upper() == "TIME_FORMAT" and len(node.expressions) == 2:
+        t, fmt = node.expressions
+        if isinstance(fmt, exp.Literal) and fmt.is_string:
+            fmt = exp.Literal.string(str(fmt.this).replace("%%h", "%%I"))
+        return exp.Anonymous(
+            this="strftime",
+            expressions=[
+                exp.Cast(this=t, to=exp.DataType.build("TIMESTAMP")),
+                fmt,
+            ],
+        )
     # MySQL allows SELECT pk, SUM(c) without GROUP BY when ONLY_FULL_GROUP_BY is off.
     # DuckDB requires the extra columns to be aggregated; ANY_VALUE matches that mode.
     if isinstance(node, exp.Select) and node.args.get("group") is None:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -171,6 +171,21 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT JSON_PRETTY(c3) FROM jsontable",
 			expected: "SELECT JSON_PRETTY(CAST(c3 AS JSON)) FROM jsontable",
 		},
+		{
+			name:     "DAYOFYEAR compact date gets dashes",
+			input:    "SELECT DAYOFYEAR('20071211') FROM mytable",
+			expected: "SELECT DAYOFYEAR(CAST('2007-12-11' AS DATE)) FROM mytable",
+		},
+		{
+			name:     "JSON_MERGE becomes json_merge_patch",
+			input:    "SELECT JSON_MERGE(c3, '{\"a\": 1}') FROM jsontable",
+			expected: "SELECT JSON_MERGE_PATCH(CAST(c3 AS JSON), CAST('{\"a\": 1}' AS JSON)) FROM jsontable",
+		},
+		{
+			name:     "TIME_FORMAT becomes strftime",
+			input:    "SELECT TIME_FORMAT(time_col, '%h%p') FROM datetime_table",
+			expected: "SELECT STRFTIME(CAST(time_col AS TIMESTAMP), '%I%p') FROM datetime_table",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
- Compact `YYYYMMDD` date strings are rewritten to `YYYY-MM-DD` for `DAYOFYEAR`.
- `JSON_MERGE(a, b)` -> `JSON_MERGE_PATCH(CAST(a AS JSON), CAST(b AS JSON))`
- `TIME_FORMAT(t, fmt)` -> `STRFTIME(CAST(t AS TIMESTAMP), fmt)` with `%h` mapped to `%I`

Unskip the matching `TestQueriesSimple` cases.

## Test plan
- [x] `go test ./transpiler/`