### PR TITLE
test: enable compatible JSON scripts

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2314,9 +2314,49 @@ func TestDateParse(t *testing.T) {
 }
 
 func TestJsonScripts(t *testing.T) {
-	t.Skip("wait for fix")
+	harness := NewDefaultDuckHarness()
+	harness.QueriesToSkip(
+		// DuckDB JSON_TYPE reports the stored physical unsigned integer type.
+		"select x, JSON_TYPE(y) from xy",
+		"select JSON_TYPE(y) from xy where x = 1;",
+		// SQLGlot does not support go-mysql-server's three-argument JSON_VALUE form.
+		`select json_value(y, '$.a', 'json') from xy`,
+		`select json_value(y, '$.a[0].b', 'signed') from xy where x = 2`,
+		// DuckDB accepts an integer JSON_EXTRACT input where go-mysql-server rejects it.
+		`select json_length(json_extract(x, "$.a")) from xy`,
+		// The DuckDB execution path does not pass this assertion's positional binding.
+		`SELECT * FROM users WHERE JSON_CONTAINS (languages, JSON_ARRAY(?)) ORDER BY users.id LIMIT 1`,
+		// Upstream expects [], but the script name and MySQL semantics both require NULL.
+		"SELECT JSON_ARRAYAGG(o_id) FROM t2",
+		// DuckDB requires the ORDER BY column to be grouped or aggregated.
+		"SELECT pk, JSON_ARRAYAGG(field) FROM (SELECT * FROM j ORDER BY pk) as sub GROUP BY field ORDER BY pk",
+		// DuckDB JSON_GROUP_OBJECT rejects duplicate keys instead of keeping the last value.
+		"SELECT JSON_OBJECTAGG(val, o_id) FROM (SELECT * FROM t2 ORDER BY o_id) as sub GROUP BY val",
+		`SELECT JSON_OBJECTAGG(c0, val) from (SELECT * FROM j ORDER BY pk) as sub`,
+		// SQLGlot cannot parse an unquoted column named value inside JSON_OBJECTAGG.
+		"SELECT c0, JSON_OBJECTAGG(`attribute`, value) FROM (SELECT * FROM t ORDER BY o_id) as sub GROUP BY c0",
+		"SELECT c0, JSON_OBJECTAGG(c0, value) FROM (SELECT * FROM t ORDER BY o_id) as sub GROUP BY c0",
+		"select JSON_OBJECTAGG(c0, value) from (SELECT * FROM t ORDER BY o_id) as sub",
+		"select JSON_OBJECTAGG(`attribute`, value) from (SELECT * FROM t ORDER BY o_id) as sub",
+		// DuckDB reports a different error category for a NULL JSON object key.
+		`SELECT JSON_OBJECTAGG(c0, val) from test`,
+		// DuckDB ->> removes one quoting layer; these JSON strings contain another.
+		`select col1->>'$.key2' from t;`,
+		`select pk, col1 from t where col1->>'$.key2' = 'abc';`,
+		// DuckDB and MySQL use different JSON value ordering.
+		"select * from t order by col1 asc;",
+		"select * from t order by col1 desc;",
+		// DuckDB preserves the original JSON text formatting and object key order.
+		"select pk, cast(col1 as char) from t order by pk asc;",
+		// DuckDB wildcard extraction returns LIST<JSON> and loses missing/null distinctions.
+		"select pk, json_extract(col1, '$.items.*') from t order by pk;",
+		// DuckDB has no compatible invalid-mode error for JSON_CONTAINS_PATH.
+		"select pk, json_contains_path(col1, 'other', '$.c.d', '$.x') from t order by pk;",
+		// DuckDB 1.1.3 has no JSON_INSERT function.
+		"select pk, json_insert(col1, '$.x', 1), json_insert(col1, '$.y', 2) from t order by pk;",
+	)
 	var skippedTests []string = nil
-	enginetest.TestJsonScripts(t, NewDefaultDuckHarness(), skippedTests)
+	enginetest.TestJsonScripts(t, harness, skippedTests)
 }
 
 func TestShowTableStatus(t *testing.T) {

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -282,7 +282,20 @@ def _has_outer(e, pred):
     return any(_has_outer(c, pred) for c in _iter_args(e))
 
 def _has_outer_agg(e):
-    return _has_outer(e, lambda x: isinstance(x, exp.AggFunc))
+    return _has_outer(
+        e,
+        lambda x: isinstance(x, exp.AggFunc) or (
+            isinstance(x, exp.Anonymous)
+            and str(x.this).upper() in ("JSON_ARRAYAGG", "JSON_GROUP_ARRAY")
+        ),
+    )
+
+def normalize_mysql_aggregates(node):
+    # Normalize before SELECT rewrites so JSON_ARRAYAGG is recognized as an
+    # aggregate when deciding whether other select expressions need ANY_VALUE.
+    if isinstance(node, exp.Anonymous) and str(node.this).upper() == "JSON_ARRAYAGG" and len(node.expressions) == 1:
+        return exp.Anonymous(this="json_group_array", expressions=[node.expressions[0]])
+    return node
 
 def _has_outer_column(e):
     return _has_outer(e, lambda x: isinstance(x, exp.Column))
@@ -834,6 +847,47 @@ def rewrite_mysql_for_duckdb(node):
             this="json_pretty",
             expressions=[exp.Cast(this=node.expressions[0], to=exp.DataType.build("JSON"))],
         )
