### PR TITLE
fix: compare string columns to numbers via TRY_CAST

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -251,8 +251,6 @@ func TestQueriesSimple(t *testing.T) {
 		"select_pk,____________________percent_rank()_over(partition_by_v2_order_by_pk),____________________dense_rank()_over(partition_by_v2_order_by_pk),____________________rank()_over(partition_by_v2_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 		"select_pk,_________first_value(pk)_over_(order_by_pk_desc),_________lag(pk,_1)_over_(order_by_pk_desc),_________count(pk)_over(partition_by_v1_order_by_pk),_________max(pk)_over(partition_by_v1_order_by_pk_desc),_________avg(v2)_over_(partition_by_v1_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 
-		"SELECT_s_>_2_FROM_tabletest",
-		"SELECT_*_FROM_tabletest_WHERE_s_>_0",
 		"SELECT_*_FROM_tabletest_WHERE_s_=_0",
 		"SELECT_SUM(i)_FROM_mytable",
 		"SELECT_RAND(i)_from_mytable_order_by_i",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -436,6 +436,24 @@ def rewrite_mysql_for_duckdb(node):
         )
     if isinstance(node, exp.Not) and isinstance(node.this, exp.Column):
         return exp.EQ(this=_mysql_string_as_number(node.this), expression=exp.Literal.number(0))
+    # MySQL compares strings to numbers by coercing the string (invalid -> 0).
+    # Do not rewrite id = 1; only inequalities may coerce a column.
+    if isinstance(node, (exp.GT, exp.GTE, exp.LT, exp.LTE, exp.EQ, exp.NEQ)):
+        left, right = node.this, node.expression
+        def _is_num_lit(e):
+            return isinstance(e, exp.Literal) and e.is_number
+        def _is_str_lit(e):
+            return isinstance(e, exp.Literal) and e.is_string
+        def _needs_num(e):
+            if _is_str_lit(e):
+                return True
+            if isinstance(e, exp.Column) and isinstance(node, (exp.GT, exp.GTE, exp.LT, exp.LTE)):
+                return True
+            return False
+        if _needs_num(left) and _is_num_lit(right):
+            return node.__class__(this=_mysql_string_as_number(left), expression=right)
+        if _is_num_lit(left) and _needs_num(right):
+            return node.__class__(this=left, expression=_mysql_string_as_number(right))
     def _mysql_truthy(e):
         # MySQL AND/OR coerce strings and numbers: invalid strings are 0.
         if isinstance(e, exp.Column) or (isinstance(e, exp.Literal) and (e.is_string or e.is_number)):

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -316,6 +316,16 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT ACOS(i) FROM mytable",
 			expected: "SELECT CASE WHEN ABS(i) > 1 THEN NULL ELSE ACOS(i) END FROM mytable",
 		},
+		{
+			name:     "string column compared to number is numeric",
+			input:    "SELECT s > 2 FROM tabletest",
+			expected: "SELECT COALESCE(TRY_CAST(s AS DOUBLE), 0) > 2 FROM tabletest",
+		},
+		{
+			name:     "id = 1 is left alone",
+			input:    "SELECT i FROM mytable WHERE id = 1",
+			expected: "SELECT i FROM mytable WHERE id = 1",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
MySQL coerces strings in inequalities to numbers (invalid strings are 0). DuckDB errors on `'second row' > 2`.

Rewrite `s > 2` to `COALESCE(TRY_CAST(s AS DOUBLE), 0) > 2`.

`id = 1` is left alone.

Unskip `SELECT s > 2` / `WHERE s > 0` on tabletest. `WHERE s = 0` stays skipped.

## Test plan
- [x] `go test ./transpiler/`