### PR TITLE
fix: wrap non-grouped SELECT columns with ANY_VALUE

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -295,8 +295,7 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_CASE_WHEN_i_>_2_THEN_i_WHEN_i_<_2_THEN_i_ELSE_'two'_END_FROM_mytable",
 		"SELECT_CASE_WHEN_i_>_2_THEN_'more_than_two'_WHEN_i_<_2_THEN_'less_than_two'_ELSE_2_END_FROM_mytable",
 		"SELECT_substring(mytable.s,_1,_5)_AS_s_FROM_mytable_INNER_JOIN_othertable_ON_(substring(mytable.s,_1,_5)_=_SUBSTRING(othertable.s2,_1,_5))_GROUP_BY_1_HAVING_s_=_\"secon\"",
-		"SELECT_s,_i_FROM_mytable_GROUP_BY_i_ORDER_BY_SUBSTRING(s,_1,_1)_DESC",
-		"SELECT_s,_i_FROM_mytable_GROUP_BY_i_HAVING_count(*)_>_0_ORDER_BY_SUBSTRING(s,_1,_1)_DESC",
+
 
 
 

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -401,6 +401,45 @@ def rewrite_mysql_for_duckdb(node):
             updated = node.copy()
             updated.set("expressions", new_exprs)
             return updated
+    # MySQL also allows SELECT s, i GROUP BY i. Wrap non-grouped, non-agg columns.
+    if isinstance(node, exp.Select) and node.args.get("group") is not None:
+        exprs = list(node.expressions or [])
+        group_exprs = list(node.args.get("group").expressions or [])
+        group_keys = set()
+        for g in group_exprs:
+            group_keys.add(g.sql(dialect="duckdb").lower())
+            if isinstance(g, exp.Literal) and g.is_int:
+                group_keys.add(str(int(g.this)))
+        def _has_agg(e):
+            return any(isinstance(x, exp.AggFunc) for x in e.walk())
+        def _already_any_value(e):
+            inner = e.this if isinstance(e, exp.Alias) else e
+            return isinstance(inner, exp.Anonymous) and str(inner.this).lower() == "any_value"
+        def _in_group(e, idx):
+            if str(idx) in group_keys:
+                return True
+            ident = e.sql(dialect="duckdb").lower()
+            if ident in group_keys:
+                return True
+            inner = e.this if isinstance(e, exp.Alias) else e
+            return inner.sql(dialect="duckdb").lower() in group_keys
+        new_exprs = []
+        changed = False
+        for idx, e in enumerate(exprs, 1):
+            if _has_agg(e) or isinstance(e, exp.Star) or _already_any_value(e) or _in_group(e, idx):
+                new_exprs.append(e)
+                continue
+            alias = e.alias if isinstance(e, exp.Alias) else None
+            inner = e.this if isinstance(e, exp.Alias) else e
+            wrapped = exp.Anonymous(this="any_value", expressions=[inner])
+            if alias:
+                wrapped = exp.alias_(wrapped, alias)
+            new_exprs.append(wrapped)
+            changed = True
+        if changed:
+            updated = node.copy()
+            updated.set("expressions", new_exprs)
+            return updated
     return node
 
 def transpile_mysql_to_duckdb(sql: str) -> str:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -236,6 +236,11 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT TRIM(s FROM 'first row') AS s FROM mytable",
 			expected: "SELECT TRIM('first row', s) AS s FROM mytable",
 		},
+		{
+			name:     "GROUP BY wraps non-grouped columns",
+			input:    "SELECT s, i FROM mytable GROUP BY i",
+			expected: "SELECT ANY_VALUE(s), i FROM mytable GROUP BY i",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
MySQL without `ONLY_FULL_GROUP_BY` allows `SELECT s, i FROM t GROUP BY i`. DuckDB rejects `s`.

This wraps non-grouped, non-aggregated projections in `ANY_VALUE(...)`. Existing `GROUP BY` keys and aggregates are left alone.

Unskip the matching `TestQueriesSimple` cases.

## Test plan
- [x] `go test ./transpiler/`