### PR TITLE
test: enable drop column tests for keyless tables

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1946,7 +1946,6 @@ func TestDropColumn(t *testing.T) {
 }
 
 func TestDropColumnKeylessTables(t *testing.T) {
-	t.Skip("wait for fix")
 	enginetest.TestDropColumnKeylessTables(t, NewDefaultDuckHarness())
 }
 


### PR DESCRIPTION
## Summary

- remove the outer skip from `TestDropColumnKeylessTables`
- run all 16 nested test cases for keyless-table column drops

## Testing

- `go test . -run '^TestDropColumnKeylessTables$' -count=1 -v`
- `go test . -run '^TestDropColumnKeylessTables$' -count=3 -v`
- each run: 16 nested PASS, 0 SKIP, 0 FAIL