### PR TITLE
fix: bare column WHERE predicates use TRY_CAST

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -257,24 +257,17 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_DISTINCT_CAST(i_AS_DECIMAL)_from_mytable;",
 		"SELECT_SUM(_DISTINCT_CAST(i_AS_DECIMAL))_from_mytable;",
 
-		"SELECT_i,v_from_stringandtable_WHERE_v",
-		"SELECT_i,v_from_stringandtable_WHERE_v_AND_v",
-		"SELECT_i,v_from_stringandtable_WHERE_v_OR_v",
-		"SELECT_i,v_from_stringandtable_WHERE_NOT_v",
-		"SELECT_i,v_from_stringandtable_WHERE_NOT_v_AND_NOT_v",
-		"SELECT_i,v_from_stringandtable_WHERE_NOT_v_OR_NOT_v",
-		"SELECT_i,v_from_stringandtable_WHERE_v_OR_NOT_v",
-		"SELECT_i,v_from_stringandtable_WHERE_v_XOR_v",
-		"SELECT_i,v_from_stringandtable_WHERE_NOT_v_XOR_NOT_v",
-		"SELECT_i,v_from_stringandtable_WHERE_v_XOR_NOT_v",
+
+
 		"select_pk,_________row_number()_over_(order_by_pk_desc),_________sum(v1)_over_(partition_by_v2_order_by_pk),_________percent_rank()_over(partition_by_v2_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 		"select_pk,____________________percent_rank()_over(partition_by_v2_order_by_pk),____________________dense_rank()_over(partition_by_v2_order_by_pk),____________________rank()_over(partition_by_v2_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 		"select_pk,_________first_value(pk)_over_(order_by_pk_desc),_________lag(pk,_1)_over_(order_by_pk_desc),_________count(pk)_over(partition_by_v1_order_by_pk),_________max(pk)_over(partition_by_v1_order_by_pk_desc),_________avg(v2)_over_(partition_by_v1_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 
+
+
 		"SELECT_s_>_2_FROM_tabletest",
 		"SELECT_*_FROM_tabletest_WHERE_s_>_0",
 		"SELECT_*_FROM_tabletest_WHERE_s_=_0",
-
 		"SELECT_SUM(i)_FROM_mytable",
 		"SELECT_RAND(i)_from_mytable_order_by_i",
 
@@ -296,7 +289,7 @@ func TestQueriesSimple(t *testing.T) {
 
 
 
-		"SELECT_i_FROM_mytable_WHERE_NOT_s_ORDER_BY_1_DESC",
+
 		"SELECT_sum(i)_as_isum,_s_FROM_mytable_GROUP_BY_i_ORDER_BY_isum_ASC_LIMIT_0,_200",
 		"SELECT_pk,_(SELECT_concat(pk,_pk)_FROM_one_pk_WHERE_pk_<_opk.pk_ORDER_BY_1_DESC_LIMIT_1)_as_strpk_FROM_one_pk_opk_having_strpk_>_\"0\"_ORDER_BY_2",
 		"SELECT_pk,_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_AS_x_FROM_one_pk_opk_GROUP_BY_x_ORDER_BY_x",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -421,6 +421,24 @@ def rewrite_mysql_for_duckdb(node):
         )
     if isinstance(node, exp.Not) and isinstance(node.this, exp.Literal) and node.this.is_string:
         return exp.EQ(this=_mysql_string_as_number(node.this), expression=exp.Literal.number(0))
+    # Bare column predicates: WHERE v / NOT v / v AND v.
+    if isinstance(node, exp.Where) and isinstance(node.this, exp.Column):
+        return exp.Where(
+            this=exp.NEQ(this=_mysql_string_as_number(node.this), expression=exp.Literal.number(0))
+        )
+    if isinstance(node, exp.Not) and isinstance(node.this, exp.Column):
+        return exp.EQ(this=_mysql_string_as_number(node.this), expression=exp.Literal.number(0))
+    if isinstance(node, (exp.And, exp.Or)):
+        left, right = node.this, node.expression
+        changed = False
+        if isinstance(left, exp.Column):
+            left = exp.NEQ(this=_mysql_string_as_number(left), expression=exp.Literal.number(0))
+            changed = True
+        if isinstance(right, exp.Column):
+            right = exp.NEQ(this=_mysql_string_as_number(right), expression=exp.Literal.number(0))
+            changed = True
+        if changed:
+            return node.__class__(this=left, expression=right)
     # MySQL DATE_FORMAT %%D is 1st/2nd/3rd/4th. DuckDB %%D is not that.
     if isinstance(node, exp.TimeToStr):
         fmt = node.args.get("format")

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -276,6 +276,11 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT i FROM mytable WHERE NOT 'hello'",
 			expected: "SELECT i FROM mytable WHERE COALESCE(TRY_CAST('hello' AS DOUBLE), 0) = 0",
 		},
+		{
+			name:     "bare column WHERE is numeric nonzero",
+			input:    "SELECT i, v FROM stringandtable WHERE v",
+			expected: "SELECT i, v FROM stringandtable WHERE COALESCE(TRY_CAST(v AS DOUBLE), 0) <> 0",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
Follow-up to #391. Bare column predicates (`WHERE v`, `NOT v`, `v AND v`) become `COALESCE(TRY_CAST(v AS DOUBLE), 0) <> 0`.

`id = 1` comparisons are left alone.

Unskip the matching `stringandtable` / `NOT s` cases.

## Test plan
- [x] `go test ./transpiler/`