### PR TITLE
chore: establish versioned image release policy

### DIFF
--- a/.github/scripts/dockerhub-manifest.sh
+++ b/.github/scripts/dockerhub-manifest.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+dockerhub_pull_token() {
+  local repository="$1"
+  local response
+
+  if ! response="$(
+    curl --fail --silent --show-error --get \
+      --data-urlencode "service=registry.docker.io" \
+      --data-urlencode "scope=repository:${repository}:pull" \
+      https://auth.docker.io/token
+  )"; then
+    echo "failed to obtain a Docker Hub pull token for $repository" >&2
+    return 2
+  fi
+
+  if ! jq -er '.token | select(type == "string" and length > 0)' <<<"$response"; then
+    echo "Docker Hub returned an invalid pull token response for $repository" >&2
+    return 2
+  fi
+}
+
+# Prints a validated digest for HTTP 200, returns 1 for an explicit 404, and
+# returns 2 for every other registry, authentication, or transport failure.
+dockerhub_manifest_digest() {
+  local repository="$1"
+  local reference="$2"
+  local token="$3"
+  local response
+  local status
+  local headers
+  local digest
+
+  if ! response="$(
+    curl --silent --show-error --head \
+      --header "Authorization: Bearer $token" \
+      --header "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json" \
+      --write-out '\n%{http_code}' \
+      "https://registry-1.docker.io/v2/${repository}/manifests/${reference}"
+  )"; then
+    echo "failed to query Docker Hub manifest $repository:$reference" >&2
+    return 2
+  fi
+
+  status="${response##*$'\n'}"
+  headers="${response%$'\n'*}"
+
+  case "$status" in
+    200)
+      digest="$(
+        awk 'tolower($1) == "docker-content-digest:" { gsub("\\r", "", $2); value = $2 } END { print value }' \
+          <<<"$headers"
+      )"
+      if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+        echo "Docker Hub returned an invalid digest for $repository:$reference" >&2
+        return 2
+      fi
+      printf '%s\n' "$digest"
+      ;;
+    404)
+      return 1
+      ;;
+    *)
+      echo "Docker Hub returned unexpected HTTP status $status for $repository:$reference" >&2
+      return 2
+      ;;
+  esac
+}

