### PR TITLE
test: unskip SELECT SUM(i) FROM mytable

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -241,7 +241,6 @@ func TestQueriesSimple(t *testing.T) {
 		"select_pk,_________first_value(pk)_over_(order_by_pk_desc),_________lag(pk,_1)_over_(order_by_pk_desc),_________count(pk)_over(partition_by_v1_order_by_pk),_________max(pk)_over(partition_by_v1_order_by_pk_desc),_________avg(v2)_over_(partition_by_v1_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 
 		"SELECT_*_FROM_tabletest_WHERE_s_=_0",
-		"SELECT_SUM(i)_FROM_mytable",
 		"SELECT_RAND(i)_from_mytable_order_by_i",
 
 		"SELECT_pk,_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_AS_x_FROM_one_pk_opk_GROUP_BY_x_ORDER_BY_x",


### PR DESCRIPTION
## Summary
\`SELECT SUM(i) FROM mytable\` already becomes DuckDB \`SUM(i)\`.

Unskip that TestQueriesSimple case.

## Test plan
- [x] no transpiler change