### PR TITLE
test: enable broken insert scripts

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -799,7 +799,6 @@ func TestInsertIntoErrors(t *testing.T) {
 }
 
 func TestBrokenInsertScripts(t *testing.T) {
-	t.Skip("wait for fix")
 	enginetest.TestBrokenInsertScripts(t, NewDefaultDuckHarness())
 }
 


### PR DESCRIPTION
## Summary
- remove the whole-suite skip from `TestBrokenInsertScripts`
- keep the canonical broken INSERT coverage enabled without engine changes or per-case skips

## Tests
- `go test . -run '^TestBrokenInsertScripts$' -count=1`
- `go test . -run '^TestBrokenInsertScripts$' -count=5`

The commit was created through GitHub and is signed/verified.

Refs #64
