### PR TITLE
fix: DAYNAME accepts non-dates via TRY_CAST and YYYYMMDD

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -277,8 +277,6 @@ func TestQueriesSimple(t *testing.T) {
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_keyless_U0,_cte___WHERE_cte.j_=_keyless.c0____)_____ORDER_BY_c0;_",
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_cte,_keyless_U0____WHERE_cte.j_=_keyless.c0_____)_____ORDER_BY_c0;_",
 		"_select_*_from_mytable,__lateral_(__with_recursive_cte(a)_as_(___select_y_from_xy___union___select_x_from_cte___join___(____select_*_____from_xy____where_x_=_1____)_sqa1___on_x_=_a___limit_3___)__select_*_from_cte_)_sqa2_where_i_=_a_order_by_i;",
-		"_select____dayname(id),____dayname(i8),____dayname(i16),____dayname(i32),____dayname(i64),____dayname(u8),____dayname(u16),____dayname(u32),____dayname(u64),____dayname(f32),____dayname(f64),____dayname(ti),____dayname(da),____dayname(te),____dayname(bo),____dayname(js),____dayname(bl),____dayname(e1),____dayname(s1)_from_typestable",
-		"select_*_from_mytable_order_by_dayname(i)",
 
 		"select_length(random_bytes(i))_from_mytable;",
 	}

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -414,6 +414,28 @@ def rewrite_mysql_for_duckdb(node):
             true=exp.Null(),
             false=node.__class__(this=x),
         )
+    # MySQL DAYNAME accepts many types; integers are YYYYMMDD. DuckDB only DATE/TIMESTAMP.
+    if isinstance(node, exp.Dayname):
+        x = node.this.transform(rewrite_mysql_for_duckdb) if node.this is not None else node.this
+        as_ts = exp.TryCast(this=x, to=exp.DataType.build("TIMESTAMP"))
+        as_ymd = exp.Anonymous(
+            this="try_strptime",
+            expressions=[
+                exp.Anonymous(
+                    this="lpad",
+                    expressions=[
+                        exp.TryCast(this=x, to=exp.DataType.build("TEXT")),
+                        exp.Literal.number(8),
+                        exp.Literal.string("0"),
+                    ],
+                ),
+                exp.Literal.string("%%Y%%m%%d"),
+            ],
+        )
+        return exp.Anonymous(
+            this="dayname",
+            expressions=[exp.Anonymous(this="coalesce", expressions=[as_ts, as_ymd])],
+        )
     # MySQL CASE allows mixed string/number results. DuckDB requires one type.
     if isinstance(node, exp.Case):
         ifs = list(node.args.get("ifs") or [])

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -351,6 +351,11 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT i FROM datetime_table WHERE date_col = '2019-12-31T00:00:01'",
 			expected: "SELECT i FROM datetime_table WHERE date_col = CAST('2019-12-31T00:00:01' AS TIMESTAMP)",
 		},
+		{
+			name:     "DAYNAME accepts non-dates",
+			input:    "SELECT DAYNAME(i) FROM mytable",
+			expected: "SELECT DAYNAME(COALESCE(TRY_CAST(i AS TIMESTAMP), TRY_STRPTIME(LPAD(TRY_CAST(i AS TEXT), 8, '0'), '%Y%m%d'))) FROM mytable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
DuckDB `DAYNAME` only takes DATE/TIMESTAMP. MySQL also accepts integers as `YYYYMMDD` and returns NULL for junk.

Rewrite to `DAYNAME(COALESCE(TRY_CAST(x AS TIMESTAMP), TRY_STRPTIME(LPAD(TRY_CAST(x AS TEXT), 8, '0'), '%Y%m%d')))`.

Unskip `DAYNAME` over typestable and `ORDER BY DAYNAME(i)`.

## Test plan
- [x] `go test ./transpiler/`