+    # MySQL JSON_LENGTH counts array entries, object members, and scalars as one.
+    if isinstance(node, exp.Anonymous) and str(node.this).upper() == "JSON_LENGTH" and len(node.expressions) in (1, 2):
+        target = node.expressions[0]
+        if len(node.expressions) == 2:
+            target = exp.Anonymous(
+                this="json_extract",
+                expressions=[target, node.expressions[1]],
+            )
+        target_type = exp.Anonymous(this="json_type", expressions=[target.copy()])
+        return exp.Case(
+            ifs=[
+                exp.If(
+                    this=exp.Is(this=target.copy(), expression=exp.Null()),
+                    true=exp.Null(),
+                ),
+                exp.If(
+                    this=exp.EQ(this=target_type.copy(), expression=exp.Literal.string("ARRAY")),
+                    true=exp.Anonymous(this="json_array_length", expressions=[target.copy()]),
+                ),
+                exp.If(
+                    this=exp.EQ(this=target_type, expression=exp.Literal.string("OBJECT")),
+                    true=exp.Anonymous(
+                        this="array_length",
+                        expressions=[exp.Anonymous(this="json_keys", expressions=[target.copy()])],
+                    ),
+                ),
+            ],
+            default=exp.Literal.number(1),
+        )
+    # MySQL JSON_CONTAINS_PATH(..., 'one'|'all', paths...) maps to json_exists checks.
+    if isinstance(node, exp.Anonymous) and str(node.this).upper() == "JSON_CONTAINS_PATH" and len(node.expressions) >= 3:
+        doc, mode, *paths = node.expressions
+        if isinstance(mode, exp.Literal) and mode.is_string:
+            checks = [
+                exp.Anonymous(this="json_exists", expressions=[doc.copy(), path])
+                for path in paths
+            ]
+            if str(mode.this).lower() == "one":
+                return exp.or_(*checks)
+            if str(mode.this).lower() == "all":
+                return exp.and_(*checks)
     # MySQL JSON_KEYS returns NULL on bad JSON. DuckDB json_keys errors.
     if isinstance(node, exp.JSONKeys):
         inner = node.this.transform(rewrite_mysql_for_duckdb) if node.this is not None else node.this
@@ -1383,7 +1437,8 @@ def transpile_mysql_to_duckdb(sql: str) -> str:
                 return node
             return exp.Null()
         return rewrite_mysql_for_duckdb(node)
