### PR TITLE
fix: MySQL string OR and bitwise TRUE/FALSE are numeric

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -231,10 +231,6 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_NOT_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_emptytable);",
 		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_NOT_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_mytable_WHERE_false);",
 
-
-
-
-
 		"SELECT_a.column_0,_mt.s_from_(values_row(1,\"1\"),_row(2,\"2\"),_row(4,\"4\"))_a____left_join_mytable_mt_on_column_0_=_mt.i____order_by_1",
 
 		"select_i+0.0/(lag(i)_over_(order_by_s))_from_mytable_order_by_1;",
@@ -245,25 +241,15 @@ func TestQueriesSimple(t *testing.T) {
 		"WITH_mytable_as_(select_*_FROM_mytable_where_i_>_2)_SELECT_*_FROM_mytable_union_SELECT_*_from_mytable;",
 
 		"SELECT_reservedWordsTable.AND,_reservedWordsTABLE.Or,_reservedwordstable.SEleCT_FROM_reservedWordsTable;",
-		"SELECT_*_from_mytable_where_(i_=_1_|_false)_IN_(true)",
-		"SELECT_*_from_mytable_where_(i_=_1_&_false)_IN_(true)",
 
 		"select_i_from_datetime_table_where_date_col_=_'2019-12-31T00:00:01'",
-
-
-
-
 
 		"SELECT_DISTINCT_CAST(i_AS_DECIMAL)_from_mytable;",
 		"SELECT_SUM(_DISTINCT_CAST(i_AS_DECIMAL))_from_mytable;",
 
-
-
 		"select_pk,_________row_number()_over_(order_by_pk_desc),_________sum(v1)_over_(partition_by_v2_order_by_pk),_________percent_rank()_over(partition_by_v2_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 		"select_pk,____________________percent_rank()_over(partition_by_v2_order_by_pk),____________________dense_rank()_over(partition_by_v2_order_by_pk),____________________rank()_over(partition_by_v2_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 		"select_pk,_________first_value(pk)_over_(order_by_pk_desc),_________lag(pk,_1)_over_(order_by_pk_desc),_________count(pk)_over(partition_by_v1_order_by_pk),_________max(pk)_over(partition_by_v1_order_by_pk_desc),_________avg(v2)_over_(partition_by_v1_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
-
-
 
 		"SELECT_s_>_2_FROM_tabletest",
 		"SELECT_*_FROM_tabletest_WHERE_s_>_0",
@@ -275,20 +261,9 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_ACOS(i)_from_mytable_order_by_i_limit_1",
 		"SELECT_CRC32(i)_from_mytable_order_by_i_limit_1",
 
-
-
-
-
 		"SELECT_CASE_WHEN_i_>_2_THEN_i_WHEN_i_<_2_THEN_i_ELSE_'two'_END_FROM_mytable",
 		"SELECT_CASE_WHEN_i_>_2_THEN_'more_than_two'_WHEN_i_<_2_THEN_'less_than_two'_ELSE_2_END_FROM_mytable",
 		"SELECT_substring(mytable.s,_1,_5)_AS_s_FROM_mytable_INNER_JOIN_othertable_ON_(substring(mytable.s,_1,_5)_=_SUBSTRING(othertable.s2,_1,_5))_GROUP_BY_1_HAVING_s_=_\"secon\"",
-
-
-
-
-
-
-
 
 		"SELECT_sum(i)_as_isum,_s_FROM_mytable_GROUP_BY_i_ORDER_BY_isum_ASC_LIMIT_0,_200",
 		"SELECT_pk,_(SELECT_concat(pk,_pk)_FROM_one_pk_WHERE_pk_<_opk.pk_ORDER_BY_1_DESC_LIMIT_1)_as_strpk_FROM_one_pk_opk_having_strpk_>_\"0\"_ORDER_BY_2",
@@ -302,24 +277,18 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_pk,_row_number()_over_(partition_by_v2_order_by_pk_),_max(v3)_over_(partition_by_v2_order_by_pk)_FROM_one_pk_three_idx_ORDER_BY_pk",
 
 		"SELECT_distinct_pk1_FROM_two_pk_WHERE_EXISTS_(SELECT_pk_from_one_pk_where_pk_<=_two_pk.pk1)",
-		"select_c1_from_jsontable_where_c1_LIKE_(('%'_OR_'dsads')_OR_'%')",
-		"select_c1_from_jsontable_where_c1_LIKE_('%'_OR_NULL)",
+
 		"show_function_status",
 		"show_function_status_like_'foo'",
 		"show_function_status_where_Db='mydb'",
-
 
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_keyless_U0,_cte___WHERE_cte.j_=_keyless.c0____)_____ORDER_BY_c0;_",
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_cte,_keyless_U0____WHERE_cte.j_=_keyless.c0_____)_____ORDER_BY_c0;_",
 		"_select_*_from_mytable,__lateral_(__with_recursive_cte(a)_as_(___select_y_from_xy___union___select_x_from_cte___join___(____select_*_____from_xy____where_x_=_1____)_sqa1___on_x_=_a___limit_3___)__select_*_from_cte_)_sqa2_where_i_=_a_order_by_i;",
 		"_select____dayname(id),____dayname(i8),____dayname(i16),____dayname(i32),____dayname(i64),____dayname(u8),____dayname(u16),____dayname(u32),____dayname(u64),____dayname(f32),____dayname(f64),____dayname(ti),____dayname(da),____dayname(te),____dayname(bo),____dayname(js),____dayname(bl),____dayname(e1),____dayname(s1)_from_typestable",
 		"select_*_from_mytable_order_by_dayname(i)",
