### PR TITLE
fix: do not abort replica snapshot when CREATE VIEW fails (#329)

### DIFF
--- a/backend/handler.go
+++ b/backend/handler.go
@@ -17,11 +17,13 @@ package backend
 import (
 	"context"
 	"fmt"
-	"github.com/apecloud/myduckserver/catalog"
 
+	"github.com/apecloud/myduckserver/catalog"
 	"github.com/dolthub/go-mysql-server/server"
+	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/vitess/go/mysql"
 	"github.com/dolthub/vitess/go/sqltypes"
+	"github.com/sirupsen/logrus"
 )
 
 type MyHandler struct {
@@ -62,7 +64,17 @@ func (h *MyHandler) ComMultiQuery(
 	var modifiers []ResultModifier
 	query, modifiers = applyRequestModifiers(query, defaultRequestModifiers)
 
-	return h.Handler.ComMultiQuery(ctx, c, query, wrapResultCallback(callback, modifiers...))
+	called := false
+	cb := func(res *sqltypes.Result, more bool) error {
+		called = true
+		return wrapResultCallback(callback, modifiers...)(res, more)
+	}
+	rest, err := h.Handler.ComMultiQuery(ctx, c, query, cb)
+	if err != nil && !called && shouldIgnoreFailedView(query, isReplicaLoadingSnapshot()) {
+		logrus.WithError(err).Warn("skipping CREATE VIEW during replica snapshot")
+		return rest, callback(&sqltypes.Result{}, false)
+	}
+	return rest, err
 }
 
 // Naive query rewriting. This is just a temporary solution
@@ -76,7 +88,32 @@ func (h *MyHandler) ComQuery(
 	var modifiers []ResultModifier
 	query, modifiers = applyRequestModifiers(query, defaultRequestModifiers)
 
-	return h.Handler.ComQuery(ctx, c, query, wrapResultCallback(callback, modifiers...))
+	called := false
+	cb := func(res *sqltypes.Result, more bool) error {
+		called = true
+		return wrapResultCallback(callback, modifiers...)(res, more)
+	}
+	err := h.Handler.ComQuery(ctx, c, query, cb)
+	if err != nil && !called && shouldIgnoreFailedView(query, isReplicaLoadingSnapshot()) {
+		logrus.WithError(err).Warn("skipping CREATE VIEW during replica snapshot")
+		return callback(&sqltypes.Result{}, false)
+	}
+	return err
+}
+
+func isReplicaLoadingSnapshot() bool {
+	_, vv, ok := sql.SystemVariables.GetGlobal("replica_is_loading_snapshot")
+	if !ok {
+		return false
+	}
+	switch v := vv.(type) {
+	case int8:
+		return v != 0
+	case bool:
+		return v
+	default:
+		return false
+	}
 }
 
 func WrapHandler(provider *catalog.DatabaseProvider) server.HandlerWrapper {

--- a/backend/request_modifier.go
+++ b/backend/request_modifier.go
@@ -302,6 +302,15 @@ func RewriteIncomingQuery(query string) string {
 	return rewritten
 }
 
+func isCreateViewStmt(query string) bool {
+	_, _, ok := findCreateViewBody(query)
+	return ok
+}
+
+func shouldIgnoreFailedView(query string, snapshot bool) bool {
+	return snapshot && isCreateViewStmt(query)
+}
+
 // applyRequestModifiers applies request modifiers to a query
 func applyRequestModifiers(query string, requestModifiers []RequestModifier) (string, []ResultModifier) {
 	resultModifiers := make([]ResultModifier, 0)

--- a/backend/request_modifier_test.go
+++ b/backend/request_modifier_test.go
@@ -99,6 +99,15 @@ func TestUnwrapCreateViewParensWithColumnList(t *testing.T) {
 	require.Equal(t, "CREATE VIEW v (a, b) AS SELECT 1, 2", got)
 }
 
+func TestShouldIgnoreFailedViewDuringSnapshot(t *testing.T) {
+	view := "CREATE OR REPLACE SQL SECURITY INVOKER VIEW log_report_count AS SELECT 1"
+	require.True(t, isCreateViewStmt(view))
+	require.True(t, shouldIgnoreFailedView(view, true))
+	require.False(t, shouldIgnoreFailedView(view, false))
+	require.False(t, shouldIgnoreFailedView("CREATE TABLE t (i INT)", true))
+	require.False(t, shouldIgnoreFailedView("SELECT 1", true))
+}
+
 func TestApplyRequestModifiersIssue329(t *testing.T) {
 	fn, _ := applyRequestModifiers("/*!50003 DROP FUNCTION IF EXISTS `toDate` */", defaultRequestModifiers)
 	require.Equal(t, skipUnsupportedDDL, fn)


### PR DESCRIPTION
## Summary
After #418, replica dump no longer dies on FUNCTION. Views that call those functions still fail CREATE VIEW and abort the schema.

During `replica_is_loading_snapshot`, a failed CREATE VIEW is skipped (empty OK) instead of aborting. Ordinary sessions still get the error.

## Test plan
- [x] go test ./backend/
