### PR TITLE
fix: wrap negative CAST AS UNSIGNED in 2^64

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -272,8 +272,7 @@ func TestQueriesSimple(t *testing.T) {
 		"select_pk,_________row_number()_over_(order_by_pk_desc),_________sum(v1)_over_(partition_by_v2_order_by_pk),_________percent_rank()_over(partition_by_v2_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 		"select_pk,____________________percent_rank()_over(partition_by_v2_order_by_pk),____________________dense_rank()_over(partition_by_v2_order_by_pk),____________________rank()_over(partition_by_v2_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 		"select_pk,_________first_value(pk)_over_(order_by_pk_desc),_________lag(pk,_1)_over_(order_by_pk_desc),_________count(pk)_over(partition_by_v1_order_by_pk),_________max(pk)_over(partition_by_v1_order_by_pk_desc),_________avg(v2)_over_(partition_by_v1_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
-		"SELECT_CAST(-3_AS_UNSIGNED)_FROM_mytable",
-		"SELECT_CONVERT(-3,_UNSIGNED)_FROM_mytable",
+
 		"SELECT_s_>_2_FROM_tabletest",
 		"SELECT_*_FROM_tabletest_WHERE_s_>_0",
 		"SELECT_*_FROM_tabletest_WHERE_s_=_0",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -380,6 +380,19 @@ def rewrite_mysql_for_duckdb(node):
     # MySQL DATETIME('...') is a timestamp constructor. DuckDB has no DATETIME().
     if isinstance(node, exp.Datetime):
         return exp.Cast(this=node.this, to=exp.DataType.build("TIMESTAMP"))
+    # MySQL CAST(negative AS UNSIGNED) wraps in 2^64. DuckDB UBIGINT rejects negatives.
+    if isinstance(node, exp.Cast):
+        to = node.args.get("to")
+        inner = node.this
+        if to is not None and not isinstance(inner, (exp.If, exp.Case)):
+            to_sql = to.sql(dialect="duckdb").upper()
+            if to_sql.startswith("U") and "INT" in to_sql:
+                wrapped = exp.If(
+                    this=exp.LT(this=inner, expression=exp.Literal.number(0)),
+                    true=exp.Add(this=inner, expression=exp.Literal.number(18446744073709551616)),
+                    false=inner,
+                )
+                return exp.Cast(this=wrapped, to=to)
     # MySQL allows SELECT pk, SUM(c) without GROUP BY when ONLY_FULL_GROUP_BY is off.
     # DuckDB requires the extra columns to be aggregated; ANY_VALUE matches that mode.
     if isinstance(node, exp.Select) and node.args.get("group") is None:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -246,6 +246,11 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT DATETIME('2020-01-01T12:00:00')",
 			expected: "SELECT CAST('2020-01-01T12:00:00' AS TIMESTAMP)",
 		},
+		{
+			name:     "CAST negative AS UNSIGNED wraps",
+			input:    "SELECT CAST(-3 AS UNSIGNED) FROM mytable",
+			expected: "SELECT CAST(CASE WHEN -3 < 0 THEN -3 + 18446744073709551616 ELSE -3 END AS UBIGINT) FROM mytable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
MySQL `CAST(-3 AS UNSIGNED)` wraps to `2^64-3`. DuckDB `UBIGINT` rejects negatives.

Rewrite unsigned integer casts to:

`CAST(CASE WHEN x < 0 THEN x + 18446744073709551616 ELSE x END AS UBIGINT)`

Unskip `CAST(-3 AS UNSIGNED)` and `CONVERT(-3, UNSIGNED)`.

## Test plan
- [x] `go test ./transpiler/`