### PR TITLE
fix: RAND(seed) matches go-mysql-server math/rand

### DIFF
--- a/catalog/connpool.go
+++ b/catalog/connpool.go
@@ -87,6 +87,10 @@ func (p *ConnectionPool) GetConn(ctx context.Context, id uint32) (*stdsql.Conn, 
 		if err != nil {
 			return nil, err
 		}
+		if err := registerMySQLRand(c); err != nil {
+			_ = c.Close()
+			return nil, fmt.Errorf("register mysql_rand: %w", err)
+		}
 		p.conns.Store(id, c)
 		conn = c
 	} else {

--- a/catalog/mysql_rand.go
+++ b/catalog/mysql_rand.go
@@ -1,0 +1,61 @@
+package catalog
+
+import (
+	stdsql "database/sql"
+	"database/sql/driver"
+	"math/rand"
+
+	"github.com/marcboeker/go-duckdb"
+)
+
+// mysqlRandUDF matches go-mysql-server RAND(seed):
+// rand.New(rand.NewSource(int64(seed))).Float64().
+type mysqlRandUDF struct{}
+
+func mysqlRandFromSeed(seed int64) float64 {
+	return rand.New(rand.NewSource(seed)).Float64()
+}
+
+func mysqlRandExec(values []driver.Value) (any, error) {
+	var seed int64
+	if len(values) > 0 && values[0] != nil {
+		switch v := values[0].(type) {
+		case int64:
+			seed = v
+		case int32:
+			seed = int64(v)
+		case int16:
+			seed = int64(v)
+		case int8:
+			seed = int64(v)
+		case float64:
+			seed = int64(v)
+		case float32:
+			seed = int64(v)
+		}
+	}
+	return mysqlRandFromSeed(seed), nil
+}
+
+func (*mysqlRandUDF) Config() duckdb.ScalarFuncConfig {
+	in, err := duckdb.NewTypeInfo(duckdb.TYPE_BIGINT)
+	if err != nil {
+		panic(err)
+	}
+	out, err := duckdb.NewTypeInfo(duckdb.TYPE_DOUBLE)
+	if err != nil {
+		panic(err)
+	}
+	return duckdb.ScalarFuncConfig{
+		InputTypeInfos: []duckdb.TypeInfo{in},
+		ResultTypeInfo: out,
+	}
+}
+
+func (*mysqlRandUDF) Executor() duckdb.ScalarFuncExecutor {
+	return duckdb.ScalarFuncExecutor{RowExecutor: mysqlRandExec}
+}
+
+func registerMySQLRand(conn *stdsql.Conn) error {
+	return duckdb.RegisterScalarUDF(conn, "mysql_rand", &mysqlRandUDF{})
+}

--- a/catalog/mysql_rand_test.go
+++ b/catalog/mysql_rand_test.go
@@ -1,0 +1,21 @@
+package catalog
+
+import "testing"
+
+func TestMySQLRandFromSeed(t *testing.T) {
+	cases := []struct {
+		seed int64
+		want float64
+	}{
+		{1, 0.6046602879796196},
+		{2, 0.16729663442585624},
+		{3, 0.7199826688373036},
+		{100, 0.8165026937796166},
+	}
+	for _, tc := range cases {
+		got := mysqlRandFromSeed(tc.seed)
+		if got != tc.want {
+			t.Fatalf("mysqlRandFromSeed(%d) = %v; want %v", tc.seed, got, tc.want)
+		}
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -232,7 +232,7 @@ func TestQueriesSimple(t *testing.T) {
 		"select_pk,____________________percent_rank()_over(partition_by_v2_order_by_pk),____________________dense_rank()_over(partition_by_v2_order_by_pk),____________________rank()_over(partition_by_v2_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 		"select_pk,_________first_value(pk)_over_(order_by_pk_desc),_________lag(pk,_1)_over_(order_by_pk_desc),_________count(pk)_over(partition_by_v1_order_by_pk),_________max(pk)_over(partition_by_v1_order_by_pk_desc),_________avg(v2)_over_(partition_by_v1_order_by_pk)_____from_one_pk_three_idx_order_by_pk",
 
-		"SELECT_RAND(i)_from_mytable_order_by_i",
+
 
 
 

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -603,6 +603,13 @@ def rewrite_mysql_for_duckdb(node):
                     ],
                 )
         return formatted
+    # MySQL RAND(seed) is deterministic. DuckDB random() has no seed.
+    if isinstance(node, exp.Rand) and node.this is not None:
+        seed = node.this.transform(rewrite_mysql_for_duckdb)
+        return exp.Anonymous(this="mysql_rand", expressions=[seed])
+    if isinstance(node, exp.Anonymous) and str(node.this).upper() == "RAND" and node.expressions:
+        seed = node.expressions[0].transform(rewrite_mysql_for_duckdb)
+        return exp.Anonymous(this="mysql_rand", expressions=[seed])
     # MySQL CRC32 is IEEE of the string bytes. DuckDB has no CRC32; use __sys__.mysql_crc32.
     if isinstance(node, exp.Anonymous) and str(node.this).upper() == "CRC32" and node.expressions:
         return exp.Anonymous(

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -362,6 +362,11 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT i FROM mytable WHERE id = 1",
 		},
 		{
+			name:     "RAND seed uses mysql_rand",
+			input:    "SELECT RAND(i) FROM mytable ORDER BY i",
+			expected: "SELECT MYSQL_RAND(i) FROM mytable ORDER BY i NULLS FIRST",
+		},
+		{
 			name:     "string column equal to zero is numeric",
 			input:    "SELECT * FROM tabletest WHERE s = 0",
 			expected: "SELECT * FROM tabletest WHERE COALESCE(TRY_CAST(s AS DOUBLE), 0) = 0",


### PR DESCRIPTION
## Summary
MySQL `RAND(n)` is deterministic. DuckDB `random()` has no seed.

Register `mysql_rand(seed)` as a scalar UDF that uses `rand.New(rand.NewSource(seed)).Float64()`, the same PRNG go-mysql-server uses. `RAND()` with no argument stays DuckDB `random()`.

## Test plan
- [x] `go test ./transpiler/ ./catalog/ -run 'TestTranslate$|TestTranslateConcurrent|TestMySQLRandFromSeed'`
- [x] `SELECT RAND(i) FROM mytable ORDER BY i` returns `0.60466…`, `0.16729…`, `0.71998…`