### PR TITLE
fix: WITH t AS (SELECT * FROM t) is not a circular CTE

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -227,9 +227,6 @@ func TestQueriesSimple(t *testing.T) {
 
 		"select_i+0.0/(lag(i)_over_(order_by_s))_from_mytable_order_by_1;",
 		"select_f64/f32,_f32/(lag(i)_over_(order_by_f64))_from_floattable_order_by_1,2;",
-		"WITH_mytable_as_(select_*_FROM_mytable)_SELECT_s,i_FROM_mytable;",
-		"WITH_mytable_as_(select_*_FROM_mytable_where_i_>_2)_SELECT_*_FROM_mytable;",
-		"WITH_mytable_as_(select_*_FROM_mytable_where_i_>_2)_SELECT_*_FROM_mytable_union_SELECT_*_from_mytable;",
 
 		"select_pk,_________row_number()_over_(order_by_pk_desc),_________sum(v1)_over_(partition_by_v2_order_by_pk),_________percent_rank()_over(partition_by_v2_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 		"select_pk,____________________percent_rank()_over(partition_by_v2_order_by_pk),____________________dense_rank()_over(partition_by_v2_order_by_pk),____________________rank()_over(partition_by_v2_order_by_pk)_____from_one_pk_three_idx_order_by_pk",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -221,6 +221,55 @@ def rewrite_mysql_for_duckdb(node):
             this=exp.Select(expressions=[exp.Literal.number(1)]),
             alias="dual",
         )
+    # MySQL WITH t AS (SELECT * FROM t) uses the base table inside. DuckDB treats it as circular.
+    if isinstance(node, (exp.Select, exp.Union, exp.Except, exp.Intersect)) and node.args.get("with_"):
+        w = node.args.get("with_")
+        if not w.args.get("recursive"):
+            renames = {}
+            new_ctes = []
+            changed = False
+            for cte in list(w.expressions or []):
+                alias = cte.args.get("alias")
+                cname = ""
+                if isinstance(alias, exp.TableAlias) and alias.this:
+                    cname = str(alias.this).lower()
+                shadows = False
+                if cname and cte.this is not None:
+                    for t in cte.this.find_all(exp.Table):
+                        if not t.args.get("db") and (t.name or "").lower() == cname:
+                            shadows = True
+                            break
+                if shadows:
+                    new_name = cname + "__mds"
+                    renames[cname] = new_name
+                    cte = cte.copy()
+                    cte.set("alias", exp.TableAlias(this=exp.to_identifier(new_name)))
+                    changed = True
+                new_ctes.append(cte)
+            if changed:
+                def _rename_outer(n):
+                    if isinstance(n, exp.Table) and not n.args.get("db"):
+                        nm = (n.name or "").lower()
+                        if nm in renames:
+                            copied = n.copy()
+                            copied.set("this", exp.to_identifier(renames[nm]))
+                            return copied
+                    return n
+                updated = node.copy()
+                new_w = w.copy()
+                new_w.set("expressions", new_ctes)
+                updated.set("with_", new_w)
+                if isinstance(updated, exp.Select):
+                    if updated.args.get("from_"):
+                        updated.set("from_", updated.args.get("from_").transform(_rename_outer))
+                    if updated.args.get("joins"):
+                        updated.set("joins", [j.transform(_rename_outer) for j in updated.args.get("joins")])
+                else:
+                    if updated.this is not None:
+                        updated.set("this", updated.this.transform(_rename_outer))
+                    if updated.args.get("expression") is not None:
+                        updated.set("expression", updated.args.get("expression").transform(_rename_outer))
+                return updated
     # MySQL VALUES ROW(1, '1') -> DuckDB VALUES (1, '1') AS t(column_0, column_1).
     if isinstance(node, exp.Values):
         new_exprs = []

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -392,6 +392,11 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT pk FROM one_pk WHERE EXISTS(SELECT 1 FROM (SELECT COUNT(*) AS u, 123 AS v FROM emptytable) AS q WHERE pk = q.u AND 123 = q.v)",
 		},
 		{
+			name:     "CTE name matching table is not circular",
+			input:    "WITH mytable AS (SELECT * FROM mytable) SELECT s, i FROM mytable",
+			expected: "WITH mytable__mds AS (SELECT * FROM mytable) SELECT s, i FROM mytable__mds",
+		},
+		{
 			name:     "DELETE JOIN becomes DELETE USING",
 			input:    "DELETE mytable FROM mytable JOIN tabletest WHERE mytable.i = tabletest.i",
 			expected: "DELETE FROM mytable USING tabletest WHERE mytable.i = tabletest.i",


### PR DESCRIPTION
## Summary
MySQL \`WITH mytable AS (SELECT * FROM mytable)\` reads the base table inside the CTE. DuckDB treats that as a circular CTE.

Rename the CTE to \`mytable__mds\` and keep the inner table as \`mytable\`.

Unskip the three \`WITH mytable AS (...)\` queries.

## Test plan
- [x] \`go test ./transpiler/\`