### PR TITLE
test: unskip TRIM(remstr FROM str)

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -256,7 +256,7 @@ func TestQueriesSimple(t *testing.T) {
 		"select_i_from_datetime_table_where_timestamp_col_=_datetime('2020-01-02T12:00:00')",
 		"select_i_from_datetime_table_where_timestamp_col_>_datetime('2020-01-02T12:00:00')_order_by_1",
 
-		"SELECT_TRIM(mytable.s_from_\"first_row\")_AS_s_FROM_mytable",
+
 
 
 		"SELECT_DISTINCT_CAST(i_AS_DECIMAL)_from_mytable;",

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -231,6 +231,11 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT ATAN(i), ATAN2(i, i + 2) FROM mytable",
 			expected: "SELECT ATAN(i), ATAN2(i, i + 2) FROM mytable",
 		},
+		{
+			name:     "TRIM remstr FROM str becomes trim(str, remstr)",
+			input:    "SELECT TRIM(s FROM 'first row') AS s FROM mytable",
+			expected: "SELECT TRIM('first row', s) AS s FROM mytable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
MySQL `TRIM(remstr FROM str)` already transpile to DuckDB `TRIM(str, remstr)`. Unskip the matching `TestQueriesSimple` case.

## Test plan
- [x] `go test ./transpiler/`