### PR TITLE
fix: SELECT VALUES(col) is NULL outside upsert

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -240,13 +240,12 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_pk,_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_AS_x_______FROM_one_pk_opk_WHERE_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_>_0_______GROUP_BY_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_ORDER_BY_x",
 
 		"SELECT_count(*)_FROM_people_WHERE_last_name='doe'_and_first_name='jane'_order_by_dob",
-		"SELECT_VALUES(i)_FROM_mytable",
-		"select_i,_row_number()_over_(order_by_i_desc)_+_3,____row_number()_over_(order_by_length(s),i)_+_0.0_/_row_number()_over_(order_by_length(s)_desc,i_desc)_+_0.0____from_mytable_order_by_1;",
-		"SELECT_pk,_row_number()_over_(partition_by_v2_order_by_pk_),_max(v3)_over_(partition_by_v2_order_by_pk)_FROM_one_pk_three_idx_ORDER_BY_pk",
-
 		"show_function_status",
 		"show_function_status_like_'foo'",
 		"show_function_status_where_Db='mydb'",
+		"select_i,_row_number()_over_(order_by_i_desc)_+_3,____row_number()_over_(order_by_length(s),i)_+_0.0_/_row_number()_over_(order_by_length(s)_desc,i_desc)_+_0.0____from_mytable_order_by_1;",
+		"SELECT_pk,_row_number()_over_(partition_by_v2_order_by_pk_),_max(v3)_over_(partition_by_v2_order_by_pk)_FROM_one_pk_three_idx_ORDER_BY_pk",
+
 
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_keyless_U0,_cte___WHERE_cte.j_=_keyless.c0____)_____ORDER_BY_c0;_",
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_cte,_keyless_U0____WHERE_cte.j_=_keyless.c0_____)_____ORDER_BY_c0;_",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -486,6 +486,10 @@ def rewrite_mysql_for_duckdb(node):
                 kind=node.args.get("kind"),
                 constraints=kept,
             )
+    # MySQL VALUES(col) is only meaningful in INSERT ON DUPLICATE KEY UPDATE.
+    # In SELECT it is deprecated and returns NULL. Do not use this for upsert.
+    if isinstance(node, exp.Anonymous) and str(node.this).upper() == "VALUES":
+        return exp.Null()
     # MySQL CHAR_LENGTH / CHARACTER_LENGTH -> DuckDB LENGTH (character count).
     # Without this, some paths still emit CHAR_LENGTH, which DuckDB does not have.
     if isinstance(node, exp.Length) and not node.args.get("binary"):

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -486,10 +486,6 @@ def rewrite_mysql_for_duckdb(node):
                 kind=node.args.get("kind"),
                 constraints=kept,
             )
-    # MySQL VALUES(col) is only meaningful in INSERT ON DUPLICATE KEY UPDATE.
-    # In SELECT it is deprecated and returns NULL. Do not use this for upsert.
-    if isinstance(node, exp.Anonymous) and str(node.this).upper() == "VALUES":
-        return exp.Null()
     # MySQL CHAR_LENGTH / CHARACTER_LENGTH -> DuckDB LENGTH (character count).
     # Without this, some paths still emit CHAR_LENGTH, which DuckDB does not have.
     if isinstance(node, exp.Length) and not node.args.get("binary"):
@@ -1208,7 +1204,17 @@ def transpile_mysql_to_duckdb(sql: str) -> str:
     if not trees or trees[0] is None:
         return ""
     # Keep the historical contract: only the first statement is returned.
-    return trees[0].transform(rewrite_mysql_for_duckdb).sql(dialect="duckdb")
+    # VALUES(col) is NULL in SELECT, but INSERT ON DUPLICATE KEY must keep it.
+    in_insert = [0]
+    def rewrite_with_insert_context(node):
+        if isinstance(node, exp.Insert):
+            in_insert[0] += 1
+        if isinstance(node, exp.Anonymous) and str(node.this).upper() == "VALUES":
+            if in_insert[0]:
+                return node
+            return exp.Null()
+        return rewrite_mysql_for_duckdb(node)
+    return trees[0].transform(rewrite_with_insert_context).sql(dialect="duckdb")
 
 while True:
     inp = read_string()

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -472,6 +472,11 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT NULL FROM mytable",
 		},
 		{
+			name:     "ON DUPLICATE KEY keeps VALUES",
+			input:    "INSERT INTO mytable (i, s) VALUES (1, 'hi') ON DUPLICATE KEY UPDATE s = VALUES(s)",
+			expected: "INSERT INTO mytable (i, s) VALUES (1, 'hi') ON DUPLICATE KEY UPDATE SET s = VALUES(s)",
+		},
+		{
 			name:     "UPDATE LEFT JOIN is left alone",
 			input:    "UPDATE othertable LEFT JOIN tabletest ON othertable.i2 = 3 AND tabletest.i = 3 SET othertable.s2 = 'fourth'",
 			expected: "UPDATE othertable LEFT JOIN tabletest ON othertable.i2 = 3 AND tabletest.i = 3 SET othertable.s2 = 'fourth'",

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -467,6 +467,11 @@ func TestTranslate(t *testing.T) {
 			expected: "UPDATE one_pk INNER JOIN two_pk ON one_pk.pk = two_pk.pk1 SET one_pk.c1 = one_pk.c1 + 1, two_pk.c1 = two_pk.c2 + 1",
 		},
 		{
+			name:     "SELECT VALUES(col) is NULL",
+			input:    "SELECT VALUES(i) FROM mytable",
+			expected: "SELECT NULL FROM mytable",
+		},
+		{
 			name:     "UPDATE LEFT JOIN is left alone",
 			input:    "UPDATE othertable LEFT JOIN tabletest ON othertable.i2 = 3 AND tabletest.i = 3 SET othertable.s2 = 'fourth'",
 			expected: "UPDATE othertable LEFT JOIN tabletest ON othertable.i2 = 3 AND tabletest.i = 3 SET othertable.s2 = 'fourth'",


### PR DESCRIPTION
## Summary
`SELECT VALUES(i) FROM mytable` is deprecated MySQL and returns NULL. Translate to `SELECT NULL`. Do not use this for INSERT ON DUPLICATE KEY.

## Test plan
- [x] `go test ./transpiler/`
- [x] `go test -run 'TestQueries/SELECT_VALUES' .`