### PR TITLE
test: enable compatible window functions

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2124,8 +2124,7 @@ func TestNaturalJoin(t *testing.T) {
 }
 
 func TestWindowFunctions(t *testing.T) {
-	t.Skip("wait for fix")
-	enginetest.TestWindowFunctions(t, NewDefaultDuckHarness())
+	testWindowFunctionsCompat(t)
 }
 
 func TestWindowRangeFrames(t *testing.T) {

--- a/transpiler/translate.go
+++ b/transpiler/translate.go
@@ -468,6 +468,10 @@ def _rewrite_mysql_update(node):
     return exp.Update(**kwargs)
 
 def rewrite_mysql_for_duckdb(node):
+    # MySQL exposes ranking results as unsigned 64-bit integers. DuckDB uses
+    # signed BIGINTs unless the window result is explicitly cast.
+    if isinstance(node, exp.Window) and isinstance(node.this, (exp.Rank, exp.DenseRank)):
+        return exp.Cast(this=node.copy(), to=exp.DataType(this=exp.DataType.Type.UBIGINT))
     # SQLGlot renders a parenthesized MySQL JOIN without ON as (a, b),
     # which DuckDB rejects. Both dialects define it as a cross join.
     if isinstance(node, exp.Join) and isinstance(node.parent, exp.Table):

--- a/transpiler/translate_test.go
+++ b/transpiler/translate_test.go
@@ -62,6 +62,16 @@ func TestTranslate(t *testing.T) {
 			expected: "SELECT * FROM (ab CROSS JOIN pq) WHERE a IN (SELECT a FROM ab)",
 		},
 		{
+			name:     "RANK and DENSE_RANK return unsigned integers",
+			input:    "SELECT rank() OVER (ORDER BY b), dense_rank() OVER (PARTITION BY c ORDER BY b DESC) FROM t",
+			expected: "SELECT CAST(RANK() OVER (ORDER BY b NULLS FIRST) AS UBIGINT), CAST(DENSE_RANK() OVER (PARTITION BY c ORDER BY b DESC) AS UBIGINT) FROM t",
+		},
+		{
+			name:     "other window functions keep their native result types",
+			input:    "SELECT percent_rank() OVER (ORDER BY b), row_number() OVER (ORDER BY b), sum(a) OVER () FROM t",
+			expected: "SELECT PERCENT_RANK() OVER (ORDER BY b NULLS FIRST), ROW_NUMBER() OVER (ORDER BY b NULLS FIRST), SUM(a) OVER () FROM t",
+		},
+		{
 			name:     "CHAR_LENGTH becomes DuckDB LENGTH",
 			input:    "SELECT CHAR_LENGTH(s) FROM t",
 			expected: "SELECT LENGTH(s) FROM t",

--- a/window_functions_test.go
+++ b/window_functions_test.go
@@ -1,0 +1,475 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/enginetest"
+	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+)
+
+func testWindowFunctionsCompat(t *testing.T) {
+	harness := NewDefaultDuckHarness()
+	harness.Setup(setup.MydbData)
+	e := mustNewEngine(t, harness)
+	defer e.Close()
+	ctx := enginetest.NewContext(harness)
+
+	enginetest.RunQueryWithContext(t, e, harness, ctx, "CREATE TABLE empty_tbl (a int, b int)")
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, rank() over (order by b) FROM empty_tbl order by a`, expect: []sql.Row{}}})
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, dense_rank() over (order by b) FROM empty_tbl order by a`, expect: []sql.Row{}}})
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, percent_rank() over (order by b) FROM empty_tbl order by a`, expect: []sql.Row{}}})
+
+	enginetest.RunQueryWithContext(t, e, harness, ctx, "CREATE TABLE results (name varchar(20), subject varchar(20), mark int)")
+	enginetest.RunQueryWithContext(t, e, harness, ctx, "INSERT INTO results VALUES ('Pratibha', 'Maths', 100),('Ankita','Science',80),('Swarna','English',100),('Ankita','Maths',65),('Pratibha','Science',80),('Swarna','Science',50),('Pratibha','English',70),('Swarna','Maths',85),('Ankita','English',90)")
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT subject, name, mark, rank() OVER (partition by subject order by mark desc ) FROM results order by subject, mark desc, name`, expect: []sql.Row{
+		{"English", "Swarna", 100, uint64(1)},
+		{"English", "Ankita", 90, uint64(2)},
+		{"English", "Pratibha", 70, uint64(3)},
+		{"Maths", "Pratibha", 100, uint64(1)},
+		{"Maths", "Swarna", 85, uint64(2)},
+		{"Maths", "Ankita", 65, uint64(3)},
+		{"Science", "Ankita", 80, uint64(1)},
+		{"Science", "Pratibha", 80, uint64(1)},
+		{"Science", "Swarna", 50, uint64(3)},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT subject, name, mark, dense_rank() OVER (partition by subject order by mark desc ) FROM results order by subject, mark desc, name`, expect: []sql.Row{
+		{"English", "Swarna", 100, uint64(1)},
+		{"English", "Ankita", 90, uint64(2)},
+		{"English", "Pratibha", 70, uint64(3)},
+		{"Maths", "Pratibha", 100, uint64(1)},
+		{"Maths", "Swarna", 85, uint64(2)},
+		{"Maths", "Ankita", 65, uint64(3)},
+		{"Science", "Ankita", 80, uint64(1)},
+		{"Science", "Pratibha", 80, uint64(1)},
+		{"Science", "Swarna", 50, uint64(2)},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT subject, name, mark, percent_rank() OVER (partition by subject order by mark desc ) FROM results order by subject, mark desc, name`, expect: []sql.Row{
+		{"English", "Swarna", 100, float64(0)},
+		{"English", "Ankita", 90, float64(0.5)},
+		{"English", "Pratibha", 70, float64(1)},
+		{"Maths", "Pratibha", 100, float64(0)},
+		{"Maths", "Swarna", 85, float64(0.5)},
+		{"Maths", "Ankita", 65, float64(1)},
+		{"Science", "Ankita", 80, float64(0)},
+		{"Science", "Pratibha", 80, float64(0)},
+		{"Science", "Swarna", 50, float64(1)},
+	}}})
+
+	enginetest.RunQueryWithContext(t, e, harness, ctx, "CREATE TABLE t1 (a INTEGER PRIMARY KEY, b INTEGER, c integer)")
+	enginetest.RunQueryWithContext(t, e, harness, ctx, "INSERT INTO t1 VALUES (0,0,0), (1,1,1), (2,2,0), (3,0,0), (4,1,0), (5,3,0)")
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, percent_rank() over (order by b) FROM t1 order by a`, expect: []sql.Row{
+		{0, 0.0},
+		{1, 0.4},
+		{2, 0.8},
+		{3, 0.0},
+		{4, 0.4},
+		{5, 1.0},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, rank() over (order by b) FROM t1 order by a`, expect: []sql.Row{
+		{0, uint64(1)},
+		{1, uint64(3)},
+		{2, uint64(5)},
+		{3, uint64(1)},
+		{4, uint64(3)},
+		{5, uint64(6)},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, dense_rank() over (order by b) FROM t1 order by a`, expect: []sql.Row{
+		{0, uint64(1)},
+		{1, uint64(2)},
+		{2, uint64(3)},
+		{3, uint64(1)},
+		{4, uint64(2)},
+		{5, uint64(4)},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, percent_rank() over (order by b desc) FROM t1 order by a`, expect: []sql.Row{
+		{0, 0.8},
+		{1, 0.4},
+		{2, 0.2},
+		{3, 0.8},
+		{4, 0.4},
+		{5, 0.0},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, rank() over (order by b desc) FROM t1 order by a`, expect: []sql.Row{
+		{0, uint64(5)},
+		{1, uint64(3)},
+		{2, uint64(2)},
+		{3, uint64(5)},
+		{4, uint64(3)},
+		{5, uint64(1)},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, dense_rank() over (order by b desc) FROM t1 order by a`, expect: []sql.Row{
+		{0, uint64(4)},
+		{1, uint64(3)},
+		{2, uint64(2)},
+		{3, uint64(4)},
+		{4, uint64(3)},
+		{5, uint64(1)},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, percent_rank() over (partition by c order by b) FROM t1 order by a`, expect: []sql.Row{
+		{0, 0.0},
+		{1, 0.0},
+		{2, 0.75},
+		{3, 0.0},
+		{4, 0.5},
+		{5, 1.0},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, rank() over (partition by c order by b) FROM t1 order by a`, expect: []sql.Row{
+		{0, uint64(1)},
+		{1, uint64(1)},
+		{2, uint64(4)},
+		{3, uint64(1)},
+		{4, uint64(3)},
+		{5, uint64(5)},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, dense_rank() over (partition by c order by b) FROM t1 order by a`, expect: []sql.Row{
+		{0, uint64(1)},
+		{1, uint64(1)},
+		{2, uint64(3)},
+		{3, uint64(1)},
+		{4, uint64(2)},
+		{5, uint64(4)},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, percent_rank() over (partition by b order by c) FROM t1 order by a`, expect: []sql.Row{
+		{0, 0.0},
+		{1, 1.0},
+		{2, 0.0},
+		{3, 0.0},
+		{4, 0.0},
+		{5, 0.0},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, rank() over (partition by b order by c) FROM t1 order by a`, expect: []sql.Row{
+		{0, uint64(1)},
+		{1, uint64(2)},
+		{2, uint64(1)},
+		{3, uint64(1)},
+		{4, uint64(1)},
+		{5, uint64(1)},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, dense_rank() over (partition by b order by c) FROM t1 order by a`, expect: []sql.Row{
+		{0, uint64(1)},
+		{1, uint64(2)},
+		{2, uint64(1)},
+		{3, uint64(1)},
+		{4, uint64(1)},
+		{5, uint64(1)},
+	}}})
+
+	// no order by clause -> all rows are peers
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, percent_rank() over (partition by b) FROM t1 order by a`, expect: []sql.Row{
+		{0, 0.0},
+		{1, 0.0},
+		{2, 0.0},
+		{3, 0.0},
+		{4, 0.0},
+		{5, 0.0},
+	}}})
+
+	// no order by clause -> all rows are peers
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, rank() over (partition by b) FROM t1 order by a`, expect: []sql.Row{
+		{0, uint64(1)},
+		{1, uint64(1)},
+		{2, uint64(1)},
+		{3, uint64(1)},
+		{4, uint64(1)},
+		{5, uint64(1)},
+	}}})
+
+	// no order by clause -> all rows are peers
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, dense_rank() over (partition by b) FROM t1 order by a`, expect: []sql.Row{
+		{0, uint64(1)},
+		{1, uint64(1)},
+		{2, uint64(1)},
+		{3, uint64(1)},
+		{4, uint64(1)},
+		{5, uint64(1)},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, first_value(b) over (partition by c order by b) FROM t1 order by a`, expect: []sql.Row{
+		{0, 0},
+		{1, 1},
+		{2, 0},
+		{3, 0},
+		{4, 0},
+		{5, 0},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, first_value(a) over (partition by b order by a ASC, c ASC) FROM t1 order by a`, expect: []sql.Row{
+		{0, 0},
+		{1, 1},
+		{2, 2},
+		{3, 0},
+		{4, 1},
+		{5, 5},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, first_value(a-1) over (partition by b order by a ASC, c ASC) FROM t1 order by a`, expect: []sql.Row{
+		{0, -1},
+		{1, 0},
+		{2, 1},
+		{3, -1},
+		{4, 0},
+		{5, 4},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, first_value(c) over (partition by b order by a) FROM t1 order by a*b,a`, expect: []sql.Row{
+		{0, 0},
+		{3, 0},
+		{1, 1},
+		{2, 0},
+		{4, 1},
+		{5, 0},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lead(a) over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, 2},
+		{1, nil},
+		{2, 3},
+		{3, 4},
+		{4, 5},
+		{5, nil},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lead(a, 1) over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, 2},
+		{1, nil},
+		{2, 3},
+		{3, 4},
+		{4, 5},
+		{5, nil},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lead(a+2) over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, 4},
+		{1, nil},
+		{2, 5},
+		{3, 6},
+		{4, 7},
+		{5, nil},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lead(a, 1, a-1) over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, 2},
+		{1, 0},
+		{2, 3},
+		{3, 4},
+		{4, 5},
+		{5, 4},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lead(a, 0) over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, 0},
+		{1, 1},
+		{2, 2},
+		{3, 3},
+		{4, 4},
+		{5, 5},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lead(a, 1, -1) over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, 2},
+		{1, -1},
+		{2, 3},
+		{3, 4},
+		{4, 5},
+		{5, -1},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lead(a, 3, -1) over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, 4},
+		{1, -1},
+		{2, 5},
+		{3, -1},
+		{4, -1},
+		{5, -1},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lead('s') over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, "s"},
+		{1, nil},
+		{2, "s"},
+		{3, "s"},
+		{4, "s"},
+		{5, nil},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, last_value(b) over (partition by c order by b) FROM t1 order by a`, expect: []sql.Row{
+		{0, 0},
+		{1, 1},
+		{2, 2},
+		{3, 0},
+		{4, 1},
+		{5, 3},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, last_value(a) over (partition by b order by a ASC, c ASC) FROM t1 order by a`, expect: []sql.Row{
+		{0, 0},
+		{1, 1},
+		{2, 2},
+		{3, 3},
+		{4, 4},
+		{5, 5},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, last_value(a-1) over (partition by b order by a ASC, c ASC) FROM t1 order by a`, expect: []sql.Row{
+		{0, -1},
+		{1, 0},
+		{2, 1},
+		{3, 2},
+		{4, 3},
+		{5, 4},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, last_value(c) over (partition by b order by c) FROM t1 order by a*b,a`, expect: []sql.Row{
+		{0, 0},
+		{3, 0},
+		{1, 1},
+		{2, 0},
+		{4, 0},
+		{5, 0},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lag(a) over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, nil},
+		{1, nil},
+		{2, 0},
+		{3, 2},
+		{4, 3},
+		{5, 4},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lag(a, 1) over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, nil},
+		{1, nil},
+		{2, 0},
+		{3, 2},
+		{4, 3},
+		{5, 4},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lag(a+2) over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, nil},
+		{1, nil},
+		{2, 2},
+		{3, 4},
+		{4, 5},
+		{5, 6},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lag(a, 1, a-1) over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, -1},
+		{1, 0},
+		{2, 0},
+		{3, 2},
+		{4, 3},
+		{5, 4},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lag(a, 0) over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, 0},
+		{1, 1},
+		{2, 2},
+		{3, 3},
+		{4, 4},
+		{5, 5},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lag(a, 1, -1) over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, -1},
+		{1, -1},
+		{2, 0},
+		{3, 2},
+		{4, 3},
+		{5, 4},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lag(a, 3, -1) over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, -1},
+		{1, -1},
+		{2, -1},
+		{3, -1},
+		{4, 0},
+		{5, 2},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, lag('s') over (partition by c order by a) FROM t1 order by a`, expect: []sql.Row{
+		{0, nil},
+		{1, nil},
+		{2, "s"},
+		{3, "s"},
+		{4, "s"},
+		{5, "s"},
+	}}})
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: "SELECT a, lag(a, -1) over (partition by c) FROM t1", err: expression.ErrInvalidOffset}})
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: "SELECT a, lag(a, 's') over (partition by c) FROM t1", err: expression.ErrInvalidOffset}})
+
+	enginetest.RunQueryWithContext(t, e, harness, ctx, "CREATE TABLE t2 (a int, b int, c int)")
+	enginetest.RunQueryWithContext(t, e, harness, ctx, "INSERT INTO t2 VALUES (1,1,1), (3,2,2), (7,4,5)")
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT bit_and(a), bit_or(b), bit_xor(c) FROM t2`, skip: "DuckDB returns signed BIGINT results; MySQL expects unsigned 64-bit integers", expect: []sql.Row{
+		{uint64(1), uint64(7), uint64(6)},
+	}}})
+
+	enginetest.RunQueryWithContext(t, e, harness, ctx, "CREATE TABLE t3 (x varchar(100))")
+	enginetest.RunQueryWithContext(t, e, harness, ctx, "INSERT INTO t3 VALUES ('these'), ('are'), ('strings')")
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT bit_and(x) from t3`, skip: "DuckDB rejects bit aggregates on VARCHAR; MySQL coerces strings to numbers", expect: []sql.Row{
+		{uint64(0)},
+	}}})
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT bit_or(x) from t3`, skip: "DuckDB rejects bit aggregates on VARCHAR; MySQL coerces strings to numbers", expect: []sql.Row{
+		{uint64(0)},
+	}}})
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT bit_xor(x) from t3`, skip: "DuckDB rejects bit aggregates on VARCHAR; MySQL coerces strings to numbers", expect: []sql.Row{
+		{uint64(0)},
+	}}})
+
+	enginetest.RunQueryWithContext(t, e, harness, ctx, "CREATE TABLE t4 (x int)")
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT bit_and(x) from t4`, skip: "DuckDB returns NULL on empty input; MySQL returns the all-bits-set identity", expect: []sql.Row{
+		{^uint64(0)},
+	}}})
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT bit_or(x) from t4`, skip: "DuckDB returns NULL on empty input; MySQL returns the zero identity", expect: []sql.Row{
+		{uint64(0)},
+	}}})
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT bit_xor(x) from t4`, skip: "DuckDB returns NULL on empty input; MySQL returns the zero identity", expect: []sql.Row{
+		{uint64(0)},
+	}}})
+
+	enginetest.RunQueryWithContext(t, e, harness, ctx, "CREATE TABLE t5 (a INTEGER, b INTEGER)")
+	enginetest.RunQueryWithContext(t, e, harness, ctx, "INSERT INTO t5 VALUES (0,0), (0,1), (1,0), (1,1)")
+
+	runWindowCompatCases(t, e, harness, ctx, []windowCompatCase{{query: `SELECT a, b, row_number() over (partition by a, b) FROM t5 order by a, b`, expect: []sql.Row{
+		{0, 0, 1},
+		{0, 1, 1},
+		{1, 0, 1},
+		{1, 1, 1},
+	}}})
+}


### PR DESCRIPTION
## Summary

- replace the outer `TestWindowFunctions` skip with all 55 upstream assertions, each isolated as its own subtest through the shared `windowCompatCase` runner
- preserve the upstream setup order, SQL, expected rows, and error kinds exactly
- cast only SQLGlot `Window(this=Rank|DenseRank)` results to `UBIGINT`, matching MySQL's unsigned result type without affecting `PERCENT_RANK`, `ROW_NUMBER`, or other window aggregates

## Root cause

DuckDB returns `RANK` and `DENSE_RANK` as signed `BIGINT`; go-mysql-server's MySQL-compatible expectations use `uint64`. The values were already identical, but row comparison failed on the Go type. A structured AST cast around the complete ranking window fixes the type at the adapter boundary.

A broader `bit_*` result cast was rejected after negative probes: DuckDB produces signed values (`-1`, `-2`) and `CAST(... AS UBIGINT)` raises an out-of-range error instead of preserving MySQL's 64-bit unsigned bit pattern.

## Result

Upstream assertions: 55 total (53 result queries, 2 error assertions).

Final general-window matrix: **48 PASS / 7 SKIP / 0 FAIL**.

Exact skips:

- `SELECT bit_and(a), bit_or(b), bit_xor(c) FROM t2` — correct values but signed `int64` instead of MySQL `uint64`
- `SELECT bit_and(x) from t3`
- `SELECT bit_or(x) from t3`
- `SELECT bit_xor(x) from t3` — DuckDB binder rejects `VARCHAR`; MySQL coerces strings numerically
- `SELECT bit_and(x) from t4`
- `SELECT bit_or(x) from t4`
- `SELECT bit_xor(x) from t4` — DuckDB returns `NULL` on empty input; MySQL returns all-bits-set / zero / zero identities

## Verification

- `go test . -run '^TestWindowFunctions$' -count=3`
- `go test . -run '^(TestGeneratedColumns|TestGeneratedColumnCompatibilityMatrix|TestWindowFunctions|TestWindowRangeFrames|TestNamedWindows)$' -count=1`
  - Generated: 48 PASS / 126 MyDuck SKIP / 8 upstream assertion SKIP / 0 FAIL, plus 1 separate Broken inner SKIP
  - General: 48 PASS / 7 SKIP / 0 FAIL
  - Range: 2 PASS / 30 SKIP / 0 FAIL
  - Named: 4 PASS / 6 SKIP / 0 FAIL
- `go test ./transpiler -count=1`
- `go test ./backend -count=1`
- `go test . -run '^(TestAnsiQuotesSqlMode|TestAnsiQuotesSqlModePrepared|TestAnsiQuotesSqlModeExecution)$' -count=1`

Final signed head: `f51cd0f6dfd1a6db31e70264cab6a581b11e1127`
Parent: `0f7dbe9cc7420e5d1a234b8aab78e2507d65d8aa`
Tree: `c5a080cd5274ec108e57bc9ecad81ee93855693d`
