### PR TITLE
test: unskip scalar subquery in SELECT list

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -280,7 +280,6 @@ func TestQueriesSimple(t *testing.T) {
 		"select_now()_=_sysdate(),_sleep(0.1),_now(6)_<_sysdate(6);")
 
 	panicQueries := []string{
-		"SELECT_(SELECT_s_FROM_mytable_ORDER_BY_i_ASC_LIMIT_1)_AS_x",
 	}
 
 	harness.QueriesToSkip(notApplicableQueries...)


### PR DESCRIPTION
## Summary
\`SELECT (SELECT s FROM mytable ORDER BY i ASC LIMIT 1) AS x\` already becomes a DuckDB scalar subquery.

Remove it from \`panicQueries\`.

## Test plan
- [x] no transpiler change