### PR TITLE
fix: UPDATE ... LIMIT n OFFSET m uses rowid

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -897,8 +897,6 @@ func TestUpdate(t *testing.T) {
 		"UPDATE_IGNORE_one_pk_JOIN_one_pk_one_pk2_on_one_pk.pk_=_one_pk2.pk_SET_one_pk.pk_=_10",
 		"UPDATE_floattable_SET_f32_=_f32_+_f32,_f64_=_f32_*_f64_WHERE_i_=_2;",
 		"UPDATE_mytable_SET_s_=_'first_row'_WHERE_i_=_1;",
-		"UPDATE_mytable_SET_s_=_'updated'_ORDER_BY_i_LIMIT_1_OFFSET_1;",
-
 		"UPDATE_niltable_SET_b_=_NULL_WHERE_f_IS_NULL;",
 		"UPDATE_othertable_INNER_JOIN_tabletest_on_othertable.i2=3_and_tabletest.i=3_SET_othertable.s2_=_'fourth'",
 		"UPDATE_one_pk_INNER_JOIN_two_pk_on_one_pk.pk_=_two_pk.pk1_SET_one_pk.c1_=_one_pk.c1_+_1,_one_pk.c2_=_one_pk.c2_+_1_ORDER_BY_one_pk.pk",

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -297,8 +297,14 @@ def _rewrite_mysql_update(node):
             sub = sub.where(node.args.get("where").this)
         if node.args.get("order") is not None:
             sub.set("order", node.args.get("order"))
-        if node.args.get("limit") is not None:
-            sub.set("limit", node.args.get("limit"))
+        lim = node.args.get("limit")
+        if lim is not None:
+            off = lim.args.get("offset")
+            if off is not None:
+                sub.set("limit", exp.Limit(expression=lim.args.get("expression")))
+                sub.set("offset", exp.Offset(expression=off))
+            else:
+                sub.set("limit", lim)
         kwargs = {
             "this": tbl,
             "expressions": list(node.expressions or []),
@@ -1233,6 +1239,13 @@ def transpile_mysql_to_duckdb(sql: str) -> str:
     # MySQL allows t.AND / t.OR / t.SELECT as identifiers. Quote so sqlglot parses them.
     bq = chr(96)
     sql = re.sub(r'\.(AND|OR|SELECT)\b', lambda m: '.' + bq + m.group(1) + bq, sql, flags=re.I)
+    # SQLGlot rejects UPDATE ... LIMIT n OFFSET m. LIMIT offset, count parses.
+    if re.match(r'(?is)^update\b', sql.strip()):
+        sql = re.sub(
+            r'(?is)\blimit\s+(\d+)\s+offset\s+(\d+)\s*;?\s*$',
+            lambda m: 'LIMIT ' + m.group(2) + ', ' + m.group(1),
+            sql.strip(),
+        )
     try:
         trees = sqlglot.parse(sql, read="mysql")
     except Exception:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -482,6 +482,11 @@ func TestTranslate(t *testing.T) {
 			expected: "UPDATE mytable SET s = 'updated' WHERE rowid IN ((SELECT rowid FROM mytable ORDER BY i ASC NULLS FIRST LIMIT 2))",
 		},
 		{
+			name:     "UPDATE LIMIT OFFSET uses rowid",
+			input:    "UPDATE mytable SET s = 'updated' ORDER BY i LIMIT 1 OFFSET 1",
+			expected: "UPDATE mytable SET s = 'updated' WHERE rowid IN ((SELECT rowid FROM mytable ORDER BY i NULLS FIRST LIMIT 1 OFFSET 1))",
+		},
+		{
 			name:     "multi-table UPDATE SET is left alone",
 			input:    "UPDATE one_pk INNER JOIN two_pk ON one_pk.pk = two_pk.pk1 SET one_pk.c1 = one_pk.c1 + 1, two_pk.c1 = two_pk.c2 + 1",
 			expected: "UPDATE one_pk INNER JOIN two_pk ON one_pk.pk = two_pk.pk1 SET one_pk.c1 = one_pk.c1 + 1, two_pk.c1 = two_pk.c2 + 1",


### PR DESCRIPTION
## Summary
SQLGlot rejects `UPDATE ... LIMIT 1 OFFSET 1`. Rewrite to MySQL `LIMIT offset, count`, then apply the existing rowid filter. Emit DuckDB `LIMIT 1 OFFSET 1`.

## Test plan
- [x] `go test ./transpiler/`
- [x] `go test -run '^TestUpdate$/UPDATE_mytable_SET_s_=_updated'`