-		"select_*_from_mytable_where_(i_BETWEEN_(CASE_1_WHEN_2_THEN_1.0_ELSE_(1||2)_END)_AND_i)",
 		"select_*_from_mytable_where_(i_BETWEEN_(''_BETWEEN_''_AND_(''_OR_'#'))_AND_i)",
 		"select_*_from_xy_inner_join_uv_on_(xy.x_in_(false_in_('asdf')));",
-
-
-
 
 		"select_length(random_bytes(i))_from_mytable;",
 	}

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -428,16 +428,48 @@ def rewrite_mysql_for_duckdb(node):
         )
     if isinstance(node, exp.Not) and isinstance(node.this, exp.Column):
         return exp.EQ(this=_mysql_string_as_number(node.this), expression=exp.Literal.number(0))
+    def _mysql_truthy(e):
+        # MySQL AND/OR coerce strings and numbers: invalid strings are 0.
+        if isinstance(e, exp.Column) or (isinstance(e, exp.Literal) and (e.is_string or e.is_number)):
+            return exp.NEQ(this=_mysql_string_as_number(e), expression=exp.Literal.number(0))
+        return None
     if isinstance(node, (exp.And, exp.Or)):
-        left, right = node.this, node.expression
+        # Transform is pre-order; rewrite nested OR/AND before coercing this node.
+        left = node.this.transform(rewrite_mysql_for_duckdb) if node.this is not None else node.this
+        right = node.expression.transform(rewrite_mysql_for_duckdb) if node.expression is not None else node.expression
         changed = False
-        if isinstance(left, exp.Column):
-            left = exp.NEQ(this=_mysql_string_as_number(left), expression=exp.Literal.number(0))
+        new_left = _mysql_truthy(left)
+        if new_left is not None:
+            left = new_left
             changed = True
-        if isinstance(right, exp.Column):
-            right = exp.NEQ(this=_mysql_string_as_number(right), expression=exp.Literal.number(0))
+        new_right = _mysql_truthy(right)
+        if new_right is not None:
+            right = new_right
             changed = True
+        cond = node.__class__(this=left, expression=right)
         if changed:
