### PR TITLE
fix: accept empty string in ENUM like MySQL non-strict (#329)

### DIFF
--- a/catalog/type_mapping.go
+++ b/catalog/type_mapping.go
@@ -99,14 +99,23 @@ func newDateTimeType(mysqlName string, precision int) AnnotatedDuckType {
 }
 
 func newEnumType(typ sql.EnumType) AnnotatedDuckType {
-	// For ENUM type, we need to escape single quotes in values
-	escapedValues := make([]string, len(typ.Values()))
-	for i, v := range typ.Values() {
-		// Replace each single quote with two single quotes to escape it
-		escapedValues[i] = strings.ReplaceAll(v, "'", "''")
+	values := typ.Values()
+	// MySQL non-strict mode stores invalid ENUM values as empty string.
+	// DuckDB rejects members that are not declared, so keep '' in the DuckDB
+	// type. SHOW CREATE TABLE still uses the original MySQL value list.
+	escapedValues := make([]string, 0, len(values)+1)
+	hasEmpty := false
+	for _, v := range values {
+		if v == "" {
+			hasEmpty = true
+		}
+		escapedValues = append(escapedValues, strings.ReplaceAll(v, "'", "''"))
+	}
+	if !hasEmpty {
+		escapedValues = append([]string{""}, escapedValues...)
 	}
 	typeString := `ENUM('` + strings.Join(escapedValues, `', '`) + `')`
-	return AnnotatedDuckType{typeString, MySQLType{Name: "ENUM", Values: typ.Values(), Collation: uint16(typ.Collation())}}
+	return AnnotatedDuckType{typeString, MySQLType{Name: "ENUM", Values: values, Collation: uint16(typ.Collation())}}
 }
 
 func newSetType(typ sql.SetType) AnnotatedDuckType {

--- a/catalog/type_mapping_test.go
+++ b/catalog/type_mapping_test.go
@@ -1,0 +1,43 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEnumTypeIncludesEmptyString(t *testing.T) {
+	typ, err := types.CreateEnumType([]string{"phprapporten", "excelrapporten"}, sql.Collation_Default)
+	require.NoError(t, err)
+	got := newEnumType(typ)
+	require.Equal(t, "ENUM('', 'phprapporten', 'excelrapporten')", got.Name())
+	require.Equal(t, []string{"phprapporten", "excelrapporten"}, got.MySQL().Values)
+}
+
+func TestDuckDBEnumAcceptsEmptyString(t *testing.T) {
+	dir := t.TempDir()
+	prov, err := NewDBProvider("", dir, "myduck")
+	require.NoError(t, err)
+	defer prov.Close()
+
+	_, err = prov.Storage().Exec(`CREATE TABLE t (doel ENUM('', 'phprapporten', 'excelrapporten'))`)
+	require.NoError(t, err)
+	_, err = prov.Storage().Exec(`INSERT INTO t VALUES ('')`)
+	require.NoError(t, err)
+	_, err = prov.Storage().Exec(`INSERT INTO t VALUES ('phprapporten')`)
+	require.NoError(t, err)
+
+	var got string
+	require.NoError(t, prov.Storage().QueryRow(`SELECT doel FROM t WHERE doel = ''`).Scan(&got))
+	require.Equal(t, "", got)
+}
+
+func TestNewEnumTypeKeepsExistingEmptyString(t *testing.T) {
+	typ, err := types.CreateEnumType([]string{"", "a", "b"}, sql.Collation_Default)
+	require.NoError(t, err)
+	got := newEnumType(typ)
+	require.Equal(t, "ENUM('', 'a', 'b')", got.Name())
+	require.Equal(t, []string{"", "a", "b"}, got.MySQL().Values)
+}


### PR DESCRIPTION
## Summary
#329 leftover: MySQL non-strict mode stores invalid ENUM values as empty string. DuckDB rejects members that were not declared, so replica LOAD DATA of '' fails.

Add '' to the DuckDB ENUM type. SHOW CREATE TABLE still uses the original MySQL value list.

## Test plan
- [x] go test ./catalog/ -run TestNewEnumType
- [x] go test ./catalog/ -run TestDuckDBEnum
