### PR TITLE
fix: (a, b) IN (SELECT ...) becomes EXISTS

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -225,11 +225,6 @@ func TestQueriesSimple(t *testing.T) {
 	waitForFixQueries := []string{
 		"_Select_x_from_(select_*_from_xy)_sq1_union_all_select_u_from_(select_*_from_uv)_sq2_limit_1_offset_1;",
 
-		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_emptytable);",
-		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_mytable_WHERE_false);",
-		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_NOT_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_emptytable);",
-		"SELECT_pk_FROM_one_pk_WHERE_(pk,_123)_NOT_IN_(SELECT_count(*)_AS_u,_123_AS_v_FROM_mytable_WHERE_false);",
-
 		"select_i+0.0/(lag(i)_over_(order_by_s))_from_mytable_order_by_1;",
 		"select_f64/f32,_f32/(lag(i)_over_(order_by_f64))_from_floattable_order_by_1,2;",
 		"WITH_mytable_as_(select_*_FROM_mytable)_SELECT_s,i_FROM_mytable;",
@@ -251,7 +246,6 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_VALUES(i)_FROM_mytable",
 		"select_i,_row_number()_over_(order_by_i_desc)_+_3,____row_number()_over_(order_by_length(s),i)_+_0.0_/_row_number()_over_(order_by_length(s)_desc,i_desc)_+_0.0____from_mytable_order_by_1;",
 		"SELECT_pk,_row_number()_over_(partition_by_v2_order_by_pk_),_max(v3)_over_(partition_by_v2_order_by_pk)_FROM_one_pk_three_idx_ORDER_BY_pk",
-
 
 		"show_function_status",
 		"show_function_status_like_'foo'",
@@ -279,8 +273,7 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_COT(i)_from_mytable_order_by_i_limit_1",
 		"select_now()_=_sysdate(),_sleep(0.1),_now(6)_<_sysdate(6);")
 
-	panicQueries := []string{
-	}
+	panicQueries := []string{}
 
 	harness.QueriesToSkip(notApplicableQueries...)
 	harness.QueriesToSkip(undefinedOrderQueries...)

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -750,9 +750,39 @@ def rewrite_mysql_for_duckdb(node):
         query = node.args.get("query")
         if query is not None or (not node.expressions and node.args.get("unbound")):
             this = node.this.transform(rewrite_mysql_for_duckdb) if node.this is not None else node.this
+            if query is not None:
+                query = query.transform(rewrite_mysql_for_duckdb)
+            # DuckDB IN expects one column. (a, b) IN (SELECT x, y) -> EXISTS.
+            if query is not None and isinstance(this, exp.Tuple):
+                sel = query.this if isinstance(query, exp.Subquery) else query
+                if isinstance(sel, exp.Select):
+                    new_sel = sel.copy()
+                    aliases = []
+                    new_exprs = []
+                    for i, e in enumerate(new_sel.expressions or []):
+                        name = e.alias if isinstance(e, exp.Alias) and e.alias else ("_c" + str(i))
+                        aliases.append(name)
+                        if isinstance(e, exp.Alias) and e.alias:
+                            new_exprs.append(e)
+                        else:
+                            new_exprs.append(exp.alias_(e, name))
+                    new_sel.set("expressions", new_exprs)
+                    eqs = []
+                    for lhs, name in zip(this.expressions or [], aliases):
+                        eqs.append(exp.EQ(this=lhs, expression=exp.column(name, table="q")))
+                    cond = eqs[0]
+                    for e in eqs[1:]:
+                        cond = exp.And(this=cond, expression=e)
+                    return exp.Exists(
+                        this=exp.Select(
+                            expressions=[exp.Literal.number(1)],
+                            from_=exp.From(this=exp.Subquery(this=new_sel, alias="q")),
+                            where=exp.Where(this=cond),
+                        )
+                    )
             kwargs = {"this": this}
             if query is not None:
-                kwargs["query"] = query.transform(rewrite_mysql_for_duckdb)
+                kwargs["query"] = query
             return exp.In(**kwargs)
         this = node.this.transform(rewrite_mysql_for_duckdb) if node.this is not None else node.this
         exprs = [

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -387,6 +387,11 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT reservedWordsTable.\"AND\", reservedWordsTABLE.\"Or\", reservedwordstable.\"SEleCT\" FROM reservedWordsTable",
 		},
 		{
+			name:     "tuple IN subquery becomes EXISTS",
+			input:    "SELECT pk FROM one_pk WHERE (pk, 123) IN (SELECT count(*) AS u, 123 AS v FROM emptytable)",
+			expected: "SELECT pk FROM one_pk WHERE EXISTS(SELECT 1 FROM (SELECT COUNT(*) AS u, 123 AS v FROM emptytable) AS q WHERE pk = q.u AND 123 = q.v)",
+		},
+		{
 			name:     "DELETE JOIN becomes DELETE USING",
 			input:    "DELETE mytable FROM mytable JOIN tabletest WHERE mytable.i = tabletest.i",
 			expected: "DELETE FROM mytable USING tabletest WHERE mytable.i = tabletest.i",


### PR DESCRIPTION
## Summary
DuckDB \`IN\` requires one column. MySQL \`(pk, 123) IN (SELECT count(*), 123 ...)\` becomes:

\`EXISTS (SELECT 1 FROM (SELECT ...) AS q WHERE pk = q.u AND 123 = q.v)\`

Unskip the four \`(pk, 123) IN/NOT IN (SELECT ...)\` queries.

## Test plan
- [x] \`go test ./transpiler/\`