### PR TITLE
fix: SHOW FUNCTION STATUS is empty, not an error

### DIFF
--- a/catalog/database.go
+++ b/catalog/database.go
@@ -28,6 +28,7 @@ var _ sql.ViewDatabase = (*Database)(nil)
 var _ sql.TriggerDatabase = (*Database)(nil)
 var _ sql.CollatedDatabase = (*Database)(nil)
 var _ sql.TemporaryTableCreator = (*Database)(nil)
+var _ sql.StoredProcedureDatabase = (*Database)(nil)
 
 func NewDatabase(name string, catalogName string) *Database {
 	return &Database{
@@ -435,6 +436,27 @@ func (d *Database) DropTrigger(ctx *sql.Context, name string) error {
 // GetTriggers implements sql.TriggerDatabase.
 func (d *Database) GetTriggers(ctx *sql.Context) ([]sql.TriggerDefinition, error) {
 	return nil, nil
+}
+
+// GetStoredProcedure implements sql.StoredProcedureDatabase.
+// Routines are not hosted in DuckDB; SHOW FUNCTION STATUS should be empty.
+func (d *Database) GetStoredProcedure(ctx *sql.Context, name string) (sql.StoredProcedureDetails, bool, error) {
+	return sql.StoredProcedureDetails{}, false, nil
+}
+
+// GetStoredProcedures implements sql.StoredProcedureDatabase.
+func (d *Database) GetStoredProcedures(ctx *sql.Context) ([]sql.StoredProcedureDetails, error) {
+	return nil, nil
+}
+
+// SaveStoredProcedure implements sql.StoredProcedureDatabase.
+func (d *Database) SaveStoredProcedure(ctx *sql.Context, spd sql.StoredProcedureDetails) error {
+	return sql.ErrStoredProceduresNotSupported.New(d.name)
+}
+
+// DropStoredProcedure implements sql.StoredProcedureDatabase.
+func (d *Database) DropStoredProcedure(ctx *sql.Context, name string) error {
+	return sql.ErrStoredProceduresNotSupported.New(d.name)
 }
 
 // GetCollation implements sql.CollatedDatabase.

--- a/main_test.go
+++ b/main_test.go
@@ -237,9 +237,6 @@ func TestQueriesSimple(t *testing.T) {
 
 
 
-				"show_function_status",
-		"show_function_status_like_'foo'",
-		"show_function_status_where_Db='mydb'",
 		"select_i,_row_number()_over_(order_by_i_desc)_+_3,____row_number()_over_(order_by_length(s),i)_+_0.0_/_row_number()_over_(order_by_length(s)_desc,i_desc)_+_0.0____from_mytable_order_by_1;",
 		"SELECT_pk,_row_number()_over_(partition_by_v2_order_by_pk_),_max(v3)_over_(partition_by_v2_order_by_pk)_FROM_one_pk_three_idx_ORDER_BY_pk",
 


### PR DESCRIPTION
## Summary
`SHOW FUNCTION STATUS` failed because the catalog did not implement stored procedures. We do not host routines; return an empty list so the statement succeeds.

CREATE/DROP PROCEDURE still returns not supported.

## Test plan
- [x] `go test ./catalog/`
- [x] `go test -run 'TestQueries/show_function' .`