### PR TITLE
fix: DATE_FORMAT %D is English day ordinal

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -285,7 +285,7 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_CRC32(i)_from_mytable_order_by_i_limit_1",
 
 
-		"select_date_format(datetime_col,_'%D')_from_datetime_table_order_by_1",
+
 
 
 		"SELECT_CASE_WHEN_i_>_2_THEN_i_WHEN_i_<_2_THEN_i_ELSE_'two'_END_FROM_mytable",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -406,6 +406,27 @@ def rewrite_mysql_for_duckdb(node):
     # MySQL DATETIME('...') is a timestamp constructor. DuckDB has no DATETIME().
     if isinstance(node, exp.Datetime):
         return exp.Cast(this=node.this, to=exp.DataType.build("TIMESTAMP"))
+    # MySQL DATE_FORMAT %%D is 1st/2nd/3rd/4th. DuckDB %%D is not that.
+    if isinstance(node, exp.TimeToStr):
+        fmt = node.args.get("format")
+        ts = node.this
+        if isinstance(fmt, exp.Literal) and fmt.is_string and str(fmt.this) == "%%D":
+            d = exp.Anonymous(this="day", expressions=[ts])
+            suffix = exp.Case(
+                this=exp.Anonymous(this="mod", expressions=[d, exp.Literal.number(10)]),
+                ifs=[
+                    exp.If(this=exp.Literal.number(1), true=exp.Literal.string("st")),
+                    exp.If(this=exp.Literal.number(2), true=exp.Literal.string("nd")),
+                    exp.If(this=exp.Literal.number(3), true=exp.Literal.string("rd")),
+                ],
+                default=exp.Literal.string("th"),
+            )
+            teen = exp.In(this=d, expressions=[exp.Literal.number(11), exp.Literal.number(12), exp.Literal.number(13)])
+            suf = exp.If(this=teen, true=exp.Literal.string("th"), false=suffix)
+            return exp.Anonymous(
+                this="concat",
+                expressions=[exp.Cast(this=d, to=exp.DataType.build("TEXT")), suf],
+            )
     # MySQL CAST(negative AS UNSIGNED) wraps in 2^64. DuckDB UBIGINT rejects negatives.
     if isinstance(node, exp.Cast):
         to = node.args.get("to")

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -256,6 +256,11 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT JSON_MERGE_PRESERVE(c3, '{\"a\": 1}') FROM jsontable",
 			expected: "SELECT CASE WHEN JSON_TYPE(CAST(c3 AS JSON)) = 'ARRAY' AND JSON_TYPE(CAST('{\"a\": 1}' AS JSON)) = 'ARRAY' THEN TO_JSON(LIST_CONCAT(JSON_EXTRACT(CAST(c3 AS JSON), '$'), JSON_EXTRACT(CAST('{\"a\": 1}' AS JSON), '$'))) ELSE JSON_MERGE_PATCH(CAST(c3 AS JSON), CAST('{\"a\": 1}' AS JSON)) END FROM jsontable",
 		},
+		{
+			name:     "DATE_FORMAT percent-D is day ordinal",
+			input:    "SELECT DATE_FORMAT(datetime_col, '%D') FROM datetime_table",
+			expected: "SELECT CONCAT(CAST(DAY(CAST(datetime_col AS TIMESTAMP)) AS TEXT), CASE WHEN DAY(CAST(datetime_col AS TIMESTAMP)) IN (11, 12, 13) THEN 'th' ELSE CASE MOD(DAY(CAST(datetime_col AS TIMESTAMP)), 10) WHEN 1 THEN 'st' WHEN 2 THEN 'nd' WHEN 3 THEN 'rd' ELSE 'th' END END) FROM datetime_table",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
MySQL `DATE_FORMAT(ts, '%D')` is `1st` / `2nd` / `3rd` / `4th`. DuckDB `strftime %D` is not that.

Rewrite to `CONCAT(DAY(...), suffix)` with 11/12/13 as `th`.

## Test plan
- [x] `go test ./transpiler/`