### PR TITLE
test: unskip TAN and COT

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -258,8 +258,6 @@ func TestQueriesSimple(t *testing.T) {
 
 	// failed during CI
 	waitForFixQueries = append(waitForFixQueries,
-		"SELECT_TAN(i)_from_mytable_order_by_i_limit_1", // might be precision issue
-		"SELECT_COT(i)_from_mytable_order_by_i_limit_1",
 		"select_now()_=_sysdate(),_sleep(0.1),_now(6)_<_sysdate(6);")
 
 	panicQueries := []string{}


### PR DESCRIPTION
## Summary
`SELECT TAN(i)` and `SELECT COT(i)` were skipped as a precision issue. They pass now.

## Test plan
- [x] `go test -run 'TestQueriesSimple/SELECT_TAN|TestQueriesSimple/SELECT_COT' .`