### PR TITLE
fix: CAST mixed MySQL CASE branches to TEXT

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -257,8 +257,6 @@ func TestQueriesSimple(t *testing.T) {
 
 		"SELECT_CRC32(i)_from_mytable_order_by_i_limit_1",
 
-		"SELECT_CASE_WHEN_i_>_2_THEN_i_WHEN_i_<_2_THEN_i_ELSE_'two'_END_FROM_mytable",
-		"SELECT_CASE_WHEN_i_>_2_THEN_'more_than_two'_WHEN_i_<_2_THEN_'less_than_two'_ELSE_2_END_FROM_mytable",
 		"SELECT_substring(mytable.s,_1,_5)_AS_s_FROM_mytable_INNER_JOIN_othertable_ON_(substring(mytable.s,_1,_5)_=_SUBSTRING(othertable.s2,_1,_5))_GROUP_BY_1_HAVING_s_=_\"secon\"",
 
 		"SELECT_sum(i)_as_isum,_s_FROM_mytable_GROUP_BY_i_ORDER_BY_isum_ASC_LIMIT_0,_200",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -414,6 +414,46 @@ def rewrite_mysql_for_duckdb(node):
             true=exp.Null(),
             false=node.__class__(this=x),
         )
+    # MySQL CASE allows mixed string/number results. DuckDB requires one type.
+    if isinstance(node, exp.Case):
+        ifs = list(node.args.get("ifs") or [])
+        new_ifs = []
+        for iff in ifs:
+            cond = iff.args.get("this")
+            true = iff.args.get("true")
+            if cond is not None:
+                cond = cond.transform(rewrite_mysql_for_duckdb)
+            if true is not None:
+                true = true.transform(rewrite_mysql_for_duckdb)
+            new_ifs.append(exp.If(this=cond, true=true))
+        default = node.args.get("default")
+        if default is not None:
+            default = default.transform(rewrite_mysql_for_duckdb)
+        this = node.this.transform(rewrite_mysql_for_duckdb) if node.this is not None else None
+        branches = [iff.args.get("true") for iff in new_ifs]
+        if default is not None:
+            branches.append(default)
+        def _is_str(e):
+            return isinstance(e, exp.Literal) and e.is_string
+        has_str = any(_is_str(b) for b in branches if b is not None)
+        has_other = any(b is not None and not _is_str(b) for b in branches)
+        if has_str and has_other:
+            def _as_text(e):
+                if e is None:
+                    return e
+                return exp.Cast(this=e, to=exp.DataType.build("TEXT"))
+            new_ifs = [
+                exp.If(this=iff.args.get("this"), true=_as_text(iff.args.get("true")))
+                for iff in new_ifs
+            ]
+            if default is not None:
+                default = _as_text(default)
+        args = {"ifs": new_ifs}
+        if this is not None:
+            args["this"] = this
+        if default is not None:
+            args["default"] = default
+        return exp.Case(**args)
     # MySQL treats a string predicate as a number: invalid strings are 0, not an error.
     def _mysql_string_as_number(e):
         return exp.Anonymous(

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -326,6 +326,11 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT i FROM mytable WHERE id = 1",
 			expected: "SELECT i FROM mytable WHERE id = 1",
 		},
+		{
+			name:     "CASE mixed int and string casts to text",
+			input:    "SELECT CASE WHEN i > 2 THEN i ELSE 'two' END FROM mytable",
+			expected: "SELECT CASE WHEN COALESCE(TRY_CAST(i AS DOUBLE), 0) > 2 THEN CAST(i AS TEXT) ELSE CAST('two' AS TEXT) END FROM mytable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
MySQL `CASE` allows mixed string/number results (`THEN i ELSE 'two'`). DuckDB requires one type.

Cast mixed branches to TEXT. `CASE` conditions still use existing rewrites (`i > 2` → TRY_CAST).

Unskip the two mixed `CASE WHEN i > 2` queries.

## Test plan
- [x] `go test ./transpiler/`