### PR TITLE
test: enable compatible lateral join queries

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -276,8 +276,13 @@ func TestJoinQueries(t *testing.T) {
 }
 
 func TestLateralJoin(t *testing.T) {
-	t.Skip("wait for fix")
-	enginetest.TestLateralJoinQueries(t, NewDefaultDuckHarness())
+	harness := NewDefaultDuckHarness()
+	harness.QueriesToSkip(
+		// DuckDB requires a single comparison between the left and right sides for
+		// non-inner lateral joins, so it rejects this disjunctive join condition.
+		"select * from t left join lateral (select * from t1 where t.i != t1.j) as tt on t.i + 1 = tt.j or t.i + 2 = tt.j order by t.i, tt.j",
+	)
+	enginetest.TestLateralJoinQueries(t, harness)
 }
 
 // TestJoinPlanning runs join-specific tests for merge


### PR DESCRIPTION
## Summary
- enable the canonical lateral join suite
- keep 14 compatible assertions running
- skip only the non-inner lateral join whose disjunctive `ON` condition is unsupported by DuckDB

## Tests
- `go test . -run '^TestLateralJoin$' -count=1 -v` (14 PASS, 1 SKIP, 0 FAIL)
- `go test . -run '^TestLateralJoin$' -count=3`
- `go test ./transpiler -count=1`
- `git diff --check`
