### PR TITLE
test: enable compatible generated column queries

### DIFF
--- a/generated_columns_test.go
+++ b/generated_columns_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/enginetest"
+	"github.com/dolthub/go-mysql-server/enginetest/queries"
+	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
+)
+
+type generatedColumnScriptSupport struct {
+	name       string
+	assertions []int
+}
+
+// MyDuck currently stores generated columns as ordinary DuckDB columns. Keep
+// assertions that execute with MySQL-compatible results, and skip assertions
+// that depend on generation, generated-column validation, or generated indexes.
+var generatedColumnScriptSupportMatrix = []generatedColumnScriptSupport{
+	{name: "stored generated column", assertions: []int{3, 4, 6, 9}},
+	{name: "Add stored column first with literal"},
+	{name: "Add stored column first with expression"},
+	{name: "index on stored generated column", assertions: []int{0, 2, 6}},
+	{name: "creating index on stored generated column", assertions: []int{0}},
+	{name: "creating index on stored generated column with type conversion", assertions: []int{0}},
+	{name: "creating index on stored generated column within multi-alter statement", assertions: []int{0}},
+	{name: "creating unique index on stored generated column", assertions: []int{0}},
+	{name: "creating index on virtual generated column", assertions: []int{0}},
+	{name: "creating index on stored generated column with type conversion", assertions: []int{0}},
+	{name: "creating index on virtual generated column with type conversion", assertions: []int{0}},
+	{name: "index on stored generated column and one non-generated column", assertions: []int{0, 2, 4}},
+	{name: "add new generated column", assertions: []int{0}},
+	{name: "stored generated column with spaces", assertions: []int{0, 2, 4, 6}},
+	{name: "virtual generated column with spaces", assertions: []int{0, 2, 4, 6}},
+	{name: "Add virtual column first with literal"},
+	{name: "Add virtual column first with expression"},
+	{name: "virtual column inserts, updates, deletes", assertions: []int{0, 2, 4}},
+	{name: "virtual column selects", assertions: []int{0, 2}},
+	{name: "virtual column in triggers", assertions: []int{0, 1, 3}},
+	{name: "virtual column json extract", assertions: []int{0}},
+	{name: "virtual column with function", assertions: []int{0}},
+	{name: "physical columns added after virtual one"},
+	{name: "virtual column ordering", assertions: []int{0, 1, 3}},
+	{name: "adding a virtual column", assertions: []int{0, 1}},
+	{name: "creating index on virtual generated column", assertions: []int{0}},
+	{name: "virtual column index", assertions: []int{1}},
+	{name: "virtual column index on a keyless table"},
+	{name: "creating index on virtual generated column with type conversion", assertions: []int{0}},
+	{name: "creating index on virtual generated column within multi-alter statement", assertions: []int{0}},
+	{name: "creating unique index on virtual generated column", assertions: []int{0}},
+	{name: "illegal table definitions", assertions: []int{0, 1}},
+	{name: "generated columns in primary key"},
+}
+
+func generatedColumnTestsForMyDuck(t testing.TB) []queries.ScriptTest {
+	t.Helper()
+
+	if len(queries.GeneratedColumnTests) != len(generatedColumnScriptSupportMatrix) {
+		t.Fatalf("generated column test matrix changed: got %d scripts, want %d", len(queries.GeneratedColumnTests), len(generatedColumnScriptSupportMatrix))
+	}
+
+	tests := append([]queries.ScriptTest(nil), queries.GeneratedColumnTests...)
+	for scriptIndex := range tests {
+		support := generatedColumnScriptSupportMatrix[scriptIndex]
+		if tests[scriptIndex].Name != support.name {
+			t.Fatalf("generated column test %d changed: got %q, want %q", scriptIndex, tests[scriptIndex].Name, support.name)
+		}
+
+		tests[scriptIndex].Assertions = append([]queries.ScriptTestAssertion(nil), tests[scriptIndex].Assertions...)
+		supported := make(map[int]struct{}, len(support.assertions))
+		for _, assertionIndex := range support.assertions {
+			if assertionIndex < 0 || assertionIndex >= len(tests[scriptIndex].Assertions) {
+				t.Fatalf("generated column assertion index out of range: script=%q assertion=%d", support.name, assertionIndex)
+			}
+			supported[assertionIndex] = struct{}{}
+		}
+
+		for assertionIndex := range tests[scriptIndex].Assertions {
+			if tests[scriptIndex].Assertions[assertionIndex].Skip {
+				continue
+			}
+			if _, ok := supported[assertionIndex]; !ok {
+				tests[scriptIndex].Assertions[assertionIndex].Skip = true
+			}
+		}
+	}
+
+	return tests
+}
+
+func testGeneratedColumns(t *testing.T, harness enginetest.Harness) {
+	harness.Setup(setup.MydbData)
+	for _, script := range generatedColumnTestsForMyDuck(t) {
+		enginetest.TestScript(t, harness, script)
+	}
+
+	// Keep the upstream capability skips separate from MyDuck's compatibility matrix.
+	for _, script := range queries.BrokenGeneratedColumnTests {
+		t.Run(script.Name, func(t *testing.T) {
+			t.Skip(script.Name)
+		})
+	}
+}
+
+func TestGeneratedColumnCompatibilityMatrix(t *testing.T) {
+	tests := generatedColumnTestsForMyDuck(t)
+	var pass, myDuckSkip, upstreamSkip int
+	for scriptIndex, script := range tests {
+		for assertionIndex, assertion := range script.Assertions {
+			if !assertion.Skip {
+				pass++
+			} else if queries.GeneratedColumnTests[scriptIndex].Assertions[assertionIndex].Skip {
+				upstreamSkip++
+			} else {
+				myDuckSkip++
+			}
+		}
+	}
+
+	if pass != 48 || myDuckSkip != 126 || upstreamSkip != 8 {
+		t.Fatalf("unexpected generated column matrix: pass=%d myduck_skip=%d upstream_skip=%d", pass, myDuckSkip, upstreamSkip)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -964,8 +964,7 @@ func TestBrokenInsertScripts(t *testing.T) {
 }
 
 func TestGeneratedColumns(t *testing.T) {
-	t.Skip("wait for fix")
-	enginetest.TestGeneratedColumns(t, NewDefaultDuckHarness())
+	testGeneratedColumns(t, NewDefaultDuckHarness())
 }
 
 func TestGeneratedColumnPlans(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace the top-level `TestGeneratedColumns` skip with a MyDuck-local deep copy of the upstream 33-script matrix
- run every setup statement, keep 48 assertions that return MySQL-compatible results, and mark only the incompatible assertion copies as skipped
- guard the pinned upstream script order and the 48 PASS / 126 MyDuck SKIP / 8 upstream SKIP split; leave `BrokenGeneratedColumnTests` and `TestGeneratedColumnPlans` unchanged

## Coverage
`GeneratedColumnTests` contains 33 scripts and 182 assertions:
- 48 PASS
- 134 assertion SKIP: 126 MyDuck boundaries plus 8 native upstream skips
- 0 FAIL

`BrokenGeneratedColumnTests` remains one separate native script SKIP and is not counted in the 182-assertion recovery matrix. All 33 setup sections execute before assertion-level skips.

## Boundaries
- DuckDB stores the transpiled generated columns as ordinary columns, so generated expressions disappear from `SHOW CREATE` and generated values read back as `NULL` or physical values.
- Explicit inserts and updates of generated columns do not raise MySQL's generated-column error. Those exact assertions are skipped before execution so an unexpected successful write cannot pollute later state.
- `ADD ... GENERATED ... FIRST`, generated indexes and uniqueness, and generated-column primary-key restrictions do not retain MySQL semantics.
- Trigger-backed generated-column coverage remains unsupported.
- In `virtual column index on a keyless table`, `update t1 set j = '{"a": 5}' where v = 2` matches zero rows because `v` is not generated. The backend returns an OkResult, while the upstream result widener applies the JSON column shape and panics with `OkResult ... is not json`; the assertion is skipped before that panic.

The exact skipped query names remain visible as individual `TestGeneratedColumns/<script>/<query>` subtests under `-v`; the local matrix uses script plus assertion index so duplicate SQL in different scripts is classified independently.

## Tests
Exact signed head `74d939f6ceeaacece260358cfcfd652613ae4d03`, rebuilt on main `7c007afa938273eafe23ee38eb91f30e13821394`:
- `go test . -run '^TestGeneratedColumns$' -count=3`: each round 48 PASS / 134 assertion SKIP / 1 separate native script SKIP / 0 FAIL
- `go test . -run '^(TestGeneratedColumnCompatibilityMatrix|TestCreateTable|TestAlterTable|TestPkOrdinalsDDL|TestAnsiQuotesSqlMode|TestAnsiQuotesSqlModePrepared|TestAnsiQuotesSqlModeExecution|TestWindowRangeFrames|TestNamedWindows)$' -count=1`
- `go test ./backend -count=1`
- `go test ./transpiler -count=1`
