### PR TITLE
fix: MySQL UPDATE SET last assignment wins

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -895,7 +895,6 @@ func TestUpdate(t *testing.T) {
 	harness.QueriesToSkip(
 		"UPDATE_IGNORE_one_pk_INNER_JOIN_two_pk_on_one_pk.pk_=_two_pk.pk1_SET_two_pk.c1_=_two_pk.c1_+_1",
 		"UPDATE_IGNORE_one_pk_JOIN_one_pk_one_pk2_on_one_pk.pk_=_one_pk2.pk_SET_one_pk.pk_=_10",
-		"UPDATE_floattable_SET_f32_=_5,_f32_=_4_WHERE_i_=_1;",
 		"UPDATE_floattable_SET_f32_=_f32_+_f32,_f64_=_f32_*_f64_WHERE_i_=_2;",
 		"UPDATE_mytable_SET_s_=_'first_row'_WHERE_i_=_1;",
 		"UPDATE_mytable_SET_s_=_'updated'_ORDER_BY_i_LIMIT_1_OFFSET_1;",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -259,9 +259,33 @@ def _target_rowid(match, tgt_name):
         return exp.column("rowid", table=alias)
     return exp.column("rowid")
 
+def _col_key(col):
+    return ((col.table or "").lower(), (col.name or "").lower())
+
+def _last_wins_sets(exprs):
+    # MySQL SET a = 1, a = 2 keeps 2. DuckDB rejects two assignments.
+    exprs = list(exprs or [])
+    last_pos = {}
+    for i, e in enumerate(exprs):
+        if isinstance(e, exp.EQ) and isinstance(e.this, exp.Column):
+            last_pos[_col_key(e.this)] = i
+    out = []
+    for i, e in enumerate(exprs):
+        if isinstance(e, exp.EQ) and isinstance(e.this, exp.Column):
+            if last_pos[_col_key(e.this)] != i:
+                continue
+        out.append(e)
+    return out
+
 def _rewrite_mysql_update(node):
     if not isinstance(node, exp.Update):
         return None
+    original = list(node.expressions or [])
+    exprs = _last_wins_sets(original)
+    deduped = exprs != original
+    if deduped:
+        node = node.copy()
+        node.set("expressions", exprs)
     srcs, ons = [], []
     _collect_from_src(node.this, srcs, ons)
     has_join = len(srcs) > 1
@@ -283,7 +307,7 @@ def _rewrite_mysql_update(node):
         kwargs.update(_with_kwargs(node))
         return exp.Update(**kwargs)
     if not has_join:
-        return None
+        return node if deduped else None
     if isinstance(node.this, exp.Table):
         for j in node.this.args.get("joins") or []:
             if not _join_is_inner_or_cross(j):

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -337,6 +337,11 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT COUNT(*) OVER () FROM mytable ORDER BY i NULLS FIRST",
 		},
 		{
+			name:     "duplicate SET keeps the last assignment",
+			input:    "UPDATE floattable SET f32 = 5, f32 = 4 WHERE i = 1",
+			expected: "UPDATE floattable SET f32 = 4 WHERE i = 1",
+		},
+		{
 			name:     "charset introducer is stripped",
 			input:    "UPDATE mytable SET s = _binary 'updated' WHERE i = 3",
 			expected: "UPDATE mytable SET s = 'updated' WHERE i = 3",


### PR DESCRIPTION
## Summary
MySQL `SET f32 = 5, f32 = 4` keeps 4. DuckDB errors on two assignments to the same column. Keep the last one.

## Test plan
- [x] `go test ./transpiler/`
- [x] `go test -run '^TestUpdate$/UPDATE_floattable_SET_f32_=_5'`