### PR TITLE
fix: coerce mixed MySQL IN and BETWEEN to numbers

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -281,8 +281,6 @@ func TestQueriesSimple(t *testing.T) {
 		"_select_*_from_mytable,__lateral_(__with_recursive_cte(a)_as_(___select_y_from_xy___union___select_x_from_cte___join___(____select_*_____from_xy____where_x_=_1____)_sqa1___on_x_=_a___limit_3___)__select_*_from_cte_)_sqa2_where_i_=_a_order_by_i;",
 		"_select____dayname(id),____dayname(i8),____dayname(i16),____dayname(i32),____dayname(i64),____dayname(u8),____dayname(u16),____dayname(u32),____dayname(u64),____dayname(f32),____dayname(f64),____dayname(ti),____dayname(da),____dayname(te),____dayname(bo),____dayname(js),____dayname(bl),____dayname(e1),____dayname(s1)_from_typestable",
 		"select_*_from_mytable_order_by_dayname(i)",
-		"select_*_from_mytable_where_(i_BETWEEN_(''_BETWEEN_''_AND_(''_OR_'#'))_AND_i)",
-		"select_*_from_xy_inner_join_uv_on_(xy.x_in_(false_in_('asdf')));",
 
 		"select_length(random_bytes(i))_from_mytable;",
 	}

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -494,6 +494,61 @@ def rewrite_mysql_for_duckdb(node):
             return node.__class__(this=_mysql_string_as_number(left), expression=right)
         if _is_num_lit(left) and _needs_num(right):
             return node.__class__(this=left, expression=_mysql_string_as_number(right))
+    # MySQL BETWEEN / IN coerce mixed strings, numbers, and booleans to numbers.
+    def _unwrap_paren(e):
+        while isinstance(e, exp.Paren):
+            e = e.this
+        return e
+    def _bool_to_int(e):
+        if isinstance(e, exp.Boolean):
+            return exp.Literal.number(1 if e.this else 0)
+        return e
+    def _lit_str_to_num(e):
+        e = _unwrap_paren(e)
+        if isinstance(e, exp.Literal) and e.is_string:
+            return _mysql_string_as_number(e)
+        return _bool_to_int(e)
+    if isinstance(node, exp.Between):
+        this = node.this.transform(rewrite_mysql_for_duckdb) if node.this is not None else node.this
+        low = node.args.get("low")
+        high = node.args.get("high")
+        if low is not None:
+            low = low.transform(rewrite_mysql_for_duckdb)
+        if high is not None:
+            high = high.transform(rewrite_mysql_for_duckdb)
+        cores = (_unwrap_paren(this), _unwrap_paren(low), _unwrap_paren(high))
+        has_str = any(isinstance(e, exp.Literal) and e.is_string for e in cores)
+        has_num = any(
+            e is not None and (
+                (isinstance(e, exp.Literal) and e.is_number)
+                or isinstance(e, (exp.Cast, exp.Boolean))
+            )
+            for e in cores
+        )
+        if has_str and has_num:
+            this, low, high = _lit_str_to_num(this), _lit_str_to_num(low), _lit_str_to_num(high)
+            return exp.Cast(
+                this=exp.Between(this=this, low=low, high=high),
+                to=exp.DataType.build("INT"),
+            )
+        return exp.Between(this=this, low=low, high=high)
+    if isinstance(node, exp.In):
+        this = node.this.transform(rewrite_mysql_for_duckdb) if node.this is not None else node.this
+        exprs = [
+            e.transform(rewrite_mysql_for_duckdb) if e is not None else e
+            for e in list(node.expressions or [])
+        ]
+        parts = [this] + exprs
+        has_bool = any(isinstance(e, exp.Boolean) for e in parts)
+        has_str = any(isinstance(e, exp.Literal) and e.is_string for e in parts)
+        if has_bool and has_str:
+            this = _lit_str_to_num(this)
+            exprs = [_lit_str_to_num(e) for e in exprs]
+            return exp.Cast(
+                this=exp.In(this=this, expressions=exprs),
+                to=exp.DataType.build("INT"),
+            )
+        return exp.In(this=this, expressions=exprs)
     def _mysql_truthy(e):
         # MySQL AND/OR coerce strings and numbers: invalid strings are 0.
         if isinstance(e, exp.Column) or (isinstance(e, exp.Literal) and (e.is_string or e.is_number)):

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -331,6 +331,16 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT CASE WHEN i > 2 THEN i ELSE 'two' END FROM mytable",
 			expected: "SELECT CASE WHEN COALESCE(TRY_CAST(i AS DOUBLE), 0) > 2 THEN CAST(i AS TEXT) ELSE CAST('two' AS TEXT) END FROM mytable",
 		},
+		{
+			name:     "FALSE IN string is numeric",
+			input:    "SELECT * FROM xy INNER JOIN uv ON (xy.x IN (FALSE IN ('asdf')))",
+			expected: "SELECT * FROM xy INNER JOIN uv ON (xy.x IN (CAST(0 IN (COALESCE(TRY_CAST('asdf' AS DOUBLE), 0)) AS INT)))",
+		},
+		{
+			name:     "mixed string BETWEEN is numeric",
+			input:    "SELECT * FROM mytable WHERE (i BETWEEN ('' BETWEEN '' AND ('' OR '#')) AND i)",
+			expected: "SELECT * FROM mytable WHERE (i BETWEEN (CAST(COALESCE(TRY_CAST('' AS DOUBLE), 0) BETWEEN COALESCE(TRY_CAST('' AS DOUBLE), 0) AND CAST(COALESCE(TRY_CAST('' AS DOUBLE), 0) <> 0 OR COALESCE(TRY_CAST('#' AS DOUBLE), 0) <> 0 AS INT) AS INT)) AND i)",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
MySQL coerces mixed `IN` / `BETWEEN` operands to numbers:
- `FALSE IN ('asdf')` is `0 IN (0)`
- `'' BETWEEN '' AND 0` is `0 BETWEEN 0 AND 0`

DuckDB rejects BOOLEAN/VARCHAR/INTEGER mixes. Coerce strings and booleans, then `CAST(... AS INT)` so the result can be used as a bound.

Unskip the matching `jsontable`/`xy` queries.

## Test plan
- [x] `go test ./transpiler/`