### PR TITLE
fix: keep ORDER BY on window aggregates

### DIFF
--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -1105,6 +1105,9 @@ def rewrite_mysql_for_duckdb(node):
                 return False
             if isinstance(e, exp.Literal):
                 return True
+            # Window aggregates still return one row per input row.
+            if any(isinstance(x, exp.Window) for x in e.walk()):
+                return False
             return any(isinstance(x, exp.AggFunc) for x in e.walk())
         if exprs and all(_is_agg_or_lit(e) for e in exprs):
             updated = node.copy()

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -332,6 +332,11 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT COUNT(*) FROM people WHERE last_name = 'doe' AND first_name = 'jane'",
 		},
 		{
+			name:     "window aggregate keeps ORDER BY",
+			input:    "SELECT count(*) OVER () FROM mytable ORDER BY i",
+			expected: "SELECT COUNT(*) OVER () FROM mytable ORDER BY i NULLS FIRST",
+		},
+		{
 			name:     "id = 1 is left alone",
 			input:    "SELECT i FROM mytable WHERE id = 1",
 			expected: "SELECT i FROM mytable WHERE id = 1",


### PR DESCRIPTION
## Summary
Follow-up to #425. Dropping ORDER BY is only safe for a true one-row aggregate. `COUNT(*) OVER (...)` still returns one row per input row.

If the select list contains a window, keep ORDER BY.

## Test plan
- [x] go test ./transpiler/
