### PR TITLE
fix: MySQL VALUES ROW becomes DuckDB VALUES tuples

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -230,8 +230,6 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_NOT_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_emptytable);",
 		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_NOT_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_mytable_WHERE_false);",
 
-		"SELECT_a.column_0,_mt.s_from_(values_row(1,\"1\"),_row(2,\"2\"),_row(4,\"4\"))_a____left_join_mytable_mt_on_column_0_=_mt.i____order_by_1",
-
 		"select_i+0.0/(lag(i)_over_(order_by_s))_from_mytable_order_by_1;",
 		"select_f64/f32,_f32/(lag(i)_over_(order_by_f64))_from_floattable_order_by_1,2;",
 		"SELECT_s2,_i2,_i____FROM_(SELECT_*_FROM_mytable)_mytable____RIGHT_JOIN_____((SELECT_i2,_s2_FROM_othertable_ORDER_BY_i2_ASC)______UNION_ALL______SELECT_CAST(4_AS_SIGNED)_AS_i2,_\"not_found\"_AS_s2_FROM_DUAL)_othertable____ON_i2_=_i",
@@ -248,7 +246,6 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_*_FROM_tabletest_WHERE_s_=_0",
 		"SELECT_SUM(i)_FROM_mytable",
 		"SELECT_RAND(i)_from_mytable_order_by_i",
-
 
 		"SELECT_pk,_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_AS_x_FROM_one_pk_opk_GROUP_BY_x_ORDER_BY_x",
 		"SELECT_pk,_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_AS_x_______FROM_one_pk_opk_WHERE_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_>_0_______GROUP_BY_x_ORDER_BY_x",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -221,6 +221,30 @@ def rewrite_mysql_for_duckdb(node):
             this=exp.Select(expressions=[exp.Literal.number(1)]),
             alias="dual",
         )
+    # MySQL VALUES ROW(1, '1') -> DuckDB VALUES (1, '1') AS t(column_0, column_1).
+    if isinstance(node, exp.Values):
+        new_exprs = []
+        changed = False
+        for e in node.expressions or []:
+            inner = e.expressions[0] if isinstance(e, exp.Tuple) and len(e.expressions or []) == 1 else e
+            if isinstance(inner, exp.Anonymous) and str(inner.this).lower() == "row":
+                new_exprs.append(exp.Tuple(expressions=list(inner.expressions or [])))
+                changed = True
+            else:
+                new_exprs.append(e)
+        if changed:
+            alias = node.args.get("alias")
+            ncols = len(new_exprs[0].expressions) if new_exprs else 0
+            if alias is not None and ncols:
+                alias = exp.TableAlias(
+                    this=alias.this if isinstance(alias, exp.TableAlias) else alias,
+                    columns=[exp.to_identifier("column_" + str(i)) for i in range(ncols)],
+                )
+            updated = node.copy()
+            updated.set("expressions", new_exprs)
+            if alias is not None:
+                updated.set("alias", alias)
+            return updated
     rewritten_delete = _rewrite_mysql_delete(node)
     if rewritten_delete is not None:
         if rewritten_delete.args.get("with_") is not None:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -377,6 +377,11 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT DISTINCT CAST(i AS DECIMAL(38, 0)) FROM mytable",
 		},
 		{
+			name:     "VALUES ROW becomes VALUES tuple",
+			input:    "SELECT a.column_0 FROM (VALUES ROW(1, '1'), ROW(2, '2')) a",
+			expected: "SELECT a.column_0 FROM (VALUES (1, '1'), (2, '2')) AS a(column_0, column_1)",
+		},
+		{
 			name:     "DELETE JOIN becomes DELETE USING",
 			input:    "DELETE mytable FROM mytable JOIN tabletest WHERE mytable.i = tabletest.i",
 			expected: "DELETE FROM mytable USING tabletest WHERE mytable.i = tabletest.i",


### PR DESCRIPTION
## Summary
MySQL \`VALUES ROW(1, '1')\` becomes DuckDB \`VALUES (1, '1') AS a(column_0, column_1)\`.

Unskip the \`values row(...) a LEFT JOIN mytable\` query.

## Test plan
- [x] \`go test ./transpiler/\`