### PR TITLE
test: enable compatible join queries

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -271,8 +271,31 @@ func TestQueriesSimple(t *testing.T) {
 
 // TestJoinQueries runs the canonical test queries against a single threaded index enabled harness.
 func TestJoinQueries(t *testing.T) {
-	t.Skip("wait for fix")
-	enginetest.TestJoinQueries(t, NewDefaultDuckHarness())
+	harness := NewDefaultDuckHarness()
+	harness.QueriesToSkip(
+		// DuckDB does not allow LIMIT or OFFSET in a recursive CTE.
+		"with recursive a(x,y) as (select i,i from mytable where i < 4 union select a.x, mytable.i from a join mytable on a.x+1 = mytable.i limit 2) select * from a;",
+		// DuckDB requires explicit aliases when tables in different schemas share a base name.
+		"select * from othertable join foo.othertable on othertable.s2 = 'third'",
+		"select * from othertable join foo.othertable on mydb.othertable.s2 = 'third'",
+		"select * from othertable join foo.othertable on foo.othertable.text = 'a'",
+		"select * from foo.othertable join othertable on othertable.s2 = 'third'",
+		"select * from foo.othertable join othertable on mydb.othertable.s2 = 'third'",
+		"select * from foo.othertable join othertable on foo.othertable.text = 'a'",
+		"select * from mydb.othertable join foo.othertable on othertable.s2 = 'third'",
+		"select * from mydb.othertable join foo.othertable on mydb.othertable.s2 = 'third'",
+		"select * from mydb.othertable join foo.othertable on foo.othertable.text = 'a'",
+		"select * from foo.othertable join mydb.othertable on othertable.s2 = 'third'",
+		"select * from foo.othertable join mydb.othertable on mydb.othertable.s2 = 'third'",
+		"select * from foo.othertable join mydb.othertable on foo.othertable.text = 'a'",
+		// DuckHarness tables do not support the script's foreign key setup.
+		"Complex join query with foreign key constraints",
+		// DuckDB orders SELECT * columns differently for these USING joins.
+		"select * from t1 join t2 using (j);",
+		"select * from t1 right join t2 using (i);",
+		"select * from t1 right join t2 using (j);",
+	)
+	enginetest.TestJoinQueries(t, harness)
 }
 
 func TestLateralJoin(t *testing.T) {

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -455,6 +455,13 @@ def _rewrite_mysql_update(node):
     return exp.Update(**kwargs)
 
 def rewrite_mysql_for_duckdb(node):
+    # SQLGlot renders a parenthesized MySQL JOIN without ON as (a, b),
+    # which DuckDB rejects. Both dialects define it as a cross join.
+    if isinstance(node, exp.Join) and isinstance(node.parent, exp.Table):
+        if not any(node.args.get(k) for k in ("on", "using", "method", "kind", "side")):
+            updated = node.copy()
+            updated.set("kind", "CROSS")
+            return updated
     # MySQL _binary 'x' / _utf8mb4 'x' are charset introducers. DuckDB has no _binary type.
     if isinstance(node, exp.Introducer):
         inner = node.args.get("expression")

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -57,6 +57,11 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT (((i AND (NOT i)) OR ((NOT i) AND i)) AND NOT (i)) OR (NOT ((i AND (NOT i)) OR ((NOT i) AND i)) AND (i)) FROM t",
 		},
 		{
+			name:     "parenthesized JOIN without ON becomes CROSS JOIN",
+			input:    "SELECT * FROM (ab JOIN pq) WHERE a IN (SELECT a FROM ab)",
+			expected: "SELECT * FROM (ab CROSS JOIN pq) WHERE a IN (SELECT a FROM ab)",
+		},
+		{
 			name:     "CHAR_LENGTH becomes DuckDB LENGTH",
 			input:    "SELECT CHAR_LENGTH(s) FROM t",
 			expected: "SELECT LENGTH(s) FROM t",


### PR DESCRIPTION
## Summary

- enable `TestJoinQueries` and keep only exact-query compatibility skips
- translate a parenthesized bare `JOIN` to explicit `CROSS JOIN`, avoiding invalid DuckDB `(ab, pq)` output
- add a regression for `SELECT * FROM (ab JOIN pq) WHERE a IN (SELECT a FROM ab)`

## Results

`TestJoinQueries`: **115 PASS / 19 SKIP / 0 FAIL**.

- **17 MyDuck skips**:
  - 1 recursive CTE with `LIMIT` (DuckDB rejects `LIMIT` / `OFFSET` in recursive queries)
  - 12 joins between same-named tables in different schemas (DuckDB requires explicit aliases)
  - 1 script whose setup requires unsupported foreign-key operations
  - 3 `SELECT * ... USING` cases where DuckDB returns a different column order from MySQL
- **2 upstream internal skips**, kept separate from the MyDuck skip list

The CROSS JOIN regression now executes and passes.

## Verification

Latest base and parent: `687dfcad5203a9440fa3dec427f8a91478091f3b`.

- `go test . -run '^TestJoinQueries$' -count=1 -v`
- `go test . -run '^TestJoinQueries$' -count=5`
- `go test ./transpiler -count=1`
- `go test ./transpiler -run '^TestTranslate$' -count=5`
- `git diff --check origin/main...HEAD`

After the final one-line main advance to `687dfcad`, the verbose JOIN run and full transpiler suite were rerun on the combined tree; both passed, and task #11/#12 changes remain present.
