### PR TITLE
fix: register MySQL UDFs once per database

### DIFF
--- a/catalog/connpool.go
+++ b/catalog/connpool.go
@@ -29,9 +29,11 @@ import (
 
 type ConnectionPool struct {
 	*stdsql.DB
-	connector *duckdb.Connector
-	conns     sync.Map // concurrent-safe map[uint32]*stdsql.Conn
-	txns      sync.Map // concurrent-safe map[uint32]*stdsql.Tx
+	connector             *duckdb.Connector
+	conns                 sync.Map // concurrent-safe map[uint32]*stdsql.Conn
+	txns                  sync.Map // concurrent-safe map[uint32]*stdsql.Tx
+	registerMySQLUDFsOnce sync.Once
+	registerMySQLUDFsErr  error
 }
 
 func NewConnectionPool(connector *duckdb.Connector, db *stdsql.DB) *ConnectionPool {
@@ -87,13 +89,9 @@ func (p *ConnectionPool) GetConn(ctx context.Context, id uint32) (*stdsql.Conn, 
 		if err != nil {
 			return nil, err
 		}
-		if err := registerMySQLRand(c); err != nil {
+		if err := p.registerMySQLUDFs(c); err != nil {
 			_ = c.Close()
-			return nil, fmt.Errorf("register mysql_rand: %w", err)
-		}
-		if err := registerMySQLRandomBytes(c); err != nil {
-			_ = c.Close()
-			return nil, fmt.Errorf("register mysql_random_bytes: %w", err)
+			return nil, err
 		}
 		p.conns.Store(id, c)
 		conn = c
@@ -101,6 +99,20 @@ func (p *ConnectionPool) GetConn(ctx context.Context, id uint32) (*stdsql.Conn, 
 		conn = entry.(*stdsql.Conn)
 	}
 	return conn, nil
+}
+
+// DuckDB stores registered scalar UDFs in the database catalog shared by all connections.
+func (p *ConnectionPool) registerMySQLUDFs(conn *stdsql.Conn) error {
+	p.registerMySQLUDFsOnce.Do(func() {
+		if err := registerMySQLRand(conn); err != nil {
+			p.registerMySQLUDFsErr = fmt.Errorf("register mysql_rand: %w", err)
+			return
+		}
+		if err := registerMySQLRandomBytes(conn); err != nil {
+			p.registerMySQLUDFsErr = fmt.Errorf("register mysql_random_bytes: %w", err)
+		}
+	})
+	return p.registerMySQLUDFsErr
 }
 
 func (p *ConnectionPool) GetConnForSchema(ctx context.Context, id uint32, schemaName string) (*stdsql.Conn, error) {
@@ -220,6 +232,8 @@ func (p *ConnectionPool) Reset(connector *duckdb.Connector, db *stdsql.DB) error
 	p.txns.Clear()
 	p.DB = db
 	p.connector = connector
+	p.registerMySQLUDFsOnce = sync.Once{}
+	p.registerMySQLUDFsErr = nil
 
 	return nil
 }

--- a/catalog/connpool_test.go
+++ b/catalog/connpool_test.go
@@ -1,0 +1,84 @@
+package catalog
+
+import (
+	"context"
+	stdsql "database/sql"
+	"os"
+	"testing"
+
+	"github.com/apecloud/myduckserver/testutil"
+	"github.com/marcboeker/go-duckdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionPoolRegistersMySQLUDFsOnce(t *testing.T) {
+	connector, err := duckdb.NewConnector("", nil)
+	require.NoError(t, err)
+	db := stdsql.OpenDB(connector)
+	pool := NewConnectionPool(connector, db)
+	activeConnector := connector
+	t.Cleanup(func() {
+		require.NoError(t, pool.Close())
+		require.NoError(t, activeConnector.Close())
+	})
+
+	conn1, err := pool.GetConn(context.Background(), 1)
+	require.NoError(t, err)
+	assertMySQLUDFsCallable(t, conn1)
+
+	// Keep conn1 checked out so database/sql must open another physical
+	// connection. DuckDB scalar UDFs belong to the database, not a connection.
+	conn2, err := pool.GetConn(context.Background(), 2)
+	require.NoError(t, err)
+	assertMySQLUDFsCallable(t, conn2)
+	require.NoError(t, pool.CloseConn(1))
+	require.NoError(t, pool.CloseConn(2))
+
+	conn3, err := pool.GetConn(context.Background(), 3)
+	require.NoError(t, err)
+	assertMySQLUDFsCallable(t, conn3)
+
+	connector2, err := duckdb.NewConnector("", nil)
+	require.NoError(t, err)
+	require.NoError(t, pool.Reset(connector2, stdsql.OpenDB(connector2)))
+	require.NoError(t, connector.Close())
+	activeConnector = connector2
+
+	conn3, err = pool.GetConn(context.Background(), 3)
+	require.NoError(t, err)
+	assertMySQLUDFsCallable(t, conn3)
+}
+
+func TestFirstMySQLQueryAfterServerStart(t *testing.T) {
+	originalWorkingDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.Chdir(originalWorkingDir))
+	}()
+
+	testDir := testutil.CreateTestDir(t)
+	testEnv := testutil.NewTestEnv()
+	require.NoError(t, testutil.StartDuckSqlServer(t, testDir, nil, testEnv))
+	t.Cleanup(func() {
+		require.NoError(t, testEnv.MyDuckServer.Close())
+		testutil.StopDuckSqlServer(t, testEnv.DuckProcess)
+	})
+
+	var got int
+	require.NoError(t, testEnv.MyDuckServer.QueryRowContext(context.Background(), "SELECT 1").Scan(&got))
+	require.Equal(t, 1, got)
+}
+
+func assertMySQLUDFsCallable(t *testing.T, conn *stdsql.Conn) {
+	t.Helper()
+
+	var randValue float64
+	var randomBytesLength int
+	err := conn.QueryRowContext(
+		context.Background(),
+		"SELECT mysql_rand(1), octet_length(mysql_random_bytes(3))",
+	).Scan(&randValue, &randomBytesLength)
+	require.NoError(t, err)
+	require.Equal(t, mysqlRandFromSeed(1), randValue)
+	require.Equal(t, 3, randomBytesLength)
+}


### PR DESCRIPTION
## Summary

- register the `mysql_rand` and `mysql_random_bytes` DuckDB scalar UDFs once per shared database catalog instead of once per pooled physical connection
- reset the one-time registration state when the connection pool switches to a fresh DuckDB connector
- cover multiple physical connections, connection churn, pool reset, both UDFs, and the first MySQL query after a real server start

## Reproduction

On exact main `9767800a`, the new multi-connection regression failed on the second physical connection with:

```
register mysql_rand: database/sql/driver: API error: could not create scalar UDF
```

## Verification

- `go test -race ./catalog -run '^TestConnectionPoolRegistersMySQLUDFsOnce$' -count=1 -v`
- `go test ./catalog -count=1`
- first-query regression repeated three times
- `go test ./pgserver -run '^TestIssue280RepeatedConnectMySQLDatabase$' -count=1`
- `go test ./pgserver -run '^TestIssue341PgAuthRejectsWrongPassword$' -count=1`
- `go test ./backend ./transpiler -count=1`
- `go test ./charset ./harness ./flightsqltest -count=1`
- `go vet ./catalog`
- `go build ./...`
