### PR TITLE
fix: skip FUNCTION dump DDL and unwrap CREATE VIEW AS (...) (#329)

### DIFF
--- a/backend/request_modifier.go
+++ b/backend/request_modifier.go
@@ -1,12 +1,21 @@
 package backend
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+)
 
 // RequestModifier is a function type that transforms a query string
 type RequestModifier func(string, *[]ResultModifier) string
 
+// skipUnsupportedDDL is a no-op that the parser accepts.
+// Used for CREATE/DROP/ALTER FUNCTION|PROCEDURE|TRIGGER|EVENT.
+const skipUnsupportedDDL = "SELECT 1"
+
 // default request modifier list
 var defaultRequestModifiers = []RequestModifier{
+	skipUnsupportedRoutineDDL,
+	unwrapCreateViewParens,
 	replaceMariaDBCollation,
 }
 
@@ -15,6 +24,282 @@ var defaultRequestModifiers = []RequestModifier{
 // This function replaces the collation with the MySQL default utf8mb4_0900_ai_ci.
 func replaceMariaDBCollation(query string, _ *[]ResultModifier) string {
 	return strings.ReplaceAll(query, "utf8mb4_uca1400_ai_ci", "utf8mb4_0900_ai_ci")
+}
+
+// skipUnsupportedRoutineDDL turns stored routines, triggers, and events
+// into a no-op. DuckDB cannot host them; replica snapshot dumps still emit
+// /*!50003 DROP FUNCTION ... */ and abort the whole schema if we parse-fail.
+func skipUnsupportedRoutineDDL(query string, _ *[]ResultModifier) string {
+	if isUnsupportedRoutineDDL(query) {
+		return skipUnsupportedDDL
+	}
+	return query
+}
+
+func isUnsupportedRoutineDDL(query string) bool {
+	q := unwrapVersionComment(query)
+	q = strings.TrimSpace(q)
+	if q == "" {
+		return false
+	}
+
+	upperStart := strings.ToUpper(q)
+	if !hasWordPrefix(upperStart, "CREATE") && !hasWordPrefix(upperStart, "ALTER") && !hasWordPrefix(upperStart, "DROP") {
+		return false
+	}
+
+	// Stop at the first '(' so CREATE TABLE t (function INT) is not treated as a routine.
+	if idx := indexUnquoted(q, '('); idx >= 0 {
+		q = q[:idx]
+	}
+
+	words := strings.FieldsFunc(q, func(r rune) bool {
+		return unicode.IsSpace(r) || r == '`' || r == '"' || r == '\'' || r == '=' || r == '.' || r == '@'
+	})
+	if len(words) < 2 {
+		return false
+	}
+
+	for _, w := range words[1:] {
+		switch strings.ToUpper(w) {
+		case "FUNCTION", "PROCEDURE", "TRIGGER", "EVENT":
+			return true
+		case "TABLE", "VIEW", "INDEX", "DATABASE", "SCHEMA", "USER", "ROLE", "SERVER":
+			return false
+		}
+	}
+	return false
+}
+
+// unwrapVersionComment turns /*!50003 DROP FUNCTION IF EXISTS `toDate` */
+// into DROP FUNCTION IF EXISTS `toDate`.
+func unwrapVersionComment(query string) string {
+	q := strings.TrimSpace(query)
+	if !strings.HasPrefix(q, "/*!") {
+		return q
+	}
+	i := 3
+	for i < len(q) && q[i] >= '0' && q[i] <= '9' {
+		i++
+	}
+	body := strings.TrimSpace(q[i:])
+	body = strings.TrimSuffix(body, "*/")
+	return strings.TrimSpace(body)
+}
+
+func hasWordPrefix(upper, word string) bool {
+	if !strings.HasPrefix(upper, word) {
+		return false
+	}
+	if len(upper) == len(word) {
+		return true
+	}
+	return !isIdentChar(rune(upper[len(word)]))
+}
+
+func isIdentChar(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
+}
+
+func indexUnquoted(s string, target byte) int {
+	var quote byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if quote != 0 {
+			if c == '\\' && quote != '`' {
+				i++
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		if c == '\'' || c == '"' || c == '`' {
+			quote = c
+			continue
+		}
+		if c == target {
+			return i
+		}
+	}
+	return -1
+}
+
+// unwrapCreateViewParens rewrites
+//
+//	CREATE ... VIEW name AS ( SELECT ... )
+//
+// to
+//
+//	CREATE ... VIEW name AS SELECT ...
+//
+// go-mysql-server rejects the parenthesized form (issue #329).
+func unwrapCreateViewParens(query string, _ *[]ResultModifier) string {
+	asEnd, bodyStart, ok := findCreateViewBody(query)
+	if !ok {
+		return query
+	}
+	i := skipSpace(query, bodyStart)
+	if i >= len(query) || query[i] != '(' {
+		return query
+	}
+	closeIdx, ok := matchingParen(query, i)
+	if !ok {
+		return query
+	}
+	inner := strings.TrimSpace(query[i+1 : closeIdx])
+	return query[:asEnd] + " " + inner + query[closeIdx+1:]
+}
+
+func findCreateViewBody(query string) (asEnd, bodyStart int, ok bool) {
+	i := skipSpace(query, 0)
+	if !matchKeywordAt(query, i, "CREATE") {
+		return 0, 0, false
+	}
+	i = skipToken(query, i)
+
+	foundView := false
+	for i < len(query) {
+		i = skipSpace(query, i)
+		if i >= len(query) {
+			return 0, 0, false
+		}
+		if matchKeywordAt(query, i, "VIEW") {
+			foundView = true
+			i = skipToken(query, i)
+			break
+		}
+		if matchKeywordAt(query, i, "TABLE") ||
+			matchKeywordAt(query, i, "INDEX") ||
+			matchKeywordAt(query, i, "FUNCTION") ||
+			matchKeywordAt(query, i, "PROCEDURE") ||
+			matchKeywordAt(query, i, "TRIGGER") ||
+			matchKeywordAt(query, i, "EVENT") ||
+			matchKeywordAt(query, i, "DATABASE") ||
+			matchKeywordAt(query, i, "SCHEMA") {
+			return 0, 0, false
+		}
+		i = skipToken(query, i)
+	}
+	if !foundView {
+		return 0, 0, false
+	}
+
+	i = skipSpace(query, i)
+	i = skipQualifiedName(query, i)
+	i = skipSpace(query, i)
+	if i < len(query) && query[i] == '(' {
+		end, matched := matchingParen(query, i)
+		if !matched {
+			return 0, 0, false
+		}
+		i = end + 1
+		i = skipSpace(query, i)
+	}
+	if !matchKeywordAt(query, i, "AS") {
+		return 0, 0, false
+	}
+	asEnd = i + 2
+	return asEnd, skipSpace(query, asEnd), true
+}
+
+func skipSpace(s string, i int) int {
+	for i < len(s) && unicode.IsSpace(rune(s[i])) {
+		i++
+	}
+	return i
+}
+
+func matchKeywordAt(s string, i int, word string) bool {
+	if i+len(word) > len(s) {
+		return false
+	}
+	if !strings.EqualFold(s[i:i+len(word)], word) {
+		return false
+	}
+	if i+len(word) < len(s) && isIdentChar(rune(s[i+len(word)])) {
+		return false
+	}
+	return true
+}
+
+func skipToken(s string, i int) int {
+	i = skipSpace(s, i)
+	if i >= len(s) {
+		return i
+	}
+	if s[i] == '`' || s[i] == '"' || s[i] == '\'' {
+		q := s[i]
+		i++
+		for i < len(s) {
+			if s[i] == q {
+				return i + 1
+			}
+			i++
+		}
+		return i
+	}
+	if isIdentChar(rune(s[i])) {
+		i++
+		for i < len(s) && isIdentChar(rune(s[i])) {
+			i++
+		}
+		return i
+	}
+	return i + 1
+}
+
+func skipQualifiedName(s string, i int) int {
+	i = skipToken(s, i)
+	i = skipSpace(s, i)
+	if i < len(s) && s[i] == '.' {
+		i++
+		i = skipSpace(s, i)
+		i = skipToken(s, i)
+	}
+	return i
+}
+
+func matchingParen(s string, open int) (int, bool) {
+	if open >= len(s) || s[open] != '(' {
+		return -1, false
+	}
+	depth := 0
+	var quote byte
+	for i := open; i < len(s); i++ {
+		c := s[i]
+		if quote != 0 {
+			if c == '\\' && quote != '`' {
+				i++
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"', '`':
+			quote = c
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i, true
+			}
+		}
+	}
+	return -1, false
+}
+
+// RewriteIncomingQuery applies the default request modifiers.
+// Tests and protocol handlers use this so replica-dump DDL is rewritten
+// the same way as live MySQL connections.
+func RewriteIncomingQuery(query string) string {
+	rewritten, _ := applyRequestModifiers(query, defaultRequestModifiers)
+	return rewritten
 }
 
 // applyRequestModifiers applies request modifiers to a query

--- a/backend/request_modifier_test.go
+++ b/backend/request_modifier_test.go
@@ -1,0 +1,112 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkipUnsupportedRoutineDDL(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		skip   bool
+	}{
+		{
+			name:  "versioned drop function",
+			input: "/*!50003 DROP FUNCTION IF EXISTS `toDate` */",
+			skip:  true,
+		},
+		{
+			name:  "create function",
+			input: "CREATE DEFINER=`root`@`%` FUNCTION `toDate`() RETURNS date DETERMINISTIC RETURN CURDATE()",
+			skip:  true,
+		},
+		{
+			name:  "drop procedure",
+			input: "DROP PROCEDURE IF EXISTS `do_work`",
+			skip:  true,
+		},
+		{
+			name:  "create trigger",
+			input: "CREATE TRIGGER foo AFTER UPDATE ON t FOR EACH ROW BEGIN SET NEW.i = 1; END",
+			skip:  true,
+		},
+		{
+			name:  "create event",
+			input: "CREATE EVENT foo ON SCHEDULE EVERY 1 YEAR DO CREATE TABLE bar (i INT)",
+			skip:  true,
+		},
+		{
+			name:  "create table not skipped",
+			input: "CREATE TABLE t (function INT, event INT)",
+			skip:  false,
+		},
+		{
+			name:  "create view not skipped",
+			input: "CREATE VIEW v AS SELECT 1",
+			skip:  false,
+		},
+		{
+			name:  "drop table named function",
+			input: "DROP TABLE IF EXISTS function",
+			skip:  false,
+		},
+		{
+			name:  "plain select",
+			input: "SELECT function FROM t",
+			skip:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := skipUnsupportedRoutineDDL(tc.input, nil)
+			if tc.skip {
+				require.Equal(t, skipUnsupportedDDL, got)
+			} else {
+				require.Equal(t, tc.input, got)
+			}
+		})
+	}
+}
+
+func TestUnwrapCreateViewParens(t *testing.T) {
+	in := `CREATE OR REPLACE SQL SECURITY INVOKER VIEW log_report_count AS (
+    SELECT
+        report_code,
+        report_name,
+        report_count
+    FROM report_logs
+    WHERE report_count > 0
+);`
+	got := unwrapCreateViewParens(in, nil)
+	require.NotContains(t, got, "AS (\n")
+	require.Contains(t, got, "VIEW log_report_count AS SELECT")
+	require.Contains(t, got, "WHERE report_count > 0")
+	require.True(t, strings.HasSuffix(strings.TrimSpace(got), ");") || strings.Contains(got, "0\n);") || strings.HasSuffix(strings.TrimSpace(got), ";"))
+}
+
+func TestUnwrapCreateViewParensKeepsPlainView(t *testing.T) {
+	in := "CREATE VIEW v AS SELECT 1"
+	require.Equal(t, in, unwrapCreateViewParens(in, nil))
+}
+
+func TestUnwrapCreateViewParensWithColumnList(t *testing.T) {
+	in := "CREATE VIEW v (a, b) AS (SELECT 1, 2)"
+	got := unwrapCreateViewParens(in, nil)
+	require.Equal(t, "CREATE VIEW v (a, b) AS SELECT 1, 2", got)
+}
+
+func TestApplyRequestModifiersIssue329(t *testing.T) {
+	fn, _ := applyRequestModifiers("/*!50003 DROP FUNCTION IF EXISTS `toDate` */", defaultRequestModifiers)
+	require.Equal(t, skipUnsupportedDDL, fn)
+
+	view, _ := applyRequestModifiers(
+		"CREATE OR REPLACE SQL SECURITY INVOKER VIEW log_report_count AS (\n    SELECT 1 WHERE 1 > 0\n)",
+		defaultRequestModifiers,
+	)
+	require.Contains(t, view, "VIEW log_report_count AS SELECT 1 WHERE 1 > 0")
+	require.NotContains(t, view, "AS (")
+}

