### PR TITLE
fix: honor ANSI_QUOTES in DuckDB execution

### DIFF
--- a/backend/executor.go
+++ b/backend/executor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/transform"
 	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"github.com/sirupsen/logrus"
 )
 
@@ -195,7 +196,7 @@ func (b *DuckBuilder) executeQuery(ctx *sql.Context, n sql.Node, conn *stdsql.Co
 		// SQLGlot cannot translate MySQL's `TABLE t` into DuckDB's `FROM t` - it produces `"table" AS t` instead.
 		duckSQL = `FROM ` + catalog.ConnectIdentifiersANSI(n.Database().Name(), n.Name())
 	default:
-		duckSQL, err = transpiler.TranslateWithSQLGlot(ctx.Query())
+		duckSQL, err = transpiler.TranslateWithSQLGlot(queryForTranslation(ctx))
 	}
 	if err != nil {
 		return nil, catalog.ErrTranspiler.New(err)
@@ -219,7 +220,7 @@ func (b *DuckBuilder) executeQuery(ctx *sql.Context, n sql.Node, conn *stdsql.Co
 
 func (b *DuckBuilder) executeDML(ctx *sql.Context, n sql.Node, conn *stdsql.Conn) (sql.RowIter, error) {
 	// Translate the MySQL query to a DuckDB query
-	duckSQL, err := transpiler.TranslateWithSQLGlot(ctx.Query())
+	duckSQL, err := transpiler.TranslateWithSQLGlot(queryForTranslation(ctx))
 	if err != nil {
 		return nil, catalog.ErrTranspiler.New(err)
 	}
@@ -265,6 +266,22 @@ func (b *DuckBuilder) executeDML(ctx *sql.Context, n sql.Node, conn *stdsql.Conn
 		InsertID:     uint64(insertId),
 		Info:         info,
 	})), nil
+}
+
+// queryForTranslation canonicalizes ANSI-quoted identifiers before SQLGlot
+// reparses the original MySQL query with its default dialect settings.
+func queryForTranslation(ctx *sql.Context) string {
+	query := ctx.Query()
+	sqlMode := sql.LoadSqlMode(ctx)
+	if !sqlMode.AnsiQuotes() {
+		return query
+	}
+
+	parsed, err := sqlparser.ParseWithOptions(ctx, query, sqlMode.ParserOptions())
+	if err != nil {
+		return query
+	}
+	return sqlparser.String(parsed)
 }
 
 // containsVariable inspects if the plan contains a system or user variable.

--- a/backend/executor_test.go
+++ b/backend/executor_test.go
@@ -1,0 +1,25 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryForTranslationHonorsAnsiQuotes(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	require.NoError(t, ctx.SetSessionVariable(ctx, "sql_mode", "ANSI_QUOTES"))
+
+	ctx = ctx.WithQuery(`select "data", '"' from auctions order by "ai" desc`)
+	require.Equal(t, "select `data`, '\\\"' from auctions order by ai desc", queryForTranslation(ctx))
+}
+
+func TestQueryForTranslationLeavesDoubleQuotedStringsWhenAnsiQuotesDisabled(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	require.NoError(t, ctx.SetSessionVariable(ctx, "sql_mode", "NO_ENGINE_SUBSTITUTION"))
+
+	query := `select "data" from auctions order by "ai" desc`
+	ctx = ctx.WithQuery(query)
+	require.Equal(t, query, queryForTranslation(ctx))
+}

--- a/main_test.go
+++ b/main_test.go
@@ -516,12 +516,61 @@ func TestAnsiQuotesSqlMode(t *testing.T) {
 }
 
 func TestAnsiQuotesSqlModePrepared(t *testing.T) {
-	t.Skip("wait for fix")
 	harness := NewDefaultDuckHarness()
 	if harness.IsUsingServer() {
 		t.Skip("prepared test depend on context for current sql_mode information, but it does not get updated when using ServerEngine")
 	}
-	enginetest.TestAnsiQuotesSqlModePrepared(t, NewDefaultDuckHarness())
+
+	ansiQuotesTests := append([]queries.ScriptTest(nil), queries.AnsiQuotesTests...)
+	for i := range ansiQuotesTests {
+		script := &ansiQuotesTests[i]
+		switch script.Name {
+		case "ANSI_QUOTES: triggers", "ANSI_QUOTES: stored procedures", "ANSI_QUOTES: events":
+			// DuckDB does not provide these MySQL server-side objects.
+			script.SkipPrepared = true
+		case "ANSI_QUOTES: column defaults":
+			// DuckDB rejects DEFAULT expressions that refer to another column.
+			script.SkipPrepared = true
+		}
+	}
+
+	for _, script := range ansiQuotesTests {
+		enginetest.TestScriptPrepared(t, harness, script)
+	}
+}
+
+func TestAnsiQuotesSqlModeExecution(t *testing.T) {
+	test := queries.ScriptTest{
+		Name: "ANSI_QUOTES: ordinary execution uses the session mode",
+		SetUpScript: []string{
+			"create table auctions (ai int primary key, data varchar(100));",
+			"insert into auctions values (1, 'forty-two');",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    `select "data" from auctions order by "ai" desc;`,
+				Expected: []sql.Row{{"data"}},
+			},
+			{
+				Query:    "SET @@sql_mode='ANSI_QUOTES';",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query:    `select "data" from auctions order by "ai" desc;`,
+				Expected: []sql.Row{{"forty-two"}},
+			},
+			{
+				Query:    "SET @@sql_mode='NO_ENGINE_SUBSTITUTION';",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query:    `select "data" from auctions order by "ai" desc;`,
+				Expected: []sql.Row{{"data"}},
+			},
+		},
+	}
+
+	enginetest.TestScript(t, NewDefaultDuckHarness(), test)
 }
 
 // Tests of choosing the correct execution plan independent of result correctness. Mostly useful for confirming that


### PR DESCRIPTION
## Summary

- canonicalize queries with the current session's `sql_mode` before SQLGlot handles query and DML execution
- enable the prepared ANSI_QUOTES suite while retaining only documented DuckDB capability skips
- cover ANSI_QUOTES-on canonicalization, mode-off passthrough, and ordinary default/on/off execution

## Testing

- `go test . -run '^TestAnsiQuotesSqlModePrepared$' -count=1 -v` (30 PASS / 5 SKIP / 0 FAIL)
- `go test . -run '^(TestAnsiQuotesSqlModePrepared|TestAnsiQuotesSqlModeExecution|TestAnsiQuotesSqlMode)$' -count=3`
- `go test ./backend -count=1`
- `go test ./transpiler -count=1`

The five remaining skips are one upstream view-output assertion plus four unsupported DuckDB capability scripts: triggers, stored procedures, events, and a default expression referencing another column.

Exact head `c27d6ab36a53852030f5dfdf5b2f6adb477e4ca3` is GitHub-verified and has parent `bf717e6e5abb64d49aadf3d4bea165d35dc4b110`.
