### PR TITLE
fix: preserve ANSI quoted view definitions

### DIFF
--- a/catalog/database.go
+++ b/catalog/database.go
@@ -20,6 +20,12 @@ type Database struct {
 	name    string
 }
 
+type ExtraViewInfo struct {
+	TextDefinition      string `json:"text_definition,omitempty"`
+	CreateViewStatement string `json:"create_view_statement,omitempty"`
+	SqlMode             string `json:"sql_mode,omitempty"`
+}
+
 var _ sql.Database = (*Database)(nil)
 var _ sql.TableCreator = (*Database)(nil)
 var _ sql.TableDropper = (*Database)(nil)
@@ -331,7 +337,7 @@ func (d *Database) RenameTable(ctx *sql.Context, oldName string, newName string)
 // extractViewDefinitions is a helper function to extract view definitions from DuckDB
 func (d *Database) extractViewDefinitions(ctx *sql.Context, schemaName string, viewName string) ([]sql.ViewDefinition, error) {
 	query := `
-		SELECT DISTINCT view_name, sql
+		SELECT DISTINCT view_name, sql, comment
 		FROM duckdb_views()
 		WHERE schema_name = ? AND NOT internal
 	`
@@ -351,7 +357,8 @@ func (d *Database) extractViewDefinitions(ctx *sql.Context, schemaName string, v
 	var views []sql.ViewDefinition
 	for rows.Next() {
 		var name, createViewStmt string
-		if err := rows.Scan(&name, &createViewStmt); err != nil {
+		var comment stdsql.NullString
+		if err := rows.Scan(&name, &createViewStmt, &comment); err != nil {
 			return nil, ErrDuckDB.New(err)
 		}
 
@@ -360,15 +367,29 @@ func (d *Database) extractViewDefinitions(ctx *sql.Context, schemaName string, v
 			continue
 		}
 
-		views = append(views, sql.ViewDefinition{
-			Name:                name,
-			CreateViewStatement: createViewStmt,
-		})
+		views = append(views, viewDefinitionFromMetadata(name, schemaName, createViewStmt, comment.String))
 	}
 	if err := rows.Err(); err != nil {
 		return nil, ErrDuckDB.New(err)
 	}
 	return views, nil
+}
+
+func viewDefinitionFromMetadata(name, schemaName, createViewStmt, encodedComment string) sql.ViewDefinition {
+	view := sql.ViewDefinition{
+		Name:                name,
+		CreateViewStatement: createViewStmt,
+		SchemaName:          schemaName,
+	}
+
+	meta := DecodeComment[ExtraViewInfo](encodedComment).Meta
+	if meta.CreateViewStatement != "" && meta.TextDefinition != "" && sql.NewSqlModeFromString(meta.SqlMode).AnsiQuotes() {
+		view.TextDefinition = meta.TextDefinition
+		view.CreateViewStatement = meta.CreateViewStatement
+		view.SqlMode = meta.SqlMode
+	}
+
+	return view
 }
 
 // AllViews implements sql.ViewDatabase.
@@ -401,7 +422,19 @@ func (d *Database) CreateView(ctx *sql.Context, name string, selectStatement str
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	_, err := adapter.Exec(ctx, fmt.Sprintf(`USE %s; CREATE VIEW "%s" AS %s`, FullSchemaName(d.catalog, d.name), name, selectStatement))
+	statement := fmt.Sprintf(`USE %s; CREATE VIEW "%s" AS %s`, FullSchemaName(d.catalog, d.name), name, selectStatement)
+	sqlMode := sql.LoadSqlMode(ctx)
+	if sqlMode.AnsiQuotes() {
+		meta := ExtraViewInfo{
+			TextDefinition:      selectStatement,
+			CreateViewStatement: createViewStmt,
+			SqlMode:             sqlMode.String(),
+		}
+		statement += fmt.Sprintf(`; COMMENT ON VIEW %s IS '%s'`,
+			FullTableName(d.catalog, d.name, name), NewCommentWithMeta("", meta).Encode())
+	}
+
+	_, err := adapter.Exec(ctx, statement)
 	if err != nil {
 		return ErrDuckDB.New(err)
 	}

--- a/catalog/database_test.go
+++ b/catalog/database_test.go
@@ -1,0 +1,54 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestViewDefinitionFromMetadata(t *testing.T) {
+	meta := ExtraViewInfo{
+		TextDefinition:      `select public_keys."public" from public_keys`,
+		CreateViewStatement: "CREATE VIEW `view1` AS select public_keys.\"public\" from public_keys",
+		SqlMode:             "ANSI_QUOTES",
+	}
+	comment := NewCommentWithMeta("", meta).Encode()
+
+	actual := viewDefinitionFromMetadata("view1", "mydb", "CREATE VIEW normalized", comment)
+	require.Equal(t, sql.ViewDefinition{
+		Name:                "view1",
+		TextDefinition:      meta.TextDefinition,
+		CreateViewStatement: meta.CreateViewStatement,
+		SqlMode:             meta.SqlMode,
+		SchemaName:          "mydb",
+	}, actual)
+}
+
+func TestViewDefinitionFromMetadataFallsBackForLegacyViews(t *testing.T) {
+	expected := sql.ViewDefinition{
+		Name:                "view1",
+		CreateViewStatement: "CREATE VIEW normalized",
+		SchemaName:          "mydb",
+	}
+
+	t.Run("no comment", func(t *testing.T) {
+		actual := viewDefinitionFromMetadata("view1", "mydb", "CREATE VIEW normalized", "")
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("user comment", func(t *testing.T) {
+		actual := viewDefinitionFromMetadata("view1", "mydb", "CREATE VIEW normalized", "user supplied comment")
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("non ANSI internal metadata", func(t *testing.T) {
+		meta := ExtraViewInfo{
+			TextDefinition:      "SELECT * FROM t",
+			CreateViewStatement: "CREATE VIEW `view1` AS SELECT * FROM t",
+			SqlMode:             "ONLY_FULL_GROUP_BY",
+		}
+		actual := viewDefinitionFromMetadata("view1", "mydb", "CREATE VIEW normalized", NewCommentWithMeta("", meta).Encode())
+		require.Equal(t, expected, actual)
+	})
+}

--- a/main_test.go
+++ b/main_test.go
@@ -501,10 +501,6 @@ func TestAnsiQuotesSqlMode(t *testing.T) {
 		`select "pk", "data" from "t" order by "pk" asc;`,
 		`insert into public_keys("item", "type", "hash", "count", "public") values (42, 'type', 1010, 1, 'public');`,
 		`select "public", "count" from view1;`,
-		// View definitions retain ANSI quotes, but MyDuck's SHOW and information_schema
-		// output does not match the MySQL representation expected by this suite.
-		`show create table view1;`,
-		`select table_name, view_definition from information_schema.views where table_name='view1';`,
 		// The skipped quoted-column INSERT leaves the view empty.
 		"select public, `count` from view1;",
 		// DuckDB does not provide MySQL triggers, stored procedures, or events.


### PR DESCRIPTION
## Summary

- persist original view SQL in the existing managed comment namespace only when the view is created with `ANSI_QUOTES`
- restore that SQL through the shared catalog path used by `SHOW CREATE` and `information_schema.views`
- keep legacy views, user comments, and non-ANSI views on the existing DuckDB-normalized fallback
- remove the two text skips that covered four view metadata assertions

## Testing

- `go test . -run '^TestAnsiQuotesSqlMode$' -count=3 -v`
  - each run: 22 assertion PASS, 9 assertion SKIP, 4 capability-script SKIP, 0 FAIL
- `go test . -run '^TestViews$' -count=1 -v`
- `go test ./catalog -run '^TestViewDefinitionFromMetadata' -count=1`

`go test ./catalog -count=1` is still red at the pre-existing `TestCreateCatalog` server startup path because `mysql_rand` UDF registration fails. This PR does not claim that package-wide run passes.