-    tree = trees[0].transform(rewrite_with_insert_context)
+    tree = trees[0].transform(normalize_mysql_aggregates)
+    tree = tree.transform(rewrite_with_insert_context)
     if isinstance(tree, exp.Insert):
         if was_replace:
             tree.set("alternative", "REPLACE")

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -182,6 +182,36 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT JSON_PRETTY(CAST(c3 AS JSON)) FROM jsontable",
 		},
 		{
+			name:     "JSON_ARRAYAGG uses DuckDB aggregate",
+			input:    "SELECT c0, JSON_ARRAYAGG(value) FROM t GROUP BY c0",
+			expected: "SELECT c0, JSON_GROUP_ARRAY(value) FROM t GROUP BY c0",
+		},
+		{
+			name:     "JSON_ARRAYAGG stays aggregate during GROUP BY rewrite",
+			input:    "SELECT pk, JSON_ARRAYAGG(field) FROM j GROUP BY field",
+			expected: "SELECT ANY_VALUE(pk), JSON_GROUP_ARRAY(field) FROM j GROUP BY field",
+		},
+		{
+			name:     "JSON_LENGTH counts arrays objects and scalars",
+			input:    "SELECT JSON_LENGTH(j) FROM t",
+			expected: "SELECT CASE WHEN j IS NULL THEN NULL WHEN JSON_TYPE(j) = 'ARRAY' THEN JSON_ARRAY_LENGTH(j) WHEN JSON_TYPE(j) = 'OBJECT' THEN ARRAY_LENGTH(JSON_KEYS(j)) ELSE 1 END FROM t",
+		},
+		{
+			name:     "JSON_LENGTH supports a path",
+			input:    "SELECT JSON_LENGTH(j, '$.a') FROM t",
+			expected: "SELECT CASE WHEN JSON_EXTRACT(j, '$.a') IS NULL THEN NULL WHEN JSON_TYPE(JSON_EXTRACT(j, '$.a')) = 'ARRAY' THEN JSON_ARRAY_LENGTH(JSON_EXTRACT(j, '$.a')) WHEN JSON_TYPE(JSON_EXTRACT(j, '$.a')) = 'OBJECT' THEN ARRAY_LENGTH(JSON_KEYS(JSON_EXTRACT(j, '$.a'))) ELSE 1 END FROM t",
+		},
+		{
+			name:     "JSON_CONTAINS_PATH one uses OR",
+			input:    "SELECT JSON_CONTAINS_PATH(j, 'one', '$.a', '$.b') FROM t",
+			expected: "SELECT JSON_EXISTS(j, '$.a') OR JSON_EXISTS(j, '$.b') FROM t",
+		},
+		{
+			name:     "JSON_CONTAINS_PATH all uses AND",
+			input:    "SELECT JSON_CONTAINS_PATH(j, 'all', '$.a', '$.b') FROM t",
+			expected: "SELECT JSON_EXISTS(j, '$.a') AND JSON_EXISTS(j, '$.b') FROM t",
+		},
+		{
 			name:     "DAYOFYEAR compact date gets dashes",
 			input:    "SELECT DAYOFYEAR('20071211') FROM mytable",
 			expected: "SELECT DAYOFYEAR(CAST('2007-12-11' AS DATE)) FROM mytable",


### PR DESCRIPTION
## Summary

- open `TestJsonScripts` without expanding into JSON_TABLE coverage
- translate MySQL `JSON_LENGTH`, `JSON_ARRAYAGG`, and literal-mode `JSON_CONTAINS_PATH` to DuckDB-compatible forms
- keep unsupported behavior behind exact full-query skips

## Coverage

The upstream file has 90 leaf assertions. Final result is **66 PASS / 24 SKIP / 0 FAIL**:

- 22 MyDuck exact-query skips: JSON physical type names (2), three-argument JSON_VALUE (2), JSON_LENGTH invalid-input error semantics (1), positional binding (1), grouped JSON_ARRAYAGG ordering (1), JSON_OBJECTAGG duplicate keys (2), JSON_OBJECTAGG parsing of unquoted `value` (4), JSON_OBJECTAGG NULL-key error category (1), nested quoted `->>` values (2), JSON ordering (2), JSON text formatting (1), wildcard missing/null semantics (1), invalid JSON_CONTAINS_PATH mode (1), and missing JSON_INSERT (1)
- 1 upstream contradictory assertion: its script name and MySQL semantics require JSON_ARRAYAGG over no rows to return NULL, but Expected is `[]`
- 1 existing upstream `ScriptTestAssertion.Skip: true`

The opening 16 JSON_TYPE assertions all execute and pass.

## Verification

- `go test . -run '^TestJsonScripts$' -count=1 -v`
- JSON event count confirms 66 leaf PASS / 24 SKIP / 0 FAIL
- `go test . -run '^TestJsonScripts$' -count=3`
- `go test ./transpiler -count=1`
- `git diff --check`

Signed exact head: `b2e261d93eb3564dc1e9f3a41bcc02a0dc56f60b` (parent `73162fcddbcc09e6fef269d6757479ee86c1bf6a`, tree `746673dcaf14cc8c84bfe3267a2a111d8609fda9`, GitHub verification `valid`).
