### PR TITLE
fix: drop ORDER BY on a lone aggregate SELECT

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -239,8 +239,7 @@ func TestQueriesSimple(t *testing.T) {
 		"SELECT_pk,_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_AS_x_______FROM_one_pk_opk_WHERE_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_>_0_______GROUP_BY_x_ORDER_BY_x",
 		"SELECT_pk,_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_AS_x_______FROM_one_pk_opk_WHERE_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_>_0_______GROUP_BY_(SELECT_max(pk)_FROM_one_pk_WHERE_pk_<_opk.pk)_ORDER_BY_x",
 
-		"SELECT_count(*)_FROM_people_WHERE_last_name='doe'_and_first_name='jane'_order_by_dob",
-		"show_function_status",
+				"show_function_status",
 		"show_function_status_like_'foo'",
 		"show_function_status_where_Db='mydb'",
 		"select_i,_row_number()_over_(order_by_i_desc)_+_3,____row_number()_over_(order_by_length(s),i)_+_0.0_/_row_number()_over_(order_by_length(s)_desc,i_desc)_+_0.0____from_mytable_order_by_1;",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -1096,6 +1096,20 @@ def rewrite_mysql_for_duckdb(node):
                     false=inner,
                 )
                 return exp.Cast(this=wrapped, to=to)
+    # MySQL allows ORDER BY a non-selected column on a lone aggregate.
+    # The result is one row, so drop the ORDER BY for DuckDB.
+    if isinstance(node, exp.Select) and node.args.get("order") is not None and node.args.get("group") is None:
+        exprs = list(node.expressions or [])
+        def _is_agg_or_lit(e):
+            if e is None or isinstance(e, exp.Star):
+                return False
+            if isinstance(e, exp.Literal):
+                return True
+            return any(isinstance(x, exp.AggFunc) for x in e.walk())
+        if exprs and all(_is_agg_or_lit(e) for e in exprs):
+            updated = node.copy()
+            updated.set("order", None)
+            return updated
     # MySQL allows SELECT pk, SUM(c) without GROUP BY when ONLY_FULL_GROUP_BY is off.
     # DuckDB requires the extra columns to be aggregated; ANY_VALUE matches that mode.
     if isinstance(node, exp.Select) and node.args.get("group") is None:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -327,6 +327,11 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT COALESCE(TRY_CAST(s AS DOUBLE), 0) > 2 FROM tabletest",
 		},
 		{
+			name:     "aggregate ORDER BY unused column is dropped",
+			input:    "SELECT count(*) FROM people WHERE last_name='doe' AND first_name='jane' ORDER BY dob",
+			expected: "SELECT COUNT(*) FROM people WHERE last_name = 'doe' AND first_name = 'jane'",
+		},
+		{
 			name:     "id = 1 is left alone",
 			input:    "SELECT i FROM mytable WHERE id = 1",
 			expected: "SELECT i FROM mytable WHERE id = 1",


### PR DESCRIPTION
## Summary
`SELECT count(*) ... ORDER BY dob` is one row in MySQL. DuckDB requires `dob` in GROUP BY. Drop the ORDER BY when every select item is an aggregate and there is no GROUP BY.

## Test plan
- [x] `go test ./transpiler/`
- [x] `go test -run 'TestQueries/SELECT_count' .`