### PR TITLE
fix: preserve NULL coercion and enable more DML tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -782,8 +782,16 @@ func TestInsertInto(t *testing.T) {
 }
 
 func TestInsertIgnoreInto(t *testing.T) {
-	t.Skip("wait for fix")
-	enginetest.TestInsertIgnoreInto(t, NewDefaultDuckHarness())
+	harness := NewDefaultDuckHarness()
+	harness.QueriesToSkip(
+		// DuckDB does not coerce invalid or NULL values and report warnings like MySQL.
+		"Test that INSERT IGNORE with Non nullable columns works",
+		"Test that INSERT IGNORE properly addresses data conversion",
+		"Insert Ignore works correctly with ON DUPLICATE UPDATE",
+		// The rows are correct, but DuckDB reports zero affected rows when conflicts are ignored.
+		"Test that INSERT IGNORE INTO works with unique keys",
+	)
+	enginetest.TestInsertIgnoreInto(t, harness)
 }
 
 func TestInsertDuplicateKeyKeyless(t *testing.T) {
@@ -797,8 +805,13 @@ func TestIgnoreIntoWithDuplicateUniqueKeyKeyless(t *testing.T) {
 }
 
 func TestInsertIntoErrors(t *testing.T) {
-	t.Skip("wait for fix")
-	enginetest.TestInsertIntoErrors(t, NewDefaultDuckHarness())
+	harness := NewDefaultDuckHarness()
+	harness.QueriesToSkip(
+		// DuckDB treats VARCHAR and VARBINARY lengths as advisory.
+		"insert into bad values ('1234567890')",
+		"insert into bad values (repeat('0', 65536))",
+	)
+	enginetest.TestInsertIntoErrors(t, harness)
 }
 
 func TestBrokenInsertScripts(t *testing.T) {
@@ -874,12 +887,21 @@ func TestSelectIntoFile(t *testing.T) {
 }
 
 func TestReplaceInto(t *testing.T) {
-	t.Skip("wait for fix")
-	enginetest.TestReplaceInto(t, NewDefaultDuckHarness())
+	harness := NewDefaultDuckHarness()
+	harness.QueriesToSkip(
+		// DuckDB reports one affected row for a replacement; MySQL reports delete + insert.
+		"REPLACE INTO mytable VALUES (1, 'first row');",
+		"REPLACE INTO mytable SET i = 1, s = 'first row';",
+		"REPLACE INTO mytable VALUES (1, 'new row same i');",
+		"REPLACE INTO mytable SET i = 1, s = 'new row same i';",
+		// DuckDB does not accept MySQL zero dates.
+		"REPLACE_INTO_typestable_VALUES_(____999,_-128,_-32768,_-2147483648,_-9223372036854775808,____0,_0,_0,_0,____1.401298464324817070923729583289916131280e-45,_4.940656458412465441765687928682213723651e-324,____'0000-00-00_00:00:00',_'0000-00-00',____'',_false,_'\"\"',_'',_'',_''____);",
+		"REPLACE_INTO_typestable_SET____id_=_999,_i8_=_-128,_i16_=_-32768,_i32_=_-2147483648,_i64_=_-9223372036854775808,____u8_=_0,_u16_=_0,_u32_=_0,_u64_=_0,____f32_=_1.401298464324817070923729583289916131280e-45,_f64_=_4.940656458412465441765687928682213723651e-324,____ti_=_'0000-00-00_00:00:00',_da_=_'0000-00-00',____te_=_'',_bo_=_false,_js_=_'\"\"',_bl_=_'',_e1_=_'',_s1_=_''____;",
+	)
+	enginetest.TestReplaceInto(t, harness)
 }
 
 func TestReplaceIntoErrors(t *testing.T) {
-	t.Skip("wait for fix")
 	enginetest.TestReplaceIntoErrors(t, NewDefaultDuckHarness())
 }
 
@@ -914,14 +936,33 @@ func TestUpdateIgnore(t *testing.T) {
 }
 
 func TestUpdateErrors(t *testing.T) {
-	t.Skip("wait for fix")
+	harness := NewDuckHarness("default", 1, testNumPartitions, true, mergableIndexDriver)
+	harness.QueriesToSkip(
+		// DuckDB treats VARCHAR lengths as advisory.
+		"update bad set s = '1234567890'",
+	)
 	// TODO different errors
-	enginetest.TestUpdateErrors(t, NewDuckHarness("default", 1, testNumPartitions, true, mergableIndexDriver))
+	enginetest.TestUpdateErrors(t, harness)
 }
 
 func TestOnUpdateExprScripts(t *testing.T) {
-	t.Skip("wait for fix")
-	enginetest.TestOnUpdateExprScripts(t, NewDuckHarness("default", 1, testNumPartitions, true, mergableIndexDriver))
+	harness := NewDuckHarness("default", 1, testNumPartitions, true, mergableIndexDriver)
+	harness.QueriesToSkip(
+		// ON UPDATE values are not stored or applied yet. Triggers, foreign keys, and procedures are unsupported.
+		"basic case",
+		"precision 3",
+		"precision 6",
+		"default time is current time",
+		"alter table",
+		"multiple columns case",
+		"before update trigger",
+		"after update trigger",
+		"insert triggers",
+		"foreign key tests",
+		"stored procedure tests",
+		"now() synonyms",
+	)
+	enginetest.TestOnUpdateExprScripts(t, harness)
 }
 
 func TestSpatialUpdate(t *testing.T) {
@@ -930,8 +971,12 @@ func TestSpatialUpdate(t *testing.T) {
 }
 
 func TestDeleteFromErrors(t *testing.T) {
-	t.Skip("wait for fix")
-	enginetest.TestDeleteErrors(t, NewDuckHarness("default", 1, testNumPartitions, true, mergableIndexDriver))
+	harness := NewDuckHarness("default", 1, testNumPartitions, true, mergableIndexDriver)
+	harness.QueriesToSkip(
+		// The query fails correctly, but the bind-parameter error text differs.
+		"DELETE FROM mytable WHERE i = ?;",
+	)
+	enginetest.TestDeleteErrors(t, harness)
 }
 
 func TestSpatialDeleteFrom(t *testing.T) {
@@ -1838,7 +1883,6 @@ func TestPkOrdinalsDDL(t *testing.T) {
 }
 
 func TestPkOrdinalsDML(t *testing.T) {
-	t.Skip("wait for fix")
 	enginetest.TestPkOrdinalsDML(t, NewDefaultDuckHarness())
 }
 
@@ -2248,8 +2292,18 @@ func TestPrepared(t *testing.T) {
 }
 
 func TestPreparedInsert(t *testing.T) {
-	t.Skip("wait for fix")
-	enginetest.TestPreparedInsert(t, NewDuckHarness("default", 1, testNumPartitions, true, mergableIndexDriver))
+	harness := NewDuckHarness("default", 1, testNumPartitions, true, mergableIndexDriver)
+	harness.QueriesToSkip(
+		// Bindings are not forwarded for general INSERTs. ON DUPLICATE KEY and foreign keys are unsupported.
+		"simple insert",
+		"Insert on duplicate key",
+		"Insert on duplicate key with row alias",
+		"Out-of-order Insert on duplicate key with row alias",
+		"Insert on duplicate key with row and column alias",
+		"Out-of-order Insert on duplicate key with row and column alias",
+		"inserts should trigger string conversion errors",
+	)
+	enginetest.TestPreparedInsert(t, harness)
 }
 
 func TestPreparedStatements(t *testing.T) {

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -980,13 +980,19 @@ def rewrite_mysql_for_duckdb(node):
         return exp.Case(**args)
     # MySQL treats a string predicate as a number: invalid strings are 0, not an error.
     def _mysql_string_as_number(e):
-        return exp.Anonymous(
+        converted = exp.Anonymous(
             this="coalesce",
             expressions=[
-                exp.TryCast(this=e, to=exp.DataType.build("DOUBLE")),
+                exp.TryCast(this=e.copy(), to=exp.DataType.build("DOUBLE")),
                 exp.Literal.number(0),
             ],
         )
+        if isinstance(e, exp.Column):
+            return exp.Case(
+                ifs=[exp.If(this=exp.Is(this=e.copy(), expression=exp.Null()), true=exp.Null())],
+                default=converted,
+            )
+        return converted
     if isinstance(node, exp.Where) and isinstance(node.this, exp.Literal) and node.this.is_string:
         return exp.Where(
             this=exp.NEQ(this=_mysql_string_as_number(node.this), expression=exp.Literal.number(0))

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -284,7 +284,7 @@ func TestTranslate(t *testing.T) {
 		{
 			name:     "bare column WHERE is numeric nonzero",
 			input:    "SELECT i, v FROM stringandtable WHERE v",
-			expected: "SELECT i, v FROM stringandtable WHERE COALESCE(TRY_CAST(v AS DOUBLE), 0) <> 0",
+			expected: "SELECT i, v FROM stringandtable WHERE CASE WHEN v IS NULL THEN NULL ELSE COALESCE(TRY_CAST(v AS DOUBLE), 0) END <> 0",
 		},
 		{
 			name:     "string OR is numeric 0/1 for LIKE",
@@ -324,7 +324,7 @@ func TestTranslate(t *testing.T) {
 		{
 			name:     "string column compared to number is numeric",
 			input:    "SELECT s > 2 FROM tabletest",
-			expected: "SELECT COALESCE(TRY_CAST(s AS DOUBLE), 0) > 2 FROM tabletest",
+			expected: "SELECT CASE WHEN s IS NULL THEN NULL ELSE COALESCE(TRY_CAST(s AS DOUBLE), 0) END > 2 FROM tabletest",
 		},
 		{
 			name:     "scalar subquery MAX is not an outer aggregate",
@@ -404,12 +404,12 @@ func TestTranslate(t *testing.T) {
 		{
 			name:     "string column equal to zero is numeric",
 			input:    "SELECT * FROM tabletest WHERE s = 0",
-			expected: "SELECT * FROM tabletest WHERE COALESCE(TRY_CAST(s AS DOUBLE), 0) = 0",
+			expected: "SELECT * FROM tabletest WHERE CASE WHEN s IS NULL THEN NULL ELSE COALESCE(TRY_CAST(s AS DOUBLE), 0) END = 0",
 		},
 		{
 			name:     "CASE mixed int and string casts to text",
 			input:    "SELECT CASE WHEN i > 2 THEN i ELSE 'two' END FROM mytable",
-			expected: "SELECT CASE WHEN COALESCE(TRY_CAST(i AS DOUBLE), 0) > 2 THEN CAST(i AS TEXT) ELSE CAST('two' AS TEXT) END FROM mytable",
+			expected: "SELECT CASE WHEN CASE WHEN i IS NULL THEN NULL ELSE COALESCE(TRY_CAST(i AS DOUBLE), 0) END > 2 THEN CAST(i AS TEXT) ELSE CAST('two' AS TEXT) END FROM mytable",
 		},
 		{
 			name:     "FALSE IN string is numeric",
@@ -424,7 +424,7 @@ func TestTranslate(t *testing.T) {
 		{
 			name:     "mixed IN is pairwise compare",
 			input:    "SELECT COUNT(*) FROM mytable WHERE s IN (1, 'first_row')",
-			expected: "SELECT COUNT(*) FROM mytable WHERE COALESCE(TRY_CAST(s AS DOUBLE), 0) = 1 OR s = 'first_row'",
+			expected: "SELECT COUNT(*) FROM mytable WHERE CASE WHEN s IS NULL THEN NULL ELSE COALESCE(TRY_CAST(s AS DOUBLE), 0) END = 1 OR s = 'first_row'",
 		},
 		{
 			name:     "DATE vs ISO datetime keeps time",
@@ -524,7 +524,7 @@ func TestTranslate(t *testing.T) {
 		{
 			name:     "UPDATE JOIN keeps extra WHERE",
 			input:    "UPDATE one_pk INNER JOIN two_pk ON one_pk.pk = two_pk.pk1 SET two_pk.c1 = two_pk.c1 + 1 WHERE one_pk.c5 < 10",
-			expected: "UPDATE two_pk SET c1 = two_pk.c1 + 1 WHERE rowid IN ((SELECT DISTINCT two_pk.rowid FROM one_pk INNER JOIN two_pk ON one_pk.pk = two_pk.pk1 WHERE COALESCE(TRY_CAST(one_pk.c5 AS DOUBLE), 0) < 10))",
+			expected: "UPDATE two_pk SET c1 = two_pk.c1 + 1 WHERE rowid IN ((SELECT DISTINCT two_pk.rowid FROM one_pk INNER JOIN two_pk ON one_pk.pk = two_pk.pk1 WHERE CASE WHEN one_pk.c5 IS NULL THEN NULL ELSE COALESCE(TRY_CAST(one_pk.c5 AS DOUBLE), 0) END < 10))",
 		},
 		{
 			name:     "UPDATE JOIN SET from other table uses FROM",


### PR DESCRIPTION
## Summary
- preserve SQL NULL when MySQL-style numeric coercion rewrites column predicates
- enable the full primary-key ordinal DML suite
- replace whole-suite skips with precise skips for INSERT IGNORE, INSERT/UPDATE/DELETE errors, REPLACE, ON UPDATE errors, and prepared decimal INSERT

## Why
`DELETE FROM a WHERE y < 3` was rewritten with `COALESCE(TRY_CAST(y AS DOUBLE), 0)`, so NULL values became zero and rows were deleted incorrectly. The rewrite now keeps NULL as NULL while still mapping invalid non-NULL strings to zero.

## Tests
- `go test ./transpiler -count=1`
- `go test . -run '^(TestInsertIgnoreInto|TestInsertIntoErrors|TestReplaceInto|TestReplaceIntoErrors|TestUpdateErrors|TestOnUpdateExprScripts|TestDeleteFromErrors|TestPkOrdinalsDML|TestPreparedInsert)$' -count=1`
- `make test` still fails on existing main failures: `TestQueriesSimple` HAVING/FORMAT/JSON_KEYS, `mysql_rand` UDF registration, and dependent pgserver startup failures. `TestQueriesSimple` reproduces unchanged on `origin/main` at `bde2f73`.

Refs #64
