### PR TITLE
fix: MySQL string WHERE predicates are numeric nonzero

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -247,8 +247,7 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_reservedWordsTable.AND,_reservedWordsTABLE.Or,_reservedwordstable.SEleCT_FROM_reservedWordsTable;",
 		"SELECT_*_from_mytable_where_(i_=_1_|_false)_IN_(true)",
 		"SELECT_*_from_mytable_where_(i_=_1_&_false)_IN_(true)",
-		"SELECT_i_FROM_mytable_WHERE_'hello';",
-		"SELECT_i_FROM_mytable_WHERE_NOT_'hello';",
+
 		"select_i_from_datetime_table_where_date_col_=_'2019-12-31T00:00:01'",
 
 

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -406,6 +406,19 @@ def rewrite_mysql_for_duckdb(node):
     # MySQL DATETIME('...') is a timestamp constructor. DuckDB has no DATETIME().
     if isinstance(node, exp.Datetime):
         return exp.Cast(this=node.this, to=exp.DataType.build("TIMESTAMP"))
+    # MySQL treats a string predicate as CAST(s AS DOUBLE) <> 0. 'hello' is 0, so false.
+    if isinstance(node, exp.Where) and isinstance(node.this, exp.Literal) and node.this.is_string:
+        return exp.Where(
+            this=exp.NEQ(
+                this=exp.Cast(this=node.this, to=exp.DataType.build("DOUBLE")),
+                expression=exp.Literal.number(0),
+            )
+        )
+    if isinstance(node, exp.Not) and isinstance(node.this, exp.Literal) and node.this.is_string:
+        return exp.EQ(
+            this=exp.Cast(this=node.this, to=exp.DataType.build("DOUBLE")),
+            expression=exp.Literal.number(0),
+        )
     # MySQL DATE_FORMAT %%D is 1st/2nd/3rd/4th. DuckDB %%D is not that.
     if isinstance(node, exp.TimeToStr):
         fmt = node.args.get("format")

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -406,19 +406,21 @@ def rewrite_mysql_for_duckdb(node):
     # MySQL DATETIME('...') is a timestamp constructor. DuckDB has no DATETIME().
     if isinstance(node, exp.Datetime):
         return exp.Cast(this=node.this, to=exp.DataType.build("TIMESTAMP"))
-    # MySQL treats a string predicate as CAST(s AS DOUBLE) <> 0. 'hello' is 0, so false.
+    # MySQL treats a string predicate as a number: invalid strings are 0, not an error.
+    def _mysql_string_as_number(e):
+        return exp.Anonymous(
+            this="coalesce",
+            expressions=[
+                exp.TryCast(this=e, to=exp.DataType.build("DOUBLE")),
+                exp.Literal.number(0),
+            ],
+        )
     if isinstance(node, exp.Where) and isinstance(node.this, exp.Literal) and node.this.is_string:
         return exp.Where(
-            this=exp.NEQ(
-                this=exp.Cast(this=node.this, to=exp.DataType.build("DOUBLE")),
-                expression=exp.Literal.number(0),
-            )
+            this=exp.NEQ(this=_mysql_string_as_number(node.this), expression=exp.Literal.number(0))
         )
     if isinstance(node, exp.Not) and isinstance(node.this, exp.Literal) and node.this.is_string:
-        return exp.EQ(
-            this=exp.Cast(this=node.this, to=exp.DataType.build("DOUBLE")),
-            expression=exp.Literal.number(0),
-        )
+        return exp.EQ(this=_mysql_string_as_number(node.this), expression=exp.Literal.number(0))
     # MySQL DATE_FORMAT %%D is 1st/2nd/3rd/4th. DuckDB %%D is not that.
     if isinstance(node, exp.TimeToStr):
         fmt = node.args.get("format")

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -266,6 +266,16 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT i, 1 AS foo, 2 AS bar FROM MyTable HAVING bar = 2",
 			expected: "SELECT i, 1 AS foo, 2 AS bar FROM MyTable HAVING 2 = 2",
 		},
+		{
+			name:     "string WHERE predicate is numeric nonzero",
+			input:    "SELECT i FROM mytable WHERE 'hello'",
+			expected: "SELECT i FROM mytable WHERE CAST('hello' AS DOUBLE) <> 0",
+		},
+		{
+			name:     "NOT string predicate is numeric zero",
+			input:    "SELECT i FROM mytable WHERE NOT 'hello'",
+			expected: "SELECT i FROM mytable WHERE CAST('hello' AS DOUBLE) = 0",
+		},
 	}
 
 	// Loop over each test case

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -269,12 +269,12 @@ func TestTranslate(t *testing.T) {
 		{
 			name:     "string WHERE predicate is numeric nonzero",
 			input:    "SELECT i FROM mytable WHERE 'hello'",
-			expected: "SELECT i FROM mytable WHERE CAST('hello' AS DOUBLE) <> 0",
+			expected: "SELECT i FROM mytable WHERE COALESCE(TRY_CAST('hello' AS DOUBLE), 0) <> 0",
 		},
 		{
 			name:     "NOT string predicate is numeric zero",
 			input:    "SELECT i FROM mytable WHERE NOT 'hello'",
-			expected: "SELECT i FROM mytable WHERE CAST('hello' AS DOUBLE) = 0",
+			expected: "SELECT i FROM mytable WHERE COALESCE(TRY_CAST('hello' AS DOUBLE), 0) = 0",
 		},
 	}
 


### PR DESCRIPTION
## Summary
MySQL treats `WHERE 'hello'` as `CAST('hello' AS DOUBLE) <> 0` (false). `NOT 'hello'` is the inverse.

Unskip the matching `TestQueriesSimple` cases.

## Test plan
- [x] `go test ./transpiler/`