### PR TITLE
test: reject wrong Postgres password when superuser password is set (#341)

### DIFF
--- a/pgserver/issue341_test.go
+++ b/pgserver/issue341_test.go
@@ -1,0 +1,34 @@
+package pgserver
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/apecloud/myduckserver/testutil"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIssue341PgAuthRejectsWrongPassword checks
+// https://github.com/apecloud/myduckserver/issues/341 :
+// --superuser-password enables SCRAM; a wrong password must not connect.
+func TestIssue341PgAuthRejectsWrongPassword(t *testing.T) {
+	testDir := testutil.CreateTestDir(t)
+	testEnv := testutil.NewTestEnv()
+	testEnv.SuperuserPassword = "secret"
+	testEnv.ExtraArgs = []string{"--superuser-password=secret"}
+	err := testutil.StartDuckSqlServer(t, testDir, nil, testEnv)
+	require.NoError(t, err)
+	defer testutil.StopDuckSqlServer(t, testEnv.DuckProcess)
+
+	port := strconv.Itoa(testEnv.DuckPgPort)
+	_, err = pgx.Connect(context.Background(), "postgresql://postgres:wrong@127.0.0.1:"+port+"/postgres")
+	require.Error(t, err, "wrong password must be rejected")
+
+	db, err := pgx.Connect(context.Background(), "postgresql://postgres:secret@127.0.0.1:"+port+"/postgres")
+	require.NoError(t, err, "correct password must connect")
+	defer db.Close(context.Background())
+	_, err = db.Exec(context.Background(), "SELECT 1")
+	require.NoError(t, err)
+}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -30,6 +30,8 @@ type TestEnv struct {
 	TestDir                             string
 	OriginalWorkingDir                  string
 	MyDuckServer                        *sqlx.DB
+	ExtraArgs                           []string
+	SuperuserPassword                   string
 }
 
 func NewTestEnv() *TestEnv {
@@ -88,6 +90,7 @@ func StartDuckSqlServer(t *testing.T, dir string, persistentSystemVars map[strin
 		"--default-time-zone=UTC",
 		"--loglevel=4", // 4: INFO, 5: DEBUG, 6: TRACE
 	}
+	args = append(args, testEnv.ExtraArgs...)
 
 	// If we're running in CI, use a precompiled dolt binary instead of go run
 	devBuildPath := initializeDevBuild(dir, goDirPath)
@@ -135,7 +138,12 @@ func StartDuckSqlServer(t *testing.T, dir string, persistentSystemVars map[strin
 
 	fmt.Printf("MyDuck CMD: %s\n", cmd.String())
 
-	dsn := fmt.Sprintf("%s@tcp(127.0.0.1:%v)/", "root", testEnv.DuckPort)
+	var dsn string
+	if testEnv.SuperuserPassword != "" {
+		dsn = fmt.Sprintf("root:%s@tcp(127.0.0.1:%v)/", testEnv.SuperuserPassword, testEnv.DuckPort)
+	} else {
+		dsn = fmt.Sprintf("%s@tcp(127.0.0.1:%v)/", "root", testEnv.DuckPort)
+	}
 	testEnv.MyDuckServer = sqlx.MustOpen("mysql", dsn)
 
 	err = WaitForSqlServerToStart(testEnv.MyDuckServer)


### PR DESCRIPTION
## Summary
#341: Postgres auth is already implemented (SCRAM). It is off when `--superuser-password` is empty.

Add a test: wrong password is rejected, correct password can run `SELECT 1`.

## Test plan
- [x] go test ./pgserver/ -run TestIssue341PgAuthRejectsWrongPassword
