### PR TITLE
fix: translate MySQL DATETIME() to TIMESTAMP cast

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -251,10 +251,7 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_i_FROM_mytable_WHERE_'hello';",
 		"SELECT_i_FROM_mytable_WHERE_NOT_'hello';",
 		"select_i_from_datetime_table_where_date_col_=_'2019-12-31T00:00:01'",
-		"select_i_from_datetime_table_where_datetime_col_=_datetime('2020-01-01T12:00:00')",
-		"select_i_from_datetime_table_where_datetime_col_>_datetime('2020-01-01T12:00:00')_order_by_1",
-		"select_i_from_datetime_table_where_timestamp_col_=_datetime('2020-01-02T12:00:00')",
-		"select_i_from_datetime_table_where_timestamp_col_>_datetime('2020-01-02T12:00:00')_order_by_1",
+
 
 
 

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -377,6 +377,9 @@ def rewrite_mysql_for_duckdb(node):
             exp.Anonymous(this="json_contains", expressions=[aj, bj]),
             exp.Anonymous(this="json_contains", expressions=[bj, aj]),
         )
+    # MySQL DATETIME('...') is a timestamp constructor. DuckDB has no DATETIME().
+    if isinstance(node, exp.Datetime):
+        return exp.Cast(this=node.this, to=exp.DataType.build("TIMESTAMP"))
     # MySQL allows SELECT pk, SUM(c) without GROUP BY when ONLY_FULL_GROUP_BY is off.
     # DuckDB requires the extra columns to be aggregated; ANY_VALUE matches that mode.
     if isinstance(node, exp.Select) and node.args.get("group") is None:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -241,6 +241,11 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT s, i FROM mytable GROUP BY i",
 			expected: "SELECT ANY_VALUE(s), i FROM mytable GROUP BY i",
 		},
+		{
+			name:     "DATETIME string becomes timestamp cast",
+			input:    "SELECT DATETIME('2020-01-01T12:00:00')",
+			expected: "SELECT CAST('2020-01-01T12:00:00' AS TIMESTAMP)",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
MySQL `DATETIME('2020-01-01T12:00:00')` has no DuckDB builtin. Rewrite to `CAST(... AS TIMESTAMP)`.

Unskip the matching `TestQueriesSimple` cases.

## Test plan
- [x] `go test ./transpiler/`