### PR TITLE
test: unskip LOG2, LN, LOG10, LOG, ATAN

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -301,10 +301,7 @@ func TestQueriesSimple(t *testing.T) {
 
 
 
-		"select_log2(i)_from_mytable_order_by_i",
-		"select_ln(i)_from_mytable_order_by_i",
-		"select_log10(i)_from_mytable_order_by_i",
-		"select_log(3,_i)_from_mytable_order_by_i",
+
 
 		"SELECT_i_FROM_mytable_WHERE_NOT_s_ORDER_BY_1_DESC",
 		"SELECT_sum(i)_as_isum,_s_FROM_mytable_GROUP_BY_i_ORDER_BY_isum_ASC_LIMIT_0,_200",
@@ -335,7 +332,7 @@ func TestQueriesSimple(t *testing.T) {
 		"select_*_from_mytable_where_(i_BETWEEN_(''_BETWEEN_''_AND_(''_OR_'#'))_AND_i)",
 		"select_*_from_xy_inner_join_uv_on_(xy.x_in_(false_in_('asdf')));",
 
-		"select_atan(i),_atan2(i,_i_+_2)_from_mytable;",
+
 
 
 		"select_length(random_bytes(i))_from_mytable;",

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -221,6 +221,16 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT LOCATE(UPPER('roW'), UPPER(s), POWER(10, 0)) FROM mytable",
 			expected: "SELECT CASE WHEN STRPOS(SUBSTRING(UPPER(s), POWER(10, 0)), UPPER('roW')) = 0 THEN 0 ELSE STRPOS(SUBSTRING(UPPER(s), POWER(10, 0)), UPPER('roW')) + (POWER(10, 0)) - 1 END FROM mytable",
 		},
+		{
+			name:     "LOG2 becomes LOG base 2",
+			input:    "SELECT LOG2(i) FROM mytable",
+			expected: "SELECT LOG(2, i) FROM mytable",
+		},
+		{
+			name:     "ATAN2 is kept",
+			input:    "SELECT ATAN(i), ATAN2(i, i + 2) FROM mytable",
+			expected: "SELECT ATAN(i), ATAN2(i, i + 2) FROM mytable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
`LOG2` / `LN` / `LOG10` / `LOG` / `ATAN` / `ATAN2` already transpile to DuckDB. Unskip the matching `TestQueriesSimple` cases.

ASIN/ACOS stay skipped: `i` is 1..3, outside `[-1, 1]`.

## Test plan
- [x] `go test ./transpiler/`