--- a/.github/workflows/promote-image.yml
+++ b/.github/workflows/promote-image.yml
@@ -1,0 +1,280 @@
+name: Promote Image
+run-name: Promote ${{ inputs.source_version }} to ${{ inputs.stable_version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Full 40-character source commit SHA of the accepted image
+        required: true
+        type: string
+      source_version:
+        description: Existing immutable prerelease tag
+        required: true
+        type: string
+      source_digest:
+        description: Existing accepted multi-architecture image digest (sha256:...)
+        required: true
+        type: string
+      stable_version:
+        description: Stable version to create or verify (vX.Y.Z)
+        required: true
+        type: string
+      acceptance_reference:
+        description: Task, report, or URL containing independent acceptance evidence
+        required: true
+        type: string
+
+concurrency:
+  group: myduckserver-image-publish
+  cancel-in-progress: false
+
+env:
+  IMAGE: docker.io/apecloud/myduckserver
+  SOURCE_REPOSITORY: https://github.com/apecloud/myduckserver
+
+jobs:
+  promote-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Validate promotion inputs
+        id: metadata
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          SOURCE_VERSION: ${{ inputs.source_version }}
+          SOURCE_DIGEST: ${{ inputs.source_digest }}
+          STABLE_VERSION: ${{ inputs.stable_version }}
+          ACCEPTANCE_REFERENCE: ${{ inputs.acceptance_reference }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "promotion workflow must be dispatched from the main branch" >&2
+            exit 1
+          fi
+          if [[ ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "source_sha must be a lowercase, full 40-character commit SHA" >&2
+            exit 1
+          fi
+          if [[ ! "$SOURCE_VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-(dev\.[0-9]{8}\.[1-9][0-9]*|rc\.[1-9][0-9]*)$ ]]; then
+            echo "source_version must be an immutable dev or rc version" >&2
+            exit 1
+          fi
+          if [[ ! "$STABLE_VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "stable_version must match vX.Y.Z" >&2
+            exit 1
+          fi
+          if [[ ! "$SOURCE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "source_digest must be a full sha256 digest" >&2
+            exit 1
+          fi
+          if [[ "${SOURCE_VERSION%%-*}" != "$STABLE_VERSION" ]]; then
+            echo "source_version and stable_version must have the same vX.Y.Z base" >&2
+            exit 1
+          fi
+          if [[ -z "${ACCEPTANCE_REFERENCE//[[:space:]]/}" ]]; then
+            echo "acceptance_reference must contain a non-whitespace value" >&2
+            exit 1
+          fi
+          if [[ "$ACCEPTANCE_REFERENCE" == *$'\n'* || "$ACCEPTANCE_REFERENCE" == *$'\r'* ]]; then
+            echo "acceptance_reference must be a single line" >&2
+            exit 1
+          fi
+          echo "sha_tag=sha-${SOURCE_SHA:0:8}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release history
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify source is reachable from main
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          actual_workflow_sha="$(git rev-parse HEAD)"
+          if [[ "$actual_workflow_sha" != "$WORKFLOW_SHA" ]]; then
+            echo "checked out workflow commit $actual_workflow_sha, expected $WORKFLOW_SHA" >&2
+            exit 1
+          fi
+          if ! git cat-file -e "$SOURCE_SHA^{commit}"; then
+            echo "source commit $SOURCE_SHA is missing from release history" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$SOURCE_SHA" "$WORKFLOW_SHA"; then
+            echo "source_sha must be reachable from main at workflow commit $WORKFLOW_SHA" >&2
+            exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+
+      - name: Verify accepted source image
+        id: source
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          SOURCE_VERSION: ${{ inputs.source_version }}
+          SOURCE_DIGEST: ${{ inputs.source_digest }}
+          SHA_TAG: ${{ steps.metadata.outputs.sha_tag }}
+          STABLE_VERSION: ${{ inputs.stable_version }}
+        run: |
+          set -euo pipefail
+          inspect_digest() {
+            docker buildx imagetools inspect "$1" --format '{{json .Manifest}}' |
+              jq -r '.digest // empty'
+          }
+
+          source_version_digest="$(inspect_digest "$IMAGE:$SOURCE_VERSION")"
+          source_sha_digest="$(inspect_digest "$IMAGE:$SHA_TAG")"
+          if [[ "$source_version_digest" != "$SOURCE_DIGEST" || "$source_sha_digest" != "$SOURCE_DIGEST" ]]; then
+            echo "source version, source commit tag, and accepted digest must match" >&2
+            exit 1
+          fi
+
+          docker buildx imagetools inspect "$IMAGE@$SOURCE_DIGEST" \
+            --format '{{json .Image}}' > accepted-image.json
+          jq -e \
+            --arg source "$SOURCE_REPOSITORY" \
+            --arg version "$SOURCE_VERSION" \
+            --arg revision "$SOURCE_SHA" \
+            '
+              (keys | sort) == ["linux/amd64", "linux/arm64"] and
+              all(.[];
+                .config.Labels["org.opencontainers.image.source"] == $source and
+                .config.Labels["org.opencontainers.image.version"] == $version and
+                .config.Labels["org.opencontainers.image.revision"] == $revision
+              )
+            ' accepted-image.json >/dev/null
+
+          stable_digest="$(inspect_digest "$IMAGE:$STABLE_VERSION" 2>/dev/null || true)"
+          if [[ -n "$stable_digest" && "$stable_digest" != "$SOURCE_DIGEST" ]]; then
+            echo "refusing to overwrite immutable stable tag $IMAGE:$STABLE_VERSION" >&2
+            exit 1
+          fi
+
+          previous_latest="$(inspect_digest "$IMAGE:latest" 2>/dev/null || true)"
+          echo "stable_exists=$([[ -n "$stable_digest" ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "previous_latest=${previous_latest:-none}" >> "$GITHUB_OUTPUT"
+
+      - name: Promote accepted digest without rebuilding
+        shell: bash
+        env:
+          SOURCE_DIGEST: ${{ inputs.source_digest }}
+          STABLE_VERSION: ${{ inputs.stable_version }}
+          STABLE_EXISTS: ${{ steps.source.outputs.stable_exists }}
+        run: |
+          set -euo pipefail
+          tags=(--tag "$IMAGE:latest")
+          if [[ "$STABLE_EXISTS" != "true" ]]; then
+            tags+=(--tag "$IMAGE:$STABLE_VERSION")
+          fi
+          docker buildx imagetools create "${tags[@]}" "$IMAGE@$SOURCE_DIGEST"
+
+      - name: Verify promotion and record evidence
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          SOURCE_VERSION: ${{ inputs.source_version }}
+          SOURCE_DIGEST: ${{ inputs.source_digest }}
+          SHA_TAG: ${{ steps.metadata.outputs.sha_tag }}
+          STABLE_VERSION: ${{ inputs.stable_version }}
+          ACCEPTANCE_REFERENCE: ${{ inputs.acceptance_reference }}
+          PREVIOUS_LATEST: ${{ steps.source.outputs.previous_latest }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          inspect_digest() {
+            docker buildx imagetools inspect "$1" --format '{{json .Manifest}}' |
+              jq -r '.digest // empty'
+          }
+
+          stable_digest="$(inspect_digest "$IMAGE:$STABLE_VERSION")"
+          latest_digest="$(inspect_digest "$IMAGE:latest")"
+          if [[ "$stable_digest" != "$SOURCE_DIGEST" || "$latest_digest" != "$SOURCE_DIGEST" ]]; then
+            echo "stable version and latest must point to accepted digest $SOURCE_DIGEST" >&2
+            exit 1
+          fi
+
+          docker buildx imagetools inspect "$IMAGE@$SOURCE_DIGEST" \
+            --format '{{json .Manifest}}' > promoted-manifest.json
+          jq -e \
+            --arg digest "$SOURCE_DIGEST" \
+            '
+              .digest == $digest and
+              (.manifests | length) == 2 and
+              ([.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64")] | length) == 1 and
+              ([.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64")] | length) == 1 and
+              all(.manifests[]; .digest | test("^sha256:[0-9a-f]{64}$"))
+            ' promoted-manifest.json >/dev/null
+          amd64_digest="$(
+            jq -er '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64") | .digest' \
+              promoted-manifest.json
+          )"
+          arm64_digest="$(
+            jq -er '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64") | .digest' \
+              promoted-manifest.json
+          )"
+
+          jq -n \
+            --arg image "$IMAGE" \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg workflow_sha "$WORKFLOW_SHA" \
+            --arg workflow_run_id "$GITHUB_RUN_ID" \
+            --arg workflow_run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --arg source_version "$SOURCE_VERSION" \
+            --arg sha_tag "$SHA_TAG" \
+            --arg stable_version "$STABLE_VERSION" \
+            --arg digest "$SOURCE_DIGEST" \
+            --arg amd64_digest "$amd64_digest" \
+            --arg arm64_digest "$arm64_digest" \
+            --arg previous_latest "$PREVIOUS_LATEST" \
+            --arg acceptance_reference "$ACCEPTANCE_REFERENCE" \
+            '{
+              image: $image,
+              source_sha: $source_sha,
+              workflow_sha: $workflow_sha,
+              workflow_run_id: $workflow_run_id,
+              workflow_run_url: $workflow_run_url,
+              source_version: $source_version,
+              sha_tag: $sha_tag,
+              stable_version: $stable_version,
+              digest: $digest,
+              platforms: {
+                "linux/amd64": $amd64_digest,
+                "linux/arm64": $arm64_digest
+              },
+              previous_latest: $previous_latest,
+              acceptance_reference: $acceptance_reference
+            }' > promotion-metadata.json
+
+          {
+            echo "## Promoted accepted image"
+            echo
+            echo "- Acceptance: $ACCEPTANCE_REFERENCE"
+            echo "- Source: \`$SOURCE_SHA\`"
+            echo "- Stable tag: \`$IMAGE:$STABLE_VERSION\`"
+            echo "- Latest: \`$IMAGE:latest\`"
+            echo "- Digest: \`$SOURCE_DIGEST\`"
+            echo "- Previous latest: \`$PREVIOUS_LATEST\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload promotion evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: promotion-metadata-${{ inputs.stable_version }}
+          path: promotion-metadata.json
+          if-no-files-found: error

--- a/.github/workflows/promote-image.yml
+++ b/.github/workflows/promote-image.yml
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
       source_version:
-        description: Existing immutable prerelease tag
+        description: Existing immutable release-candidate tag
         required: true
         type: string
       source_digest:
@@ -58,8 +58,8 @@ jobs:
             echo "source_sha must be a lowercase, full 40-character commit SHA" >&2
             exit 1
           fi
-          if [[ ! "$SOURCE_VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-(dev\.[0-9]{8}\.[1-9][0-9]*|rc\.[1-9][0-9]*)$ ]]; then
-            echo "source_version must be an immutable dev or rc version" >&2
+          if [[ ! "$SOURCE_VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-rc\.[1-9][0-9]*$ ]]; then
+            echo "source_version must be an immutable release-candidate version" >&2
             exit 1
           fi
           if [[ ! "$STABLE_VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
@@ -85,7 +85,7 @@ jobs:
           echo "sha_tag=sha-${SOURCE_SHA:0:8}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout release history
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
@@ -113,10 +113,10 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: docker.io
           username: ${{ secrets.DOCKER_REGISTRY_USER }}
@@ -133,13 +133,22 @@ jobs:
           STABLE_VERSION: ${{ inputs.stable_version }}
         run: |
           set -euo pipefail
-          inspect_digest() {
-            docker buildx imagetools inspect "$1" --format '{{json .Manifest}}' |
-              jq -r '.digest // empty'
-          }
-
-          source_version_digest="$(inspect_digest "$IMAGE:$SOURCE_VERSION")"
-          source_sha_digest="$(inspect_digest "$IMAGE:$SHA_TAG")"
+          source .github/scripts/dockerhub-manifest.sh
+          pull_token="$(dockerhub_pull_token 'apecloud/myduckserver')"
+          if source_version_digest="$(dockerhub_manifest_digest 'apecloud/myduckserver' "$SOURCE_VERSION" "$pull_token")"; then
+            :
+          else
+            status=$?
+            echo "source release-candidate tag could not be resolved" >&2
+            exit "$status"
+          fi
+          if source_sha_digest="$(dockerhub_manifest_digest 'apecloud/myduckserver' "$SHA_TAG" "$pull_token")"; then
+            :
+          else
+            status=$?
+            echo "source commit tag could not be resolved" >&2
+            exit "$status"
+          fi
           if [[ "$source_version_digest" != "$SOURCE_DIGEST" || "$source_sha_digest" != "$SOURCE_DIGEST" ]]; then
             echo "source version, source commit tag, and accepted digest must match" >&2
             exit 1
@@ -160,13 +169,28 @@ jobs:
               )
             ' accepted-image.json >/dev/null
 
-          stable_digest="$(inspect_digest "$IMAGE:$STABLE_VERSION" 2>/dev/null || true)"
-          if [[ -n "$stable_digest" && "$stable_digest" != "$SOURCE_DIGEST" ]]; then
-            echo "refusing to overwrite immutable stable tag $IMAGE:$STABLE_VERSION" >&2
-            exit 1
+          stable_digest=""
+          if stable_digest="$(dockerhub_manifest_digest 'apecloud/myduckserver' "$STABLE_VERSION" "$pull_token")"; then
+            if [[ "$stable_digest" != "$SOURCE_DIGEST" ]]; then
+              echo "refusing to overwrite immutable stable tag $IMAGE:$STABLE_VERSION" >&2
+              exit 1
+            fi
+          else
+            status=$?
+            if [[ "$status" -ne 1 ]]; then
+              exit "$status"
+            fi
           fi
 
-          previous_latest="$(inspect_digest "$IMAGE:latest" 2>/dev/null || true)"
+          previous_latest=""
+          if previous_latest="$(dockerhub_manifest_digest 'apecloud/myduckserver' latest "$pull_token")"; then
+            :
+          else
+            status=$?
+            if [[ "$status" -ne 1 ]]; then
+              exit "$status"
+            fi
+          fi
           echo "stable_exists=$([[ -n "$stable_digest" ]] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "previous_latest=${previous_latest:-none}" >> "$GITHUB_OUTPUT"
 
@@ -197,13 +221,22 @@ jobs:
           WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          inspect_digest() {
-            docker buildx imagetools inspect "$1" --format '{{json .Manifest}}' |
-              jq -r '.digest // empty'
-          }
-
-          stable_digest="$(inspect_digest "$IMAGE:$STABLE_VERSION")"
-          latest_digest="$(inspect_digest "$IMAGE:latest")"
+          source .github/scripts/dockerhub-manifest.sh
+          pull_token="$(dockerhub_pull_token 'apecloud/myduckserver')"
+          if stable_digest="$(dockerhub_manifest_digest 'apecloud/myduckserver' "$STABLE_VERSION" "$pull_token")"; then
+            :
+          else
+            status=$?
+            echo "promoted stable tag could not be resolved" >&2
+            exit "$status"
+          fi
+          if latest_digest="$(dockerhub_manifest_digest 'apecloud/myduckserver' latest "$pull_token")"; then
+            :
+          else
+            status=$?
+            echo "promoted latest tag could not be resolved" >&2
+            exit "$status"
+          fi
           if [[ "$stable_digest" != "$SOURCE_DIGEST" || "$latest_digest" != "$SOURCE_DIGEST" ]]; then
             echo "stable version and latest must point to accepted digest $SOURCE_DIGEST" >&2
             exit 1
@@ -228,6 +261,7 @@ jobs:
             jq -er '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64") | .digest' \
               promoted-manifest.json
           )"
+          promoted_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
           jq -n \
             --arg image "$IMAGE" \
@@ -243,6 +277,7 @@ jobs:
             --arg arm64_digest "$arm64_digest" \
             --arg previous_latest "$PREVIOUS_LATEST" \
             --arg acceptance_reference "$ACCEPTANCE_REFERENCE" \
+            --arg promoted_at "$promoted_at" \
             '{
               image: $image,
               source_sha: $source_sha,
@@ -258,7 +293,8 @@ jobs:
                 "linux/arm64": $arm64_digest
               },
               previous_latest: $previous_latest,
-              acceptance_reference: $acceptance_reference
+              acceptance_reference: $acceptance_reference,
+              promoted_at: $promoted_at
             }' > promotion-metadata.json
 
           {
@@ -273,7 +309,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload promotion evidence
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: promotion-metadata-${{ inputs.stable_version }}
           path: promotion-metadata.json

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -52,11 +52,19 @@ jobs:
           fi
 
       - name: Checkout exact application source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.source_sha }}
           path: source
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout exact release tooling
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.sha }}
+          path: release-tools
+          fetch-depth: 1
           persist-credentials: false
 
       - name: Verify checkout and derive metadata
@@ -72,6 +80,11 @@ jobs:
             echo "checked out $actual_sha, expected $SOURCE_SHA" >&2
             exit 1
           fi
+          actual_workflow_sha="$(git -C release-tools rev-parse HEAD)"
+          if [[ "$actual_workflow_sha" != "$WORKFLOW_SHA" ]]; then
+            echo "checked out workflow commit $actual_workflow_sha, expected $WORKFLOW_SHA" >&2
+            exit 1
+          fi
           if ! git -C source cat-file -e "$WORKFLOW_SHA^{commit}"; then
             echo "workflow commit $WORKFLOW_SHA is missing from the checkout" >&2
             exit 1
@@ -85,13 +98,13 @@ jobs:
           echo "build_time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: docker.io
           username: ${{ secrets.DOCKER_REGISTRY_USER }}
@@ -104,16 +117,23 @@ jobs:
           SHA_TAG: ${{ steps.metadata.outputs.sha_tag }}
         run: |
           set -euo pipefail
+          source release-tools/.github/scripts/dockerhub-manifest.sh
+          pull_token="$(dockerhub_pull_token 'apecloud/myduckserver')"
           for tag in "$VERSION" "$SHA_TAG"; do
-            if docker buildx imagetools inspect "$IMAGE:$tag" >/dev/null 2>&1; then
-              echo "refusing to overwrite existing immutable tag: $IMAGE:$tag" >&2
+            if existing_digest="$(dockerhub_manifest_digest 'apecloud/myduckserver' "$tag" "$pull_token")"; then
+              echo "refusing to overwrite existing immutable tag $IMAGE:$tag at $existing_digest" >&2
               exit 1
+            else
+              status=$?
+              if [[ "$status" -ne 1 ]]; then
+                exit "$status"
+              fi
             fi
           done
 
       - name: Build and push immutable image tags
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./source
           file: ./source/docker/Dockerfile
@@ -148,13 +168,22 @@ jobs:
           WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          inspect_digest() {
-            docker buildx imagetools inspect "$1" --format '{{json .Manifest}}' |
-              jq -r '.digest // empty'
-          }
-
-          version_digest="$(inspect_digest "$IMAGE:$VERSION")"
-          sha_digest="$(inspect_digest "$IMAGE:$SHA_TAG")"
+          source release-tools/.github/scripts/dockerhub-manifest.sh
+          pull_token="$(dockerhub_pull_token 'apecloud/myduckserver')"
+          if version_digest="$(dockerhub_manifest_digest 'apecloud/myduckserver' "$VERSION" "$pull_token")"; then
+            :
+          else
+            status=$?
+            echo "published version tag could not be resolved" >&2
+            exit "$status"
+          fi
+          if sha_digest="$(dockerhub_manifest_digest 'apecloud/myduckserver' "$SHA_TAG" "$pull_token")"; then
+            :
+          else
+            status=$?
+            echo "published commit tag could not be resolved" >&2
+            exit "$status"
+          fi
           if [[ ! "$BUILD_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "build did not return a full sha256 digest: $BUILD_DIGEST" >&2
             exit 1
@@ -239,7 +268,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload release evidence
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-metadata-${{ inputs.version }}
           path: release-metadata.json

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -115,12 +115,20 @@ jobs:
           fi
           builder_image="${BASH_REMATCH[1]}"
           builder_image_digest="${BASH_REMATCH[2]}"
+          if [[ ! "${builder_image##*/}" =~ ^[^:]+:[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "builder image must include a readable tag before its digest" >&2
+            exit 1
+          fi
           if [[ ! "${base_images[1]}" =~ ^([^@[:space:]]+)@(sha256:[0-9a-f]{64})$ ]]; then
             echo "runtime image must include a readable tag and full sha256 manifest digest" >&2
             exit 1
           fi
           runtime_image="${BASH_REMATCH[1]}"
           runtime_image_digest="${BASH_REMATCH[2]}"
+          if [[ ! "${runtime_image##*/}" =~ ^[^:]+:[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "runtime image must include a readable tag before its digest" >&2
+            exit 1
+          fi
           short_sha="${SOURCE_SHA:0:8}"
           {
             echo "sha_tag=sha-$short_sha"

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -93,9 +93,43 @@ jobs:
             echo "source_sha must be reachable from main at workflow commit $WORKFLOW_SHA" >&2
             exit 1
           fi
+          mapfile -t base_images < <(
+            awk '
+              toupper($1) == "FROM" {
+                for (i = 2; i <= NF; i++) {
+                  if ($i !~ /^--/) {
+                    print $i
+                    break
+                  }
+                }
+              }
+            ' source/docker/Dockerfile
+          )
+          if [[ "${#base_images[@]}" -ne 2 ]]; then
+            echo "Dockerfile must contain exactly one builder and one runtime FROM image" >&2
+            exit 1
+          fi
+          if [[ ! "${base_images[0]}" =~ ^([^@[:space:]]+)@(sha256:[0-9a-f]{64})$ ]]; then
+            echo "builder image must include a readable tag and full sha256 manifest digest" >&2
+            exit 1
+          fi
+          builder_image="${BASH_REMATCH[1]}"
+          builder_image_digest="${BASH_REMATCH[2]}"
+          if [[ ! "${base_images[1]}" =~ ^([^@[:space:]]+)@(sha256:[0-9a-f]{64})$ ]]; then
+            echo "runtime image must include a readable tag and full sha256 manifest digest" >&2
+            exit 1
+          fi
+          runtime_image="${BASH_REMATCH[1]}"
+          runtime_image_digest="${BASH_REMATCH[2]}"
           short_sha="${SOURCE_SHA:0:8}"
-          echo "sha_tag=sha-$short_sha" >> "$GITHUB_OUTPUT"
-          echo "build_time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          {
+            echo "sha_tag=sha-$short_sha"
+            echo "build_time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+            echo "builder_image=$builder_image"
+            echo "builder_image_digest=$builder_image_digest"
+            echo "runtime_image=$runtime_image"
+            echo "runtime_image_digest=$runtime_image_digest"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
@@ -166,6 +200,10 @@ jobs:
           BUILD_TIME: ${{ steps.metadata.outputs.build_time }}
           BUILD_DIGEST: ${{ steps.build.outputs.digest }}
           WORKFLOW_SHA: ${{ github.sha }}
+          BUILDER_IMAGE: ${{ steps.metadata.outputs.builder_image }}
+          BUILDER_IMAGE_DIGEST: ${{ steps.metadata.outputs.builder_image_digest }}
+          RUNTIME_IMAGE: ${{ steps.metadata.outputs.runtime_image }}
+          RUNTIME_IMAGE_DIGEST: ${{ steps.metadata.outputs.runtime_image_digest }}
         run: |
           set -euo pipefail
           source release-tools/.github/scripts/dockerhub-manifest.sh
@@ -242,6 +280,10 @@ jobs:
             --arg amd64_digest "$amd64_digest" \
             --arg arm64_digest "$arm64_digest" \
             --arg build_time "$BUILD_TIME" \
+            --arg builder_image "$BUILDER_IMAGE" \
+            --arg builder_image_digest "$BUILDER_IMAGE_DIGEST" \
+            --arg runtime_image "$RUNTIME_IMAGE" \
+            --arg runtime_image_digest "$RUNTIME_IMAGE_DIGEST" \
             '{
               image: $image,
               source_sha: $source_sha,
@@ -255,6 +297,16 @@ jobs:
                 "linux/amd64": $amd64_digest,
                 "linux/arm64": $arm64_digest
               },
+              base_images: {
+                builder: {
+                  image: $builder_image,
+                  digest: $builder_image_digest
+                },
+                runtime: {
+                  image: $runtime_image,
+                  digest: $runtime_image_digest
+                }
+              },
               build_time: $build_time
             }' > release-metadata.json
 
@@ -265,6 +317,8 @@ jobs:
             echo "- Version tag: \`$IMAGE:$VERSION\`"
             echo "- Commit tag: \`$IMAGE:$SHA_TAG\`"
             echo "- Digest: \`$BUILD_DIGEST\`"
+            echo "- Builder: \`$BUILDER_IMAGE@$BUILDER_IMAGE_DIGEST\`"
+            echo "- Runtime: \`$RUNTIME_IMAGE@$RUNTIME_IMAGE_DIGEST\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload release evidence

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,17 +1,246 @@
 name: Release Image
+run-name: Build ${{ inputs.version }} from ${{ inputs.source_sha }}
 
 on:
-  push:
-    branches:
-      - 'main'
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Full 40-character application source commit SHA
+        required: true
+        type: string
+      version:
+        description: Immutable prerelease version (vX.Y.Z-dev.YYYYMMDD.N or vX.Y.Z-rc.N)
+        required: true
+        type: string
 
+concurrency:
+  group: myduckserver-image-publish
+  cancel-in-progress: false
+
+env:
+  IMAGE: docker.io/apecloud/myduckserver
+  SOURCE_REPOSITORY: https://github.com/apecloud/myduckserver
 
 jobs:
   release-image:
-    uses: apecloud/apecloud-cd/.github/workflows/release-image-cache.yml@v0.1.79
-    with:
-      IMG: "apecloud/myduckserver"
-      VERSION: "latest"
-      GO_VERSION: "1.23"
-      DOCKERFILE_PATH: "./docker/Dockerfile"
-    secrets: inherit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      sha_tag: ${{ steps.metadata.outputs.sha_tag }}
+      version: ${{ inputs.version }}
+    steps:
+      - name: Validate release inputs
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "release workflow must be dispatched from the main branch" >&2
+            exit 1
+          fi
+          if [[ ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "source_sha must be a lowercase, full 40-character commit SHA" >&2
+            exit 1
+          fi
+          if [[ ! "$VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-(dev\.[0-9]{8}\.[1-9][0-9]*|rc\.[1-9][0-9]*)$ ]]; then
+            echo "version must match vX.Y.Z-dev.YYYYMMDD.N or vX.Y.Z-rc.N" >&2
+            exit 1
+          fi
+
+      - name: Checkout exact application source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_sha }}
+          path: source
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify checkout and derive metadata
+        id: metadata
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git -C source rev-parse HEAD)"
+          if [[ "$actual_sha" != "$SOURCE_SHA" ]]; then
+            echo "checked out $actual_sha, expected $SOURCE_SHA" >&2
+            exit 1
+          fi
+          if ! git -C source cat-file -e "$WORKFLOW_SHA^{commit}"; then
+            echo "workflow commit $WORKFLOW_SHA is missing from the checkout" >&2
+            exit 1
+          fi
+          if ! git -C source merge-base --is-ancestor "$SOURCE_SHA" "$WORKFLOW_SHA"; then
+            echo "source_sha must be reachable from main at workflow commit $WORKFLOW_SHA" >&2
+            exit 1
+          fi
+          short_sha="${SOURCE_SHA:0:8}"
+          echo "sha_tag=sha-$short_sha" >> "$GITHUB_OUTPUT"
+          echo "build_time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+
+      - name: Enforce immutable tags
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          SHA_TAG: ${{ steps.metadata.outputs.sha_tag }}
+        run: |
+          set -euo pipefail
+          for tag in "$VERSION" "$SHA_TAG"; do
+            if docker buildx imagetools inspect "$IMAGE:$tag" >/dev/null 2>&1; then
+              echo "refusing to overwrite existing immutable tag: $IMAGE:$tag" >&2
+              exit 1
+            fi
+          done
+
+      - name: Build and push immutable image tags
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./source
+          file: ./source/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          sbom: false
+          tags: |
+            ${{ env.IMAGE }}:${{ inputs.version }}
+            ${{ env.IMAGE }}:${{ steps.metadata.outputs.sha_tag }}
+          labels: |
+            org.opencontainers.image.source=${{ env.SOURCE_REPOSITORY }}
+            org.opencontainers.image.version=${{ inputs.version }}
+            org.opencontainers.image.revision=${{ inputs.source_sha }}
+            org.opencontainers.image.created=${{ steps.metadata.outputs.build_time }}
+          build-args: |
+            VERSION=${{ inputs.version }}
+            GIT_COMMIT=${{ inputs.source_sha }}
+            BUILD_TIME=${{ steps.metadata.outputs.build_time }}
+            SOURCE_REPOSITORY=${{ env.SOURCE_REPOSITORY }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify published tags and record evidence
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          VERSION: ${{ inputs.version }}
+          SHA_TAG: ${{ steps.metadata.outputs.sha_tag }}
+          BUILD_TIME: ${{ steps.metadata.outputs.build_time }}
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          inspect_digest() {
+            docker buildx imagetools inspect "$1" --format '{{json .Manifest}}' |
+              jq -r '.digest // empty'
+          }
+
+          version_digest="$(inspect_digest "$IMAGE:$VERSION")"
+          sha_digest="$(inspect_digest "$IMAGE:$SHA_TAG")"
+          if [[ ! "$BUILD_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "build did not return a full sha256 digest: $BUILD_DIGEST" >&2
+            exit 1
+          fi
+          if [[ "$version_digest" != "$BUILD_DIGEST" || "$sha_digest" != "$BUILD_DIGEST" ]]; then
+            echo "published tag digest does not match build digest $BUILD_DIGEST" >&2
+            exit 1
+          fi
+
+          docker buildx imagetools inspect "$IMAGE@$BUILD_DIGEST" \
+            --format '{{json .Manifest}}' > published-manifest.json
+          docker buildx imagetools inspect "$IMAGE@$BUILD_DIGEST" \
+            --format '{{json .Image}}' > published-image.json
+          jq -e \
+            --arg digest "$BUILD_DIGEST" \
+            '
+              .digest == $digest and
+              (.manifests | length) == 2 and
+              ([.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64")] | length) == 1 and
+              ([.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64")] | length) == 1 and
+              all(.manifests[]; .digest | test("^sha256:[0-9a-f]{64}$"))
+            ' published-manifest.json >/dev/null
+          jq -e \
+            --arg source "$SOURCE_REPOSITORY" \
+            --arg version "$VERSION" \
+            --arg revision "$SOURCE_SHA" \
+            --arg created "$BUILD_TIME" \
+            '
+              (keys | sort) == ["linux/amd64", "linux/arm64"] and
+              all(.[];
+                .config.Labels["org.opencontainers.image.source"] == $source and
+                .config.Labels["org.opencontainers.image.version"] == $version and
+                .config.Labels["org.opencontainers.image.revision"] == $revision and
+                .config.Labels["org.opencontainers.image.created"] == $created
+              )
+            ' published-image.json >/dev/null
+
+          amd64_digest="$(
+            jq -er '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64") | .digest' \
+              published-manifest.json
+          )"
+          arm64_digest="$(
+            jq -er '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64") | .digest' \
+              published-manifest.json
+          )"
+
+          jq -n \
+            --arg image "$IMAGE" \
+            --arg source_sha "$SOURCE_SHA" \
+            --arg workflow_sha "$WORKFLOW_SHA" \
+            --arg workflow_run_id "$GITHUB_RUN_ID" \
+            --arg workflow_run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --arg version "$VERSION" \
+            --arg sha_tag "$SHA_TAG" \
+            --arg digest "$BUILD_DIGEST" \
+            --arg amd64_digest "$amd64_digest" \
+            --arg arm64_digest "$arm64_digest" \
+            --arg build_time "$BUILD_TIME" \
+            '{
+              image: $image,
+              source_sha: $source_sha,
+              workflow_sha: $workflow_sha,
+              workflow_run_id: $workflow_run_id,
+              workflow_run_url: $workflow_run_url,
+              version: $version,
+              sha_tag: $sha_tag,
+              digest: $digest,
+              platforms: {
+                "linux/amd64": $amd64_digest,
+                "linux/arm64": $arm64_digest
+              },
+              build_time: $build_time
+            }' > release-metadata.json
+
+          {
+            echo "## Published immutable image"
+            echo
+            echo "- Source: \`$SOURCE_SHA\`"
+            echo "- Version tag: \`$IMAGE:$VERSION\`"
+            echo "- Commit tag: \`$IMAGE:$SHA_TAG\`"
+            echo "- Digest: \`$BUILD_DIGEST\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload release evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-metadata-${{ inputs.version }}
+          path: release-metadata.json
+          if-no-files-found: error

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ SRC_FILES := $(wildcard $(SRC_DIR)/*.go)
 VERSION := $(shell git describe --tags --always --dirty)
 BUILD_TIME := $(shell date +%Y-%m-%dT%H:%M:%S%z)
 GIT_COMMIT := $(shell git rev-parse HEAD)
+SOURCE_REPOSITORY ?= https://github.com/apecloud/myduckserver
 
 # Docker image information
 IMAGE_NAME ?= myduck
@@ -18,7 +19,7 @@ IMAGE_TAG ?= latest
 REGISTRY ?= apecloud
 
 # Compilation flags
-LDFLAGS := -X 'main.Version=$(VERSION)' -X 'main.BuildTime=$(BUILD_TIME)' -X 'main.GitCommit=$(GIT_COMMIT)'
+LDFLAGS := -X 'main.Version=$(VERSION)' -X 'main.BuildTime=$(BUILD_TIME)' -X 'main.GitCommit=$(GIT_COMMIT)' -X 'main.SourceRepository=$(SOURCE_REPOSITORY)'
 
 # Build target
 $(BINARY_NAME): $(SRC_FILES)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,10 @@ FROM --platform=${BUILDPLATFORM} golang:latest AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG BUILD_TIME=unknown
+ARG SOURCE_REPOSITORY=https://github.com/apecloud/myduckserver
 ENV GOOS=$TARGETOS
 ENV GOARCH=$TARGETARCH
 
@@ -45,15 +49,24 @@ RUN --mount=type=bind,target=. \
     --mount=type=cache,target=/go/pkg/mod \
     go env && \
     if [ "$TARGETARCH" = "arm64" ]; then \
-      CC="aarch64-linux-gnu-gcc" CXX="aarch64-linux-gnu-g++" CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /myduckserver; \
+      CC="aarch64-linux-gnu-gcc" CXX="aarch64-linux-gnu-g++" CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-X main.Version=${VERSION} -X main.GitCommit=${GIT_COMMIT} -X main.BuildTime=${BUILD_TIME} -X main.SourceRepository=${SOURCE_REPOSITORY}" -o /myduckserver; \
     else \
-      CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /myduckserver; \
+      CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-X main.Version=${VERSION} -X main.GitCommit=${GIT_COMMIT} -X main.BuildTime=${BUILD_TIME} -X main.SourceRepository=${SOURCE_REPOSITORY}" -o /myduckserver; \
     fi
 
 # Step 2: Final stage
 FROM debian:bookworm-slim
 
 ARG TARGETARCH
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG BUILD_TIME=unknown
+ARG SOURCE_REPOSITORY=https://github.com/apecloud/myduckserver
+
+LABEL org.opencontainers.image.source="${SOURCE_REPOSITORY}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${GIT_COMMIT}" \
+      org.opencontainers.image.created="${BUILD_TIME}"
 
 RUN apt-get update && apt-get install -y debian-archive-keyring \
     && apt-get update && apt-get install -y \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Step 1: Build stage
-FROM --platform=${BUILDPLATFORM} golang:latest AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.23.12-bookworm@sha256:167053a2bb901972bf2c1611f8f52c44d5fe7e762e5cab213708d82c421614db AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -55,7 +55,7 @@ RUN --mount=type=bind,target=. \
     fi
 
 # Step 2: Final stage
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
 
 ARG TARGETARCH
 ARG VERSION=dev

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,122 @@
+# Release and Image Policy
+
+MyDuck Server images are published to `docker.io/apecloud/myduckserver`.
+Application source, release tooling, and acceptance are separate steps so a
+published image can always be traced and rolled back.
+
+## Tag policy
+
+| Tag | Example | Mutable | Created by |
+| --- | --- | --- | --- |
+| Development version | `v0.1.0-dev.20260821.1` | No | Release Image workflow |
+| Release candidate | `v0.1.0-rc.1` | No | Release Image workflow |
+| Source commit | `sha-5e29d94d` | No | Release Image workflow |
+| Stable version | `v0.1.0` | No | Promote Image workflow after acceptance |
+| Stable channel | `latest` | Yes | Promote Image workflow after acceptance |
+
+Development and release-candidate builds use semantic versions with the
+formats shown above. Bug fixes increment the patch version. Backward-compatible
+features increment the minor version. Breaking changes increment the major
+version.
+
+The workflows refuse to overwrite a version or source-commit tag. A stable
+version tag may be used again only when it already points to the exact accepted
+digest. A push to `main` never publishes or moves `latest`.
+
+## Prerequisites
+
+Repository Actions must be enabled. The existing Docker Hub credentials must
+be available as `DOCKER_REGISTRY_USER` and `DOCKER_REGISTRY_PASSWORD` Actions
+secrets.
+
+## Build an immutable prerelease
+
+Run the **Release Image** workflow from the `main` branch with:
+
+- `source_sha`: the full, lowercase, 40-character application commit SHA;
+- `version`: a development or release-candidate version.
+
+The workflow checks out that exact SHA into an isolated directory, compares the
+actual checkout SHA byte for byte with the input, and verifies that it is an
+ancestor of the `main` commit from which the workflow was dispatched. The
+workflow definition may be newer than the application source, but the build
+context and Dockerfile both come from the requested application commit.
+
+One multi-architecture build publishes the version and commit tags. Both tags
+must resolve to the digest returned by the build. The workflow uploads
+`release-metadata.json` with the source and workflow SHAs, run ID and URL,
+immutable tags, top-level digest, per-platform digests, and build time.
+
+The first restored baseline uses:
+
+```text
+source_sha: 5e29d94db535e51876ec9465c5ef78a8e2c2d92a
+version: v0.1.0-dev.20260821.1
+commit tag: sha-5e29d94d
+```
+
+This baseline predates the `myduckserver --version` command. Its version and
+source commit must be queried from its OCI labels. Do not apply the release
+tooling commit to the baseline source tree.
+
+## Inspect build identity
+
+All images contain standard OCI labels, including source repository, version,
+full source revision, and build time:
+
+```bash
+docker pull apecloud/myduckserver@sha256:<digest>
+docker image inspect apecloud/myduckserver@sha256:<digest> \
+  --format '{{json .Config.Labels}}'
+```
+
+Images built from this release tooling commit or later also expose the same
+identity from the binary:
+
+```bash
+docker run --rm --entrypoint myduckserver \
+  apecloud/myduckserver@sha256:<digest> --version
+```
+
+## Accept and promote without rebuilding
+
+Independent acceptance must cover startup, MySQL and PostgreSQL queries,
+initialization scripts, persistent data, and restart recovery. Record the test
+report or task reference before promotion.
+
+Run the **Promote Image** workflow from the `main` branch with:
+
+- the full source SHA;
+- the existing development or release-candidate version;
+- the accepted `sha256:...` digest;
+- the new stable version;
+- the independent acceptance reference.
+
+The workflow verifies that the source commit is reachable from `main` and that
+both the prerelease tag and `sha-<commit>` tag point to the accepted digest. It
+then adds the stable version and `latest` to that digest with
+`docker buildx imagetools create`. It does not invoke a build. The workflow
+inspects both promoted tags afterward and uploads `promotion-metadata.json`,
+including the workflow run, per-platform digests, acceptance reference, and
+previous `latest` digest.
+
+For example, after accepting `v0.1.0-rc.1`, promote its existing digest to
+`v0.1.0` and `latest`. The immutable image still reports its original build
+version (`v0.1.0-rc.1`); the stable tag records that this exact candidate passed
+release acceptance.
+
+## Roll back `latest`
+
+Do not rebuild an old version and do not move its immutable tags. Re-run the
+**Promote Image** workflow using the previous stable version, its original
+prerelease tag, source SHA, digest, and acceptance reference. The workflow
+verifies all immutable references and moves only `latest` back to that digest.
+
+Every release record must keep:
+
+- workflow run URL;
+- full application source SHA;
+- prerelease, source-commit, and stable tags as applicable;
+- multi-architecture digest;
+- acceptance result and reference;
+- previous `latest` digest for rollback.

--- a/docs/release.md
+++ b/docs/release.md
@@ -10,7 +10,7 @@ published image can always be traced and rolled back.
 | --- | --- | --- | --- |
 | Development version | `v0.1.0-dev.20260822.1` | No | Release Image workflow |
 | Release candidate | `v0.1.0-rc.1` | No | Release Image workflow |
-| Source commit | `sha-5e29d94d` | No | Release Image workflow |
+| Source commit | `sha-01234567` | No | Release Image workflow |
 | Stable version | `v0.1.0` | No | Promote Image workflow after acceptance |
 | Stable channel | `latest` | Yes | Promote Image workflow after acceptance |
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -84,10 +84,11 @@ Independent acceptance must cover startup, MySQL and PostgreSQL queries,
 initialization scripts, persistent data, and restart recovery. Record the test
 report or task reference before promotion.
 
-Run the **Promote Image** workflow from the `main` branch with:
+Only an accepted release candidate may become stable. Run the **Promote
+Image** workflow from the `main` branch with:
 
 - the full source SHA;
-- the existing development or release-candidate version;
+- the existing release-candidate version;
 - the accepted `sha256:...` digest;
 - the new stable version;
 - the independent acceptance reference.
@@ -119,4 +120,5 @@ Every release record must keep:
 - prerelease, source-commit, and stable tags as applicable;
 - multi-architecture digest;
 - acceptance result and reference;
+- build or promotion time;
 - previous `latest` digest for rollback.

--- a/docs/release.md
+++ b/docs/release.md
@@ -8,7 +8,7 @@ published image can always be traced and rolled back.
 
 | Tag | Example | Mutable | Created by |
 | --- | --- | --- | --- |
-| Development version | `v0.1.0-dev.20260821.1` | No | Release Image workflow |
+| Development version | `v0.1.0-dev.20260822.1` | No | Release Image workflow |
 | Release candidate | `v0.1.0-rc.1` | No | Release Image workflow |
 | Source commit | `sha-5e29d94d` | No | Release Image workflow |
 | Stable version | `v0.1.0` | No | Promote Image workflow after acceptance |
@@ -47,17 +47,22 @@ must resolve to the digest returned by the build. The workflow uploads
 `release-metadata.json` with the source and workflow SHAs, run ID and URL,
 immutable tags, top-level digest, per-platform digests, and build time.
 
-The first restored baseline uses:
+The application Dockerfile must pin both its builder and runtime images with a
+readable tag and a full multi-architecture manifest digest. The workflow
+rejects an unpinned Dockerfile and records both base-image digests in the
+release evidence.
+
+The first restored baseline will use:
 
 ```text
-source_sha: 5e29d94db535e51876ec9465c5ef78a8e2c2d92a
-version: v0.1.0-dev.20260821.1
-commit tag: sha-5e29d94d
+source_sha: exact main commit containing the pinned Dockerfile and release policy
+version: v0.1.0-dev.20260822.1
+commit tag: sha-<first 8 characters of source_sha>
 ```
 
-This baseline predates the `myduckserver --version` command. Its version and
-source commit must be queried from its OCI labels. Do not apply the release
-tooling commit to the baseline source tree.
+The earlier `5e29d94db535e51876ec9465c5ef78a8e2c2d92a` commit remains the fifth
+compatibility-restoration milestone, but it is not an image release source:
+its mutable builder tag now produces a binary incompatible with its runtime.
 
 ## Inspect build identity
 
@@ -119,6 +124,7 @@ Every release record must keep:
 - full application source SHA;
 - prerelease, source-commit, and stable tags as applicable;
 - multi-architecture digest;
+- builder and runtime top-level manifest digests;
 - acceptance result and reference;
 - build or promotion time;
 - previous `latest` digest for rollback.

--- a/main.go
+++ b/main.go
@@ -45,7 +45,8 @@ import (
 )
 
 var (
-	initMode = false
+	initMode    = false
+	versionMode = false
 
 	address       = "0.0.0.0"
 	port          = 3306
@@ -75,6 +76,7 @@ var (
 
 func init() {
 	flag.BoolVar(&initMode, "init", initMode, "Initialize the program and exit. The necessary extensions will be installed.")
+	flag.BoolVar(&versionMode, "version", versionMode, "Print version information and exit.")
 
 	flag.StringVar(&address, "address", address, "The address to bind to.")
 	flag.IntVar(&port, "port", port, "The port to bind to.")
@@ -111,6 +113,10 @@ func ensureSQLTranslate() {
 
 func main() {
 	flag.Parse() // Parse all flags
+	if versionMode {
+		fmt.Println(versionInfo())
+		return
+	}
 
 	if replicaOptions.ReportPort == 0 {
 		replicaOptions.ReportPort = port

--- a/version.go
+++ b/version.go
@@ -1,0 +1,34 @@
+// Copyright 2024-2025 ApeCloud, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+var (
+	Version          = "dev"
+	GitCommit        = "unknown"
+	BuildTime        = "unknown"
+	SourceRepository = "https://github.com/apecloud/myduckserver"
+)
+
+func versionInfo() string {
+	return fmt.Sprintf(
+		"myduckserver version=%s commit=%s build_time=%s source=%s",
+		Version,
+		GitCommit,
+		BuildTime,
+		SourceRepository,
+	)
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,40 @@
+// Copyright 2024-2025 ApeCloud, Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+
+func TestVersionInfo(t *testing.T) {
+	originalVersion := Version
+	originalGitCommit := GitCommit
+	originalBuildTime := BuildTime
+	originalSourceRepository := SourceRepository
+	t.Cleanup(func() {
+		Version = originalVersion
+		GitCommit = originalGitCommit
+		BuildTime = originalBuildTime
+		SourceRepository = originalSourceRepository
+	})
+
+	Version = "v0.1.0-dev.20260821.1"
+	GitCommit = "5e29d94db535e51876ec9465c5ef78a8e2c2d92a"
+	BuildTime = "2026-08-21T15:35:20Z"
+	SourceRepository = "https://github.com/apecloud/myduckserver"
+
+	want := "myduckserver version=v0.1.0-dev.20260821.1 commit=5e29d94db535e51876ec9465c5ef78a8e2c2d92a build_time=2026-08-21T15:35:20Z source=https://github.com/apecloud/myduckserver"
+	if got := versionInfo(); got != want {
+		t.Fatalf("versionInfo() = %q, want %q", got, want)
+	}
+}

--- a/version_test.go
+++ b/version_test.go
@@ -28,12 +28,12 @@ func TestVersionInfo(t *testing.T) {
 		SourceRepository = originalSourceRepository
 	})
 
-	Version = "v0.1.0-dev.20260821.1"
+	Version = "v0.1.0-dev.20260822.1"
 	GitCommit = "5e29d94db535e51876ec9465c5ef78a8e2c2d92a"
 	BuildTime = "2026-08-21T15:35:20Z"
 	SourceRepository = "https://github.com/apecloud/myduckserver"
 
-	want := "myduckserver version=v0.1.0-dev.20260821.1 commit=5e29d94db535e51876ec9465c5ef78a8e2c2d92a build_time=2026-08-21T15:35:20Z source=https://github.com/apecloud/myduckserver"
+	want := "myduckserver version=v0.1.0-dev.20260822.1 commit=5e29d94db535e51876ec9465c5ef78a8e2c2d92a build_time=2026-08-21T15:35:20Z source=https://github.com/apecloud/myduckserver"
 	if got := versionInfo(); got != want {
 		t.Fatalf("versionInfo() = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

- replace automatic `latest` publication with a manual exact-SHA build that accepts only main-reachable commits and creates immutable prerelease plus `sha-<8>` tags
- add digest-only promotion to an immutable stable tag and `latest` after an independent acceptance reference is supplied
- verify multi-architecture digests and OCI identity, preserve public release evidence, and expose `myduckserver --version` for images built from this commit onward
- document version, promotion, rollback, and baseline rules

The first baseline remains the exact application source `5e29d94db535e51876ec9465c5ef78a8e2c2d92a`; its identity is read from OCI labels because that source predates `--version`.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release-image.yml .github/workflows/promote-image.yml`
- `git diff --check`
- `go test . -run '^TestVersionInfo$' -count=1`
- `go test ./backend -count=1`
- `go test ./transpiler -count=1`
- linker-injected build produced the exact expected `myduckserver --version` output

A local arm64 image build reached `go mod download` after completing the base and runtime dependency stages, then hit a transient `proxy.golang.org` timeout. No workflow or remote image publication was triggered; container label/version evidence will be supplemented from the cached retry.
