### PR TITLE
fix: RANDOM_BYTES(n) is n real random bytes

### DIFF
--- a/catalog/connpool.go
+++ b/catalog/connpool.go
@@ -91,6 +91,10 @@ func (p *ConnectionPool) GetConn(ctx context.Context, id uint32) (*stdsql.Conn, 
 			_ = c.Close()
 			return nil, fmt.Errorf("register mysql_rand: %w", err)
 		}
+		if err := registerMySQLRandomBytes(c); err != nil {
+			_ = c.Close()
+			return nil, fmt.Errorf("register mysql_random_bytes: %w", err)
+		}
 		p.conns.Store(id, c)
 		conn = c
 	} else {

--- a/catalog/mysql_random_bytes.go
+++ b/catalog/mysql_random_bytes.go
@@ -1,0 +1,68 @@
+package catalog
+
+import (
+	crand "crypto/rand"
+	stdsql "database/sql"
+	"database/sql/driver"
+	"fmt"
+
+	"github.com/marcboeker/go-duckdb"
+)
+
+// mysqlRandomBytesUDF implements MySQL RANDOM_BYTES(n): n cryptographically
+// random bytes. n must be 1..1024.
+type mysqlRandomBytesUDF struct{}
+
+func mysqlRandomBytesExec(values []driver.Value) (any, error) {
+	if len(values) == 0 || values[0] == nil {
+		return nil, nil
+	}
+	var n int64
+	switch v := values[0].(type) {
+	case int64:
+		n = v
+	case int32:
+		n = int64(v)
+	case int16:
+		n = int64(v)
+	case int8:
+		n = int64(v)
+	case float64:
+		n = int64(v)
+	case float32:
+		n = int64(v)
+	default:
+		return nil, fmt.Errorf("RANDOM_BYTES: invalid length")
+	}
+	if n < 1 || n > 1024 {
+		return nil, fmt.Errorf("RANDOM_BYTES: length must be between 1 and 1024")
+	}
+	b := make([]byte, n)
+	if _, err := crand.Read(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (*mysqlRandomBytesUDF) Config() duckdb.ScalarFuncConfig {
+	in, err := duckdb.NewTypeInfo(duckdb.TYPE_BIGINT)
+	if err != nil {
+		panic(err)
+	}
+	out, err := duckdb.NewTypeInfo(duckdb.TYPE_BLOB)
+	if err != nil {
+		panic(err)
+	}
+	return duckdb.ScalarFuncConfig{
+		InputTypeInfos: []duckdb.TypeInfo{in},
+		ResultTypeInfo: out,
+	}
+}
+
+func (*mysqlRandomBytesUDF) Executor() duckdb.ScalarFuncExecutor {
+	return duckdb.ScalarFuncExecutor{RowExecutor: mysqlRandomBytesExec}
+}
+
+func registerMySQLRandomBytes(conn *stdsql.Conn) error {
+	return duckdb.RegisterScalarUDF(conn, "mysql_random_bytes", &mysqlRandomBytesUDF{})
+}

--- a/catalog/mysql_random_bytes_test.go
+++ b/catalog/mysql_random_bytes_test.go
@@ -1,0 +1,27 @@
+package catalog
+
+import (
+	"database/sql/driver"
+	"testing"
+)
+
+func TestMySQLRandomBytesExecLength(t *testing.T) {
+	got, err := mysqlRandomBytesExec([]driver.Value{int64(3)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, ok := got.([]byte)
+	if !ok {
+		t.Fatalf("got %T, want []byte", got)
+	}
+	if len(b) != 3 {
+		t.Fatalf("len = %d; want 3", len(b))
+	}
+}
+
+func TestMySQLRandomBytesExecRejectsZero(t *testing.T) {
+	_, err := mysqlRandomBytesExec([]driver.Value{int64(0)})
+	if err == nil {
+		t.Fatal("expected error for length 0")
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -242,7 +242,7 @@ func TestQueriesSimple(t *testing.T) {
 		"____SELECT_COUNT(*)__FROM_keyless__WHERE_keyless.c0_IN_(_____WITH_RECURSIVE_cte(depth,_i,_j)_AS_(_______SELECT_0,_T1.c0,_T1.c1_______FROM_keyless_T1_______WHERE_T1.c0_=_0_________UNION_ALL_________SELECT_cte.depth_+_1,_cte.i,_T2.c1_+_1_______FROM_cte,_keyless_T2_______WHERE_cte.depth_=_T2.c0___)_____SELECT_U0.c0___FROM_cte,_keyless_U0____WHERE_cte.j_=_keyless.c0_____)_____ORDER_BY_c0;_",
 		"_select_*_from_mytable,__lateral_(__with_recursive_cte(a)_as_(___select_y_from_xy___union___select_x_from_cte___join___(____select_*_____from_xy____where_x_=_1____)_sqa1___on_x_=_a___limit_3___)__select_*_from_cte_)_sqa2_where_i_=_a_order_by_i;",
 
-		"select_length(random_bytes(i))_from_mytable;",
+
 	}
 
 	// Order undefined

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -545,6 +545,13 @@ def rewrite_mysql_for_duckdb(node):
                 kind=node.args.get("kind"),
                 constraints=kept,
             )
+    # MySQL LENGTH(RANDOM_BYTES(n)) is the byte count. Evaluate RANDOM_BYTES once.
+    if isinstance(node, exp.Length) and isinstance(node.this, exp.Anonymous) and str(node.this.this).upper() in ("RANDOM_BYTES", "MYSQL_RANDOM_BYTES") and node.this.expressions:
+        n = node.this.expressions[0].transform(rewrite_mysql_for_duckdb)
+        return exp.Anonymous(
+            this="octet_length",
+            expressions=[exp.Anonymous(this="mysql_random_bytes", expressions=[n])],
+        )
     # MySQL CHAR_LENGTH / CHARACTER_LENGTH -> DuckDB LENGTH (character count).
     # Without this, some paths still emit CHAR_LENGTH, which DuckDB does not have.
     if isinstance(node, exp.Length) and not node.args.get("binary"):
@@ -610,6 +617,10 @@ def rewrite_mysql_for_duckdb(node):
     if isinstance(node, exp.Anonymous) and str(node.this).upper() == "RAND" and node.expressions:
         seed = node.expressions[0].transform(rewrite_mysql_for_duckdb)
         return exp.Anonymous(this="mysql_rand", expressions=[seed])
+    # MySQL RANDOM_BYTES(n) is n random bytes. DuckDB has no builtin.
+    if isinstance(node, exp.Anonymous) and str(node.this).upper() == "RANDOM_BYTES" and node.expressions:
+        n = node.expressions[0].transform(rewrite_mysql_for_duckdb)
+        return exp.Anonymous(this="mysql_random_bytes", expressions=[n])
     # MySQL CRC32 is IEEE of the string bytes. DuckDB has no CRC32; use __sys__.mysql_crc32.
     if isinstance(node, exp.Anonymous) and str(node.this).upper() == "CRC32" and node.expressions:
         return exp.Anonymous(

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -367,6 +367,11 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT MYSQL_RAND(i) FROM mytable ORDER BY i NULLS FIRST",
 		},
 		{
+			name:     "RANDOM_BYTES uses mysql_random_bytes",
+			input:    "SELECT LENGTH(RANDOM_BYTES(i)) FROM mytable",
+			expected: "SELECT OCTET_LENGTH(MYSQL_RANDOM_BYTES(i)) FROM mytable",
+		},
+		{
 			name:     "string column equal to zero is numeric",
 			input:    "SELECT * FROM tabletest WHERE s = 0",
 			expected: "SELECT * FROM tabletest WHERE COALESCE(TRY_CAST(s AS DOUBLE), 0) = 0",


### PR DESCRIPTION
## Summary
`RANDOM_BYTES(n)` must be n random bytes. DuckDB has no builtin. Register `mysql_random_bytes` with `crypto/rand`. Length 1–1024. Not REPEAT.

`LENGTH(RANDOM_BYTES(n))` becomes `OCTET_LENGTH(mysql_random_bytes(n))` so the function runs once.

## Test plan
- [x] `go test ./catalog/ -run 'TestMySQLRandomBytes'`
- [x] `go test ./transpiler/`
- [x] `go test -run 'TestQueries/select_length(random_bytes'`