--- a/devtools/replica-setup-mysql/snapshot.sh
+++ b/devtools/replica-setup-mysql/snapshot.sh
@@ -53,6 +53,9 @@ echo "Copying data from MySQL to MyDuck..."
 # Run mysqlsh command and capture the output
 output=$(mysqlsh --uri "$SOURCE_DSN" $SOURCE_PASSWORD_OPTION -- util copy-instance "mysql://${MYDUCK_USER}:${MYDUCK_PASSWORD}@${MYDUCK_HOST}:${MYDUCK_PORT}" \
     --users false \
+    --routines false \
+    --events false \
+    --triggers false \
     --consistent false \
     --ignore-existing-objects true \
     --handle-grant-errors ignore \

--- a/issue329_test.go
+++ b/issue329_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/apecloud/myduckserver/backend"
+	"github.com/dolthub/go-mysql-server/enginetest"
+	"github.com/dolthub/go-mysql-server/enginetest/queries"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+func TestIssue329CreateViewWithParens(t *testing.T) {
+	raw := `CREATE OR REPLACE SQL SECURITY INVOKER VIEW v_paren AS (
+    SELECT i FROM t329 WHERE i > 0
+)`
+	rewritten := backend.RewriteIncomingQuery(raw)
+
+	script := queries.ScriptTest{
+		Name: "CREATE VIEW AS (SELECT ...) from issue 329",
+		SetUpScript: []string{
+			"CREATE TABLE t329 (i BIGINT PRIMARY KEY)",
+			"INSERT INTO t329 VALUES (1), (2)",
+			rewritten,
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query: "SELECT i FROM v_paren ORDER BY i",
+				Expected: []sql.Row{
+					{int64(1)},
+					{int64(2)},
+				},
+			},
+		},
+	}
+	enginetest.TestScript(t, NewDefaultDuckHarness(), script)
+}
+
+func TestIssue329SkipFunctionDDL(t *testing.T) {
+	rewritten := backend.RewriteIncomingQuery("/*!50003 DROP FUNCTION IF EXISTS `toDate` */")
+	script := queries.ScriptTest{
+		Name: "DROP FUNCTION from replica dump is a no-op",
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    rewritten,
+				Expected: []sql.Row{{int64(1)}},
+			},
+		},
+	}
+	enginetest.TestScript(t, NewDefaultDuckHarness(), script)
+}


### PR DESCRIPTION
## Summary
Issue 329 leftover: replica snapshot dies on stored functions, and CREATE VIEW AS (SELECT ...) fails to parse.

- Treat CREATE/DROP/ALTER FUNCTION, PROCEDURE, TRIGGER, EVENT as SELECT 1, including MySQL version comments from dumps.
- Rewrite CREATE VIEW name AS (SELECT ...) to CREATE VIEW name AS SELECT ...
- mysqlsh copy-instance now passes --routines false --events false --triggers false.

Views still need a real definition. Functions stay unsupported; we just stop aborting the dump.

## Test plan
- [x] go test ./backend/
- [x] go test -run TestIssue329 .
