### PR TITLE
fix: substitute SELECT aliases in HAVING

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -243,8 +243,7 @@ func TestQueriesSimple(t *testing.T) {
 		"WITH_mytable_as_(select_*_FROM_mytable)_SELECT_s,i_FROM_mytable;",
 		"WITH_mytable_as_(select_*_FROM_mytable_where_i_>_2)_SELECT_*_FROM_mytable;",
 		"WITH_mytable_as_(select_*_FROM_mytable_where_i_>_2)_SELECT_*_FROM_mytable_union_SELECT_*_from_mytable;",
-		"SELECT_i,_1_AS_foo,_2_AS_bar_FROM_MyTable_HAVING_bar_=_2_ORDER_BY_foo,_i;",
-		"SELECT_i,_1_AS_foo,_2_AS_bar_FROM_MyTable_HAVING_bar_=_1_ORDER_BY_foo,_i;",
+
 		"SELECT_reservedWordsTable.AND,_reservedWordsTABLE.Or,_reservedwordstable.SEleCT_FROM_reservedWordsTable;",
 		"SELECT_*_from_mytable_where_(i_=_1_|_false)_IN_(true)",
 		"SELECT_*_from_mytable_where_(i_=_1_&_false)_IN_(true)",
@@ -276,7 +275,7 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_s_>_2_FROM_tabletest",
 		"SELECT_*_FROM_tabletest_WHERE_s_>_0",
 		"SELECT_*_FROM_tabletest_WHERE_s_=_0",
-		"SELECT_i_AS_foo_FROM_mytable_HAVING_foo_NOT_IN_(1,_2,_5)",
+
 		"SELECT_SUM(i)_FROM_mytable",
 		"SELECT_RAND(i)_from_mytable_order_by_i",
 

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -503,6 +503,23 @@ def rewrite_mysql_for_duckdb(node):
             updated = node.copy()
             updated.set("expressions", new_exprs)
             return updated
+    # MySQL HAVING can use SELECT aliases. Substitute the aliased expression.
+    if isinstance(node, exp.Select) and node.args.get("having") is not None:
+        aliases = {}
+        for e in node.expressions or []:
+            if isinstance(e, exp.Alias) and e.alias:
+                aliases[str(e.alias).lower()] = e.this
+        if aliases:
+            def _replace_having_alias(n):
+                if isinstance(n, exp.Column) and not n.table and n.name and n.name.lower() in aliases:
+                    return aliases[n.name.lower()]
+                return n
+            having = node.args.get("having")
+            new_having = having.transform(_replace_having_alias)
+            if new_having is not having:
+                updated = node.copy()
+                updated.set("having", new_having)
+                return updated
     return node
 
 def transpile_mysql_to_duckdb(sql: str) -> str:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -261,6 +261,11 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT DATE_FORMAT(datetime_col, '%D') FROM datetime_table",
 			expected: "SELECT CONCAT(CAST(DAY(CAST(datetime_col AS TIMESTAMP)) AS TEXT), CASE WHEN DAY(CAST(datetime_col AS TIMESTAMP)) IN (11, 12, 13) THEN 'th' ELSE CASE MOD(DAY(CAST(datetime_col AS TIMESTAMP)), 10) WHEN 1 THEN 'st' WHEN 2 THEN 'nd' WHEN 3 THEN 'rd' ELSE 'th' END END) FROM datetime_table",
 		},
+		{
+			name:     "HAVING uses SELECT alias expression",
+			input:    "SELECT i, 1 AS foo, 2 AS bar FROM MyTable HAVING bar = 2",
+			expected: "SELECT i, 1 AS foo, 2 AS bar FROM MyTable HAVING 2 = 2",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
MySQL allows `HAVING bar` when `bar` is a SELECT alias. DuckDB does not see SELECT aliases in HAVING.

Substitute the alias with the aliased expression.

Unskip the matching `TestQueriesSimple` cases.

## Test plan
- [x] `go test ./transpiler/`