### PR TITLE
test: unskip 3-arg LOCATE

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -300,7 +300,7 @@ func TestQueriesSimple(t *testing.T) {
 
 
 
-		"select_locate(upper(\"roW\"),_upper(s),_power(10,_0))_from_mytable_order_by_i",
+
 		"select_log2(i)_from_mytable_order_by_i",
 		"select_ln(i)_from_mytable_order_by_i",
 		"select_log10(i)_from_mytable_order_by_i",

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -216,6 +216,11 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT LEAST(i, s) FROM mytable",
 			expected: "SELECT CASE WHEN i IS NULL OR s IS NULL THEN NULL ELSE LEAST(i, s) END FROM mytable",
 		},
+		{
+			name:     "LOCATE with start uses strpos of substring",
+			input:    "SELECT LOCATE(UPPER('roW'), UPPER(s), POWER(10, 0)) FROM mytable",
+			expected: "SELECT CASE WHEN STRPOS(SUBSTRING(UPPER(s), POWER(10, 0)), UPPER('roW')) = 0 THEN 0 ELSE STRPOS(SUBSTRING(UPPER(s), POWER(10, 0)), UPPER('roW')) + (POWER(10, 0)) - 1 END FROM mytable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
3-arg `LOCATE` already transpile to `STRPOS(SUBSTRING(...))`. Unskip the matching `TestQueriesSimple` case and lock the mapping.

## Test plan
- [x] `go test ./transpiler/`