### PR TITLE
test: unskip GROUP BY i with extra SELECT column

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -253,7 +253,6 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_SUM(i)_FROM_mytable",
 		"SELECT_RAND(i)_from_mytable_order_by_i",
 
-		"SELECT_sum(i)_as_isum,_s_FROM_mytable_GROUP_BY_i_ORDER_BY_isum_ASC_LIMIT_0,_200",
 
 		"SELECT_pk,_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_AS_x_FROM_one_pk_opk_GROUP_BY_x_ORDER_BY_x",
 		"SELECT_pk,_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_AS_x_______FROM_one_pk_opk_WHERE_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_>_0_______GROUP_BY_x_ORDER_BY_x",


### PR DESCRIPTION
## Summary
\`SELECT sum(i) as isum, s ... GROUP BY i\` already wraps \`s\` with \`ANY_VALUE\`.

Unskip that TestQueriesSimple case only. emptytable is #405.

## Test plan
- [x] no transpiler change