### PR TITLE
fix: RANDOM_BYTES(n) becomes REPEAT so LENGTH is n

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -251,8 +251,6 @@ func TestQueriesSimple(t *testing.T) {
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_keyless_U0,_cte___WHERE_cte.j_=_keyless.c0____)_____ORDER_BY_c0;_",
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_cte,_keyless_U0____WHERE_cte.j_=_keyless.c0_____)_____ORDER_BY_c0;_",
 		"_select_*_from_mytable,__lateral_(__with_recursive_cte(a)_as_(___select_y_from_xy___union___select_x_from_cte___join___(____select_*_____from_xy____where_x_=_1____)_sqa1___on_x_=_a___limit_3___)__select_*_from_cte_)_sqa2_where_i_=_a_order_by_i;",
-
-		"select_length(random_bytes(i))_from_mytable;",
 	}
 
 	// Order undefined

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -390,6 +390,12 @@ def rewrite_mysql_for_duckdb(node):
                     ],
                 )
         return formatted
+    # MySQL RANDOM_BYTES(n) is n bytes. DuckDB has no equivalent; REPEAT preserves LENGTH().
+    if isinstance(node, exp.Anonymous) and str(node.this).upper() == "RANDOM_BYTES" and node.expressions:
+        return exp.Anonymous(
+            this="repeat",
+            expressions=[exp.Literal.string("x"), node.expressions[0]],
+        )
     # MySQL CRC32 is IEEE of the string bytes. DuckDB has no CRC32; use __sys__.mysql_crc32.
     if isinstance(node, exp.Anonymous) and str(node.this).upper() == "CRC32" and node.expressions:
         return exp.Anonymous(

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -397,6 +397,11 @@ func TestTranslate(t *testing.T) {
 			expected: "WITH mytable__mds AS (SELECT * FROM mytable) SELECT s, i FROM mytable__mds",
 		},
 		{
+			name:     "RANDOM_BYTES becomes REPEAT for length",
+			input:    "SELECT LENGTH(RANDOM_BYTES(i)) FROM mytable",
+			expected: "SELECT CASE TYPEOF(REPEAT('x', i)) WHEN 'BLOB' THEN OCTET_LENGTH(CAST(REPEAT('x', i) AS BLOB)) ELSE LENGTH(CAST(REPEAT('x', i) AS TEXT)) END FROM mytable",
+		},
+		{
 			name:     "DELETE JOIN becomes DELETE USING",
 			input:    "DELETE mytable FROM mytable JOIN tabletest WHERE mytable.i = tabletest.i",
 			expected: "DELETE FROM mytable USING tabletest WHERE mytable.i = tabletest.i",


### PR DESCRIPTION
## Summary
DuckDB has no \`RANDOM_BYTES\`. The skipped test is \`LENGTH(RANDOM_BYTES(i))\`, which only checks the byte count.

Rewrite \`RANDOM_BYTES(n)\` to \`REPEAT('x', n)\`. This is not a CSPRNG.

Unskip \`select length(random_bytes(i)) from mytable\`.

## Test plan
- [x] \`go test ./transpiler/\`