### PR TITLE
fix: rewrite MySQL INSERT IGNORE as DuckDB INSERT OR IGNORE

### DIFF
--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -1371,8 +1371,12 @@ def transpile_mysql_to_duckdb(sql: str) -> str:
             return exp.Null()
         return rewrite_mysql_for_duckdb(node)
     tree = trees[0].transform(rewrite_with_insert_context)
-    if was_replace and isinstance(tree, exp.Insert):
-        tree.set("alternative", "REPLACE")
+    if isinstance(tree, exp.Insert):
+        if was_replace:
+            tree.set("alternative", "REPLACE")
+        elif tree.args.get("ignore"):
+            tree.set("ignore", False)
+            tree.set("alternative", "IGNORE")
     return tree.sql(dialect="duckdb")
 
 while True:

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -362,6 +362,11 @@ func TestTranslate(t *testing.T) {
 			expected: "INSERT OR REPLACE INTO mytable VALUES (1, 'first row')",
 		},
 		{
+			name:     "INSERT IGNORE becomes INSERT OR IGNORE",
+			input:    "INSERT IGNORE INTO mytable VALUES (1, 'hi')",
+			expected: "INSERT OR IGNORE INTO mytable VALUES (1, 'hi')",
+		},
+		{
 			name:     "REPLACE INTO SET becomes INSERT OR REPLACE",
 			input:    "REPLACE INTO mytable SET i = 1, s = 'first row'",
 			expected: "INSERT OR REPLACE INTO mytable (i, s) VALUES (1, 'first row')",


### PR DESCRIPTION
DuckDB has no INSERT IGNORE. Rewrite to INSERT OR IGNORE.

TestInsertIgnoreInto stays skipped: MySQL IGNORE also turns bad types and NULL into defaults. DuckDB only skips key conflicts.