+            # MySQL AND/OR yield 0/1/NULL, used as LIKE patterns and BETWEEN bounds.
+            return exp.Cast(this=cond, to=exp.DataType.build("INT"))
+        return cond
+    # LIKE 0 must match the string '0', not a boolean.
+    # Transform is pre-order; rewrite the pattern first so string OR becomes 0/1.
+    if isinstance(node, exp.Like):
+        this = node.this.transform(rewrite_mysql_for_duckdb) if node.this is not None else node.this
+        pat = node.args.get("expression")
+        if pat is not None:
+            pat = pat.transform(rewrite_mysql_for_duckdb)
+        core = pat.this if isinstance(pat, exp.Paren) else pat
+        if not (isinstance(core, exp.Literal) and core.is_string):
+            pat = exp.Cast(this=pat, to=exp.DataType.build("TEXT"))
+        return exp.Like(this=this, expression=pat)
+    # MySQL TRUE/FALSE are 1/0 in bitwise operators. DuckDB rejects BOOLEAN | INTEGER.
+    def _bool_to_int(e):
+        if isinstance(e, exp.Boolean):
+            return exp.Literal.number(1 if e.this else 0)
+        return e
+    if isinstance(node, (exp.BitwiseOr, exp.BitwiseAnd, exp.BitwiseXor)):
+        left, right = _bool_to_int(node.this), _bool_to_int(node.expression)
+        if left is not node.this or right is not node.expression:
             return node.__class__(this=left, expression=right)
     # MySQL DATE_FORMAT %%D is 1st/2nd/3rd/4th. DuckDB %%D is not that.
     if isinstance(node, exp.TimeToStr):

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -281,6 +281,31 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT i, v FROM stringandtable WHERE v",
 			expected: "SELECT i, v FROM stringandtable WHERE COALESCE(TRY_CAST(v AS DOUBLE), 0) <> 0",
 		},
+		{
+			name:     "string OR is numeric 0/1 for LIKE",
+			input:    "SELECT c1 FROM jsontable WHERE c1 LIKE (('%' OR 'dsads') OR '%')",
+			expected: "SELECT c1 FROM jsontable WHERE c1 LIKE CAST((CAST((CAST(COALESCE(TRY_CAST('%' AS DOUBLE), 0) <> 0 OR COALESCE(TRY_CAST('dsads' AS DOUBLE), 0) <> 0 AS INT)) OR COALESCE(TRY_CAST('%' AS DOUBLE), 0) <> 0 AS INT)) AS TEXT)",
+		},
+		{
+			name:     "string OR NULL is numeric for LIKE",
+			input:    "SELECT c1 FROM jsontable WHERE c1 LIKE ('%' OR NULL)",
+			expected: "SELECT c1 FROM jsontable WHERE c1 LIKE CAST((CAST(COALESCE(TRY_CAST('%' AS DOUBLE), 0) <> 0 OR NULL AS INT)) AS TEXT)",
+		},
+		{
+			name:     "numeric OR in CASE is 0/1",
+			input:    "SELECT CASE 1 WHEN 2 THEN 1.0 ELSE (1||2) END",
+			expected: "SELECT CASE 1 WHEN 2 THEN 1.0 ELSE (CAST(COALESCE(TRY_CAST(1 AS DOUBLE), 0) <> 0 OR COALESCE(TRY_CAST(2 AS DOUBLE), 0) <> 0 AS INT)) END",
+		},
+		{
+			name:     "bitwise OR FALSE is 0",
+			input:    "SELECT * FROM mytable WHERE (i = 1 | FALSE) IN (TRUE)",
+			expected: "SELECT * FROM mytable WHERE (i = 1 | 0) IN (TRUE)",
+		},
+		{
+			name:     "bitwise AND FALSE is 0",
+			input:    "SELECT * FROM mytable WHERE (i = 1 & FALSE) IN (TRUE)",
+			expected: "SELECT * FROM mytable WHERE (i = 1 & 0) IN (TRUE)",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
MySQL coerces strings in `AND`/`OR` to numbers (invalid strings are 0) and treats `TRUE`/`FALSE` as 1/0 in bitwise operators. DuckDB rejects both.

- `'%' OR 'dsads'` becomes `CAST(... TRY_CAST ... <> 0 AS INT)` so `LIKE` gets `'0'`/`'1'`/`NULL`
- `1 | FALSE` / `1 & FALSE` become `1 | 0` / `1 & 0`

Unskip the matching LIKE-OR, bitwise, and `1||2` CASE BETWEEN queries.

## Test plan
- [x] `go test ./transpiler/`