### PR TITLE
fix: JSON_KEYS uses TRY_CAST so bad JSON is NULL

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -297,7 +297,6 @@ func TestQueriesSimple(t *testing.T) {
 		"select_now()_=_sysdate(),_sleep(0.1),_now(6)_<_sysdate(6);")
 
 	panicQueries := []string{
-		"SELECT_JSON_KEYS(c3)_FROM_jsontable",
 		"SELECT_(SELECT_s_FROM_mytable_ORDER_BY_i_ASC_LIMIT_1)_AS_x",
 	}
 

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -332,6 +332,13 @@ def rewrite_mysql_for_duckdb(node):
             this="json_pretty",
             expressions=[exp.Cast(this=node.expressions[0], to=exp.DataType.build("JSON"))],
         )
+    # MySQL JSON_KEYS returns NULL on bad JSON. DuckDB json_keys errors.
+    if isinstance(node, exp.JSONKeys):
+        inner = node.this.transform(rewrite_mysql_for_duckdb) if node.this is not None else node.this
+        return exp.Anonymous(
+            this="json_keys",
+            expressions=[exp.TryCast(this=inner, to=exp.DataType.build("JSON"))],
+        )
     # MySQL accepts YYYYMMDD date strings; DuckDB DATE needs YYYY-MM-DD.
     def _compact_date_literal(e):
         if isinstance(e, exp.Literal) and e.is_string:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -356,6 +356,11 @@ func TestTranslate(t *testing.T) {
 			input:    "SELECT DAYNAME(i) FROM mytable",
 			expected: "SELECT DAYNAME(COALESCE(TRY_CAST(i AS TIMESTAMP), TRY_STRPTIME(LPAD(TRY_CAST(i AS TEXT), 8, '0'), '%Y%m%d'))) FROM mytable",
 		},
+		{
+			name:     "JSON_KEYS uses TRY_CAST",
+			input:    "SELECT JSON_KEYS(c3) FROM jsontable",
+			expected: "SELECT JSON_KEYS(TRY_CAST(c3 AS JSON)) FROM jsontable",
+		},
 	}
 
 	// Loop over each test case


### PR DESCRIPTION
## Summary
DuckDB `json_keys` errors on malformed JSON. MySQL `JSON_KEYS` returns NULL.

Rewrite to `JSON_KEYS(TRY_CAST(c3 AS JSON))`.

Unskip `SELECT JSON_KEYS(c3) FROM jsontable` (was a panic skip).

## Test plan
- [x] `go test ./transpiler/`