### PR TITLE
test: unskip CREATE TABLE defaults with _utf8mb4

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1072,8 +1072,6 @@ func TestCreateTable(t *testing.T) {
 		"CREATE_TABLE_t1_(____pk_bigint_primary_key,____v1_bigint_default_(2)_comment_'hi_there',____index_idx_v1_(v1)_comment_'index_here'____)",
 		"CREATE_TABLE_t1_SELECT_*_from_mytable",
 		"CREATE_TABLE_t1_SELECT_*_from_mytable",
-		"CREATE_TABLE_t1_(_____pk_int_NOT_NULL,_____col1_blob_DEFAULT_(_utf8mb4'abc'),_____col2_json_DEFAULT_(json_object(_utf8mb4'a',1)),_____col3_text_DEFAULT_(_utf8mb4'abc'),_____PRIMARY_KEY_(pk)___)",
-		"CREATE_TABLE_t1_(_____pk_int_NOT_NULL,_____col1_blob_DEFAULT_(_utf8mb4'abc'),_____col2_json_DEFAULT_(json_object(_utf8mb4'a',1)),_____col3_text_DEFAULT_(_utf8mb4'abc'),_____PRIMARY_KEY_(pk)___)",
 		"CREATE_TABLE_td_(_____pk_int_PRIMARY_KEY,_____col2_int_NOT_NULL_DEFAULT_2,______col3_double_NOT_NULL_DEFAULT_(round(-(1.58),0)),_____col4_varchar(10)_DEFAULT_'new_row',___________col5_float_DEFAULT_33.33,___________col6_int_DEFAULT_NULL,_____col7_timestamp_DEFAULT_NOW(),_____col8_bigint_DEFAULT_(NOW())___)",
 		"CREATE_TABLE_td_(_____pk_int_PRIMARY_KEY,_____col2_int_NOT_NULL_DEFAULT_2,______col3_double_NOT_NULL_DEFAULT_(round(-(1.58),0)),_____col4_varchar(10)_DEFAULT_'new_row',___________col5_float_DEFAULT_33.33,___________col6_int_DEFAULT_NULL,_____col7_timestamp_DEFAULT_NOW(),_____col8_bigint_DEFAULT_(NOW())___)",
 		"create_table_t1_(i_int_primary_key,_b1_blob,_b2_blob,_index(b1(123),_b2(456)))",


### PR DESCRIPTION
## Summary
`DEFAULT (_utf8mb4'abc')` already works after the introducer rewrite. Open the two skipped CREATE TABLE cases.

## Test plan
- [x] `go test -run '^TestCreateTable$' .`