### PR TITLE
fix: do not wrap constant SELECT items with ANY_VALUE

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -225,7 +225,6 @@ func TestQueriesSimple(t *testing.T) {
 	waitForFixQueries := []string{
 		"_Select_x_from_(select_*_from_xy)_sq1_union_all_select_u_from_(select_*_from_uv)_sq2_limit_1_offset_1;",
 
-		"SELECT_count(*),_i,_concat(i,_i),_123,_'abc',_concat('abc',_'def')_FROM_emptytable;",
 		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_emptytable);",
 		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_mytable_WHERE_false);",
 		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_NOT_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_emptytable);",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -845,10 +845,12 @@ def rewrite_mysql_for_duckdb(node):
         def _already_any_value(e):
             inner = e.this if isinstance(e, exp.Alias) else e
             return isinstance(inner, exp.Anonymous) and str(inner.this).lower() == "any_value"
+        def _has_column(e):
+            return any(isinstance(x, exp.Column) for x in e.walk())
         if exprs and any(_has_agg(e) for e in exprs) and any(not _has_agg(e) for e in exprs):
             new_exprs = []
             for e in exprs:
-                if _has_agg(e) or isinstance(e, exp.Star) or _already_any_value(e):
+                if _has_agg(e) or isinstance(e, exp.Star) or _already_any_value(e) or not _has_column(e):
                     new_exprs.append(e)
                     continue
                 alias = e.alias if isinstance(e, exp.Alias) else None
@@ -884,8 +886,10 @@ def rewrite_mysql_for_duckdb(node):
             return inner.sql(dialect="duckdb").lower() in group_keys
         new_exprs = []
         changed = False
+        def _has_column(e):
+            return any(isinstance(x, exp.Column) for x in e.walk())
         for idx, e in enumerate(exprs, 1):
-            if _has_agg(e) or isinstance(e, exp.Star) or _already_any_value(e) or _in_group(e, idx):
+            if _has_agg(e) or isinstance(e, exp.Star) or _already_any_value(e) or _in_group(e, idx) or not _has_column(e):
                 new_exprs.append(e)
                 continue
             alias = e.alias if isinstance(e, exp.Alias) else None

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -82,6 +82,11 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT ANY_VALUE(pk1), SUM(c1) FROM two_pk WHERE pk1 = 0",
 		},
 		{
+			name:     "aggregate leaves constant select items unwrapped",
+			input:    "SELECT count(*), i, concat(i, i), 123, 'abc', concat('abc', 'def') FROM emptytable",
+			expected: "SELECT COUNT(*), ANY_VALUE(i), ANY_VALUE(i || i), 123, 'abc', 'abc' || 'def' FROM emptytable",
+		},
+		{
 			name:     "explicit GROUP BY is left alone",
 			input:    "SELECT pk1, SUM(c1) FROM two_pk GROUP BY pk1",
 			expected: "SELECT pk1, SUM(c1) FROM two_pk GROUP BY pk1",


### PR DESCRIPTION
## Summary
#404 was wrong: \`ANY_VALUE(123)\` on an empty table is NULL. MySQL keeps the constant.

Only wrap SELECT items that reference a column.

Unskip \`SELECT count(*), i, concat(...), 123, 'abc', concat('abc', 'def') FROM emptytable\`.

GROUP BY i extra column stays a separate unskip.

## Test plan
- [x] \`go test ./transpiler/\`