### PR TITLE
test: enable ANSI quotes and query error suites

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -458,8 +458,37 @@ func TestQueryPlanTODOs(t *testing.T) {
 // }
 
 func TestAnsiQuotesSqlMode(t *testing.T) {
-	t.Skip("wait for fix")
-	enginetest.TestAnsiQuotesSqlMode(t, NewDefaultDuckHarness())
+	harness := NewDefaultDuckHarness()
+	ansiQuotesTests := append([]queries.ScriptTest(nil), queries.AnsiQuotesTests...)
+	ansiQuotesTests[0].Assertions = append([]queries.ScriptTestAssertion(nil), ansiQuotesTests[0].Assertions...)
+	ansiQuotesTests[0].Assertions[0].Query = `select  "data" from auctions order by "ai" desc;`
+	harness.QueriesToSkip(
+		// MyDuck's query path does not honor session ANSI_QUOTES mode, so double-quoted
+		// expressions are treated as string literals instead of identifiers. Extra whitespace
+		// distinguishes this mode-on assertion from the identical mode-off query below.
+		`select  "data" from auctions order by "ai" desc;`,
+		`select "data", '"' from auctions order by "ai";`,
+		`select "data", '\"' from auctions order by "ai";`,
+		`insert into t ("pk", "data") values (1, 'one');`,
+		`select "pk", "data" from "t" order by "pk" asc;`,
+		`insert into public_keys("item", "type", "hash", "count", "public") values (42, 'type', 1010, 1, 'public');`,
+		`select "public", "count" from view1;`,
+		// View definitions retain ANSI quotes, but MyDuck's SHOW and information_schema
+		// output does not match the MySQL representation expected by this suite.
+		`show create table view1;`,
+		`select table_name, view_definition from information_schema.views where table_name='view1';`,
+		// The skipped quoted-column INSERT leaves the view empty.
+		"select public, `count` from view1;",
+		// DuckDB does not provide MySQL triggers, stored procedures, or events.
+		"ANSI_QUOTES: triggers",
+		"ANSI_QUOTES: stored procedures",
+		"ANSI_QUOTES: events",
+		// DuckDB rejects a DEFAULT expression that refers to another column.
+		"ANSI_QUOTES: column defaults",
+	)
+	for _, script := range ansiQuotesTests {
+		enginetest.TestScript(t, harness, script)
+	}
 }
 
 func TestAnsiQuotesSqlModePrepared(t *testing.T) {
@@ -670,8 +699,20 @@ func TestIndexQueryPlans(t *testing.T) {
 }
 
 func TestQueryErrors(t *testing.T) {
-	t.Skip("wait for fix")
-	enginetest.TestQueryErrors(t, NewDefaultDuckHarness())
+	harness := NewDefaultDuckHarness()
+	harness.QueriesToSkip(
+		// DuckDB rejects this malformed regexp, but returns its native error text.
+		`SELECT * FROM mytable WHERE s REGEXP("*main.go")`,
+		// Unbound placeholders reach DuckDB and produce an argument-count error instead
+		// of go-mysql-server's ErrUnboundPreparedStatementVariable.
+		"SELECT pk FROM one_pk WHERE pk > ?",
+		"SELECT pk FROM one_pk WHERE pk > :pk",
+		// DuckDB rejects multi-character ESCAPE strings as syntax errors rather than
+		// go-mysql-server's ErrInvalidArgument.
+		`SELECT name FROM specialtable t WHERE t.name LIKE '$%' ESCAPE 'abc'`,
+		`SELECT name FROM specialtable t WHERE t.name LIKE '$%' ESCAPE '$$'`,
+	)
+	enginetest.TestQueryErrors(t, harness)
 }
 
 func TestInfoSchema(t *testing.T) {
@@ -1269,7 +1310,7 @@ func mustNewEngine(t *testing.T, h enginetest.Harness) enginetest.QueryEngine {
 }
 
 func TestRowLimit(t *testing.T) {
-	t.Skip("wait for fix")
+	t.Skip("DuckDB does not enforce MySQL maximum row length; both scripts are incompatible and provide no coverage")
 	enginetest.TestRowLimit(t, NewDefaultDuckHarness())
 }
 


### PR DESCRIPTION
## Summary

- enable the non-prepared ANSI_QUOTES suite with precise query and capability skips
- enable QueryErrors while excluding five DuckDB error-shape differences
- keep RowLimit as a concrete top-level capability skip because DuckDB does not enforce MySQL row length limits; it provides 0 restored coverage

## Coverage

ANSI_QUOTES executes 18 passing assertions:
- basic cases: 9 PASS / 3 SKIP
- ANSI combination mode: 1 PASS / 2 SKIP
- views: 5 PASS / 8 SKIP
- check constraints: 3 PASS / 0 SKIP

The mode-on and mode-off basic assertions contain the same SQL upstream. A local script copy adds harmless whitespace only to the mode-on occurrence, allowing the query-based skip harness to skip that incompatible assertion while the mode-off occurrence executes and passes.

Triggers, stored procedures, column defaults that reference another column, and events remain script-level skips. `TestAnsiQuotesSqlModePrepared` is unchanged.

QueryErrors executes 119 passing cases and excludes exactly five queries:
- `SELECT * FROM mytable WHERE s REGEXP("*main.go")`: expected `the given regular expression is invalid`; DuckDB returns `Invalid Input Error: no argument for repetition operator: *`
- `SELECT pk FROM one_pk WHERE pk > ?`
- `SELECT pk FROM one_pk WHERE pk > :pk`: both expect `ErrUnboundPreparedStatementVariable`; MyDuck returns `incorrect argument count for command: have 0 want 1`
- `SELECT name FROM specialtable t WHERE t.name LIKE '$%' ESCAPE 'abc'`
- `SELECT name FROM specialtable t WHERE t.name LIKE '$%' ESCAPE '$$'`: both expect `ErrInvalidArgument`; DuckDB returns `Syntax Error: Invalid escape string. Escape string must be empty or one character.`

## Tests

- `go test -run '^(TestAnsiQuotesSqlMode|TestQueryErrors|TestRowLimit)$' -count=3 .`
  - each round: ANSI_QUOTES PASS / QueryErrors PASS / RowLimit top-level SKIP
  - aggregate: 6 PASS / 3 SKIP / 0 FAIL at suite level
- rebased on `origin/main@32b32c5`; the same targeted command with `-count=1` passes
