### PR TITLE
fix: quote reserved-word column names so sqlglot can parse them

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -237,8 +237,6 @@ func TestQueriesSimple(t *testing.T) {
 		"WITH_mytable_as_(select_*_FROM_mytable_where_i_>_2)_SELECT_*_FROM_mytable;",
 		"WITH_mytable_as_(select_*_FROM_mytable_where_i_>_2)_SELECT_*_FROM_mytable_union_SELECT_*_from_mytable;",
 
-		"SELECT_reservedWordsTable.AND,_reservedWordsTABLE.Or,_reservedwordstable.SEleCT_FROM_reservedWordsTable;",
-
 		"select_pk,_________row_number()_over_(order_by_pk_desc),_________sum(v1)_over_(partition_by_v2_order_by_pk),_________percent_rank()_over(partition_by_v2_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 		"select_pk,____________________percent_rank()_over(partition_by_v2_order_by_pk),____________________dense_rank()_over(partition_by_v2_order_by_pk),____________________rank()_over(partition_by_v2_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 		"select_pk,_________first_value(pk)_over_(order_by_pk_desc),_________lag(pk,_1)_over_(order_by_pk_desc),_________count(pk)_over(partition_by_v1_order_by_pk),_________max(pk)_over(partition_by_v1_order_by_pk_desc),_________avg(v2)_over_(partition_by_v1_order_by_pk)_____from_one_pk_three_idx_order_by_pk",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -950,6 +950,10 @@ def rewrite_mysql_for_duckdb(node):
     return node
 
 def transpile_mysql_to_duckdb(sql: str) -> str:
+    import re
+    # MySQL allows t.AND / t.OR / t.SELECT as identifiers. Quote so sqlglot parses them.
+    bq = chr(96)
+    sql = re.sub(r'\.(AND|OR|SELECT)\b', lambda m: '.' + bq + m.group(1) + bq, sql, flags=re.I)
     try:
         trees = sqlglot.parse(sql, read="mysql")
     except Exception:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -382,6 +382,11 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT a.column_0 FROM (VALUES (1, '1'), (2, '2')) AS a(column_0, column_1)",
 		},
 		{
+			name:     "reserved word columns are quoted",
+			input:    "SELECT reservedWordsTable.AND, reservedWordsTABLE.Or, reservedwordstable.SEleCT FROM reservedWordsTable",
+			expected: "SELECT reservedWordsTable.\"AND\", reservedWordsTABLE.\"Or\", reservedwordstable.\"SEleCT\" FROM reservedWordsTable",
+		},
+		{
 			name:     "DELETE JOIN becomes DELETE USING",
 			input:    "DELETE mytable FROM mytable JOIN tabletest WHERE mytable.i = tabletest.i",
 			expected: "DELETE FROM mytable USING tabletest WHERE mytable.i = tabletest.i",


### PR DESCRIPTION
## Summary
MySQL allows \`t.AND\` / \`t.OR\` / \`t.SELECT\` as identifiers. sqlglot's MySQL parser treats them as keywords.

Quote those dotted names before parse. DuckDB output uses double quotes.

Unskip \`SELECT reservedWordsTable.AND, ...\`.

## Test plan
- [x] \`go test ./transpiler/\`