### PR TITLE
fix: CAST AS DECIMAL uses integer scale

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -241,9 +241,6 @@ func TestQueriesSimple(t *testing.T) {
 
 		"SELECT_reservedWordsTable.AND,_reservedWordsTABLE.Or,_reservedwordstable.SEleCT_FROM_reservedWordsTable;",
 
-		"SELECT_DISTINCT_CAST(i_AS_DECIMAL)_from_mytable;",
-		"SELECT_SUM(_DISTINCT_CAST(i_AS_DECIMAL))_from_mytable;",
-
 		"select_pk,_________row_number()_over_(order_by_pk_desc),_________sum(v1)_over_(partition_by_v2_order_by_pk),_________percent_rank()_over(partition_by_v2_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 		"select_pk,____________________percent_rank()_over(partition_by_v2_order_by_pk),____________________dense_rank()_over(partition_by_v2_order_by_pk),____________________rank()_over(partition_by_v2_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 		"select_pk,_________first_value(pk)_over_(order_by_pk_desc),_________lag(pk,_1)_over_(order_by_pk_desc),_________count(pk)_over(partition_by_v1_order_by_pk),_________max(pk)_over(partition_by_v1_order_by_pk_desc),_________avg(v2)_over_(partition_by_v1_order_by_pk)_____from_one_pk_three_idx_order_by_pk",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -829,6 +829,9 @@ def rewrite_mysql_for_duckdb(node):
         inner = node.this
         if to is not None and not isinstance(inner, (exp.If, exp.Case)):
             to_sql = to.sql(dialect="duckdb").upper()
+            # MySQL CAST(x AS DECIMAL) is integer-scale. DuckDB DECIMAL is (18,3).
+            if to_sql in ("DECIMAL", "NUMERIC"):
+                return exp.Cast(this=inner, to=exp.DataType.build("DECIMAL(38, 0)"))
             if to_sql.startswith("U") and "INT" in to_sql:
                 wrapped = exp.If(
                     this=exp.LT(this=inner, expression=exp.Literal.number(0)),

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -372,6 +372,11 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT __SYS__.MYSQL_CRC32(CAST(i AS TEXT)) FROM mytable",
 		},
 		{
+			name:     "CAST AS DECIMAL is integer scale",
+			input:    "SELECT DISTINCT CAST(i AS DECIMAL) FROM mytable",
+			expected: "SELECT DISTINCT CAST(i AS DECIMAL(38, 0)) FROM mytable",
+		},
+		{
 			name:     "DELETE JOIN becomes DELETE USING",
 			input:    "DELETE mytable FROM mytable JOIN tabletest WHERE mytable.i = tabletest.i",
 			expected: "DELETE FROM mytable USING tabletest WHERE mytable.i = tabletest.i",


### PR DESCRIPTION
## Summary
MySQL \`CAST(x AS DECIMAL)\` is scale 0. DuckDB \`DECIMAL\` is \`(18,3)\`.

Rewrite bare \`DECIMAL\`/\`NUMERIC\` to \`DECIMAL(38, 0)\`.

Unskip \`SELECT DISTINCT CAST(i AS DECIMAL)\` and \`SUM(DISTINCT CAST(i AS DECIMAL))\`.

## Test plan
- [x] \`go test ./transpiler/\`