### PR TITLE
test: document query error compatibility boundaries

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -774,14 +774,16 @@ func TestIndexQueryPlans(t *testing.T) {
 func TestQueryErrors(t *testing.T) {
 	harness := NewDefaultDuckHarness()
 	harness.QueriesToSkip(
-		// DuckDB rejects this malformed regexp, but returns its native error text.
+		// DuckDB returns `Invalid Input Error: no argument for repetition operator: *`,
+		// while the upstream contract requires the exact text "the given regular expression is invalid".
 		`SELECT * FROM mytable WHERE s REGEXP("*main.go")`,
-		// Unbound placeholders reach DuckDB and produce an argument-count error instead
-		// of go-mysql-server's ErrUnboundPreparedStatementVariable.
+		// Both unbound placeholder forms reach DuckDB and return
+		// `incorrect argument count for command: have 0 want 1`, rather than
+		// go-mysql-server's ErrUnboundPreparedStatementVariable.
 		"SELECT pk FROM one_pk WHERE pk > ?",
 		"SELECT pk FROM one_pk WHERE pk > :pk",
-		// DuckDB rejects multi-character ESCAPE strings as syntax errors rather than
-		// go-mysql-server's ErrInvalidArgument.
+		// DuckDB returns `Syntax Error: Invalid escape string. Escape string must be empty or one character.`
+		// for each multi-character ESCAPE string, rather than go-mysql-server's ErrInvalidArgument.
 		`SELECT name FROM specialtable t WHERE t.name LIKE '$%' ESCAPE 'abc'`,
 		`SELECT name FROM specialtable t WHERE t.name LIKE '$%' ESCAPE '$$'`,
 	)


### PR DESCRIPTION
## Summary\n- Re-verified the five existing TestQueryErrors exclusions from exact main 80214326.\n- Preserve all five exact query skips because MyDuck still returns DuckDB-native error contracts.\n- Document the observed native messages alongside the upstream contracts; no behavior or DuckDB version changes.\n\n## Evidence\n- Probe with all five skips removed: 5 expected contract mismatches reproduced.\n- go test TestQueryErrors count=3: 3/3 PASS, each 119 PASS / 5 SKIP / 0 FAIL.\n- git diff --check: PASS.\n\nBase: 80214326eee434b9d06241c697d98e27016539d6\nHead: ae741de