### PR TITLE
test: enable compatible blob tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2233,8 +2233,13 @@ func TestNullRanges(t *testing.T) {
 }
 
 func TestBlobs(t *testing.T) {
-	t.Skip("wait for fix")
-	enginetest.TestBlobs(t, NewDefaultDuckHarness())
+	harness := NewDefaultDuckHarness()
+	// DuckDB column defaults cannot reference another column.
+	harness.QueriesToSkip(
+		"ALTER TABLE blobt ADD COLUMN v2 BIGINT DEFAULT (i + 2) AFTER b",
+		"ALTER TABLE textt ADD COLUMN v2 BIGINT DEFAULT (i + 2) AFTER t",
+	)
+	enginetest.TestBlobs(t, harness)
 }
 
 func TestIndexes(t *testing.T) {


### PR DESCRIPTION
## Summary

- enable the upstream BLOB compatibility suite
- keep the two cross-column DEFAULT cases precisely skipped because DuckDB rejects column references in DEFAULT expressions

## Verification

- `go test -run '^TestBlobs$' -count=3 -v .` (each run: 35 pass, 2 skip)
- `go test -run '^(TestBlobs|TestConvert|TestNumericErrorScripts)$' -count=1 -v .` (BLOB: 35 pass, 2 skip; the other two suites retain their existing outer skips)
