### PR TITLE
fix: do not treat window functions as GROUP BY aggregates

### DIFF
--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -274,7 +274,8 @@ def _iter_args(e):
 def _has_outer(e, pred):
     # Do not look inside scalar subqueries. MAX in (SELECT MAX(pk) ...) is
     # not an aggregate of the outer SELECT.
-    if e is None or isinstance(e, exp.Subquery):
+    # Window SUM() OVER (...) is also not a GROUP BY aggregate.
+    if e is None or isinstance(e, (exp.Subquery, exp.Window)):
         return False
     if pred(e):
         return True

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -347,6 +347,11 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT COUNT(*) OVER () FROM mytable ORDER BY i NULLS FIRST",
 		},
 		{
+			name:     "window functions are not outer aggregates",
+			input:    "SELECT pk, row_number() OVER (ORDER BY pk DESC), SUM(v1) OVER (PARTITION BY v2 ORDER BY pk) FROM one_pk_three_idx ORDER BY pk",
+			expected: "SELECT pk, ROW_NUMBER() OVER (ORDER BY pk DESC), SUM(v1) OVER (PARTITION BY v2 ORDER BY pk NULLS FIRST) FROM one_pk_three_idx ORDER BY pk NULLS FIRST",
+		},
+		{
 			name:     "duplicate SET keeps the last assignment",
 			input:    "UPDATE floattable SET f32 = 5, f32 = 4 WHERE i = 1",
 			expected: "UPDATE floattable SET f32 = 4 WHERE i = 1",


### PR DESCRIPTION
## Summary
`SUM(v1) OVER (...)` is one row per input row. The missing-GROUP-BY rewrite treated the inner `SUM` as an outer aggregate and wrapped `pk` / `ROW_NUMBER()` in `ANY_VALUE`.

Same class of bug as #431 (subquery aggregates). Do not look inside `exp.Window`.

Window tests stay skipped: DuckDB `SUM`/`AVG` of ints stay ints, `RANK` is signed. Values were right after this fix; types were not.

## Test plan
- [x] `go test ./transpiler/ -count=1`