### PR TITLE
fix: MySQL ASIN/ACOS return NULL outside [-1, 1]

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -257,8 +257,6 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_SUM(i)_FROM_mytable",
 		"SELECT_RAND(i)_from_mytable_order_by_i",
 
-		"SELECT_ASIN(i)_from_mytable_order_by_i_limit_1",
-		"SELECT_ACOS(i)_from_mytable_order_by_i_limit_1",
 		"SELECT_CRC32(i)_from_mytable_order_by_i_limit_1",
 
 		"SELECT_CASE_WHEN_i_>_2_THEN_i_WHEN_i_<_2_THEN_i_ELSE_'two'_END_FROM_mytable",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -406,6 +406,14 @@ def rewrite_mysql_for_duckdb(node):
     # MySQL DATETIME('...') is a timestamp constructor. DuckDB has no DATETIME().
     if isinstance(node, exp.Datetime):
         return exp.Cast(this=node.this, to=exp.DataType.build("TIMESTAMP"))
+    # MySQL ASIN/ACOS return NULL outside [-1, 1]. DuckDB errors.
+    if isinstance(node, (exp.Asin, exp.Acos)):
+        x = node.this.transform(rewrite_mysql_for_duckdb) if node.this is not None else node.this
+        return exp.If(
+            this=exp.GT(this=exp.Abs(this=x), expression=exp.Literal.number(1)),
+            true=exp.Null(),
+            false=node.__class__(this=x),
+        )
     # MySQL treats a string predicate as a number: invalid strings are 0, not an error.
     def _mysql_string_as_number(e):
         return exp.Anonymous(

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -306,6 +306,16 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT * FROM mytable WHERE (i = 1 & FALSE) IN (TRUE)",
 			expected: "SELECT * FROM mytable WHERE (i = 1 & 0) IN (TRUE)",
 		},
+		{
+			name:     "ASIN outside [-1,1] is NULL",
+			input:    "SELECT ASIN(i) FROM mytable",
+			expected: "SELECT CASE WHEN ABS(i) > 1 THEN NULL ELSE ASIN(i) END FROM mytable",
+		},
+		{
+			name:     "ACOS outside [-1,1] is NULL",
+			input:    "SELECT ACOS(i) FROM mytable",
+			expected: "SELECT CASE WHEN ABS(i) > 1 THEN NULL ELSE ACOS(i) END FROM mytable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
MySQL `ASIN`/`ACOS` return NULL when `abs(x) > 1`. DuckDB errors.

Rewrite to `CASE WHEN ABS(x) > 1 THEN NULL ELSE ASIN(x) END` (same for ACOS).

Unskip `SELECT ASIN(i)` / `SELECT ACOS(i)` from mytable.

## Test plan
- [x] `go test ./transpiler/`