### PR TITLE
ci: make compatibility environments reproducible

### DIFF
--- a/.github/workflows/clients-compatibility.yml
+++ b/.github/workflows/clients-compatibility.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test-mysql:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -32,10 +32,12 @@ jobs:
           python-version: '3.13'
 
       - name: Install system packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: bats cpanminus libmysqlclient-dev dotnet-sdk-8.0 dotnet-runtime-8.0 php-mysql r-base-core
-          version: 1.1
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            bats cpanminus libmysqlclient-dev dotnet-sdk-8.0 \
+            dotnet-runtime-8.0 php-mysql r-base-core
+          cpanm --version
 
       - name: Install dependencies
         run: |
@@ -72,7 +74,7 @@ jobs:
           bats ./compatibility/mysql/test.bats
 
   test-postgresql:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -92,10 +94,12 @@ jobs:
           python-version: '3.13'
 
       - name: Install system packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: bats cpanminus libpq-dev postgresql-client dotnet-sdk-8.0 dotnet-runtime-8.0 r-base-core
-          version: 1.1
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            bats cpanminus libpq-dev postgresql-client dotnet-sdk-8.0 \
+            dotnet-runtime-8.0 r-base-core
+          cpanm --version
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/mysql-copy-tests.yml
+++ b/.github/workflows/mysql-copy-tests.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   copy-instance-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     services:
       source:
-        image: mysql:lts
+        # MySQL 8.4.7, linux/amd64
+        image: mysql@sha256:6c6706ec58d3ac9e925d5f0435c6a923117f68232551b9c8271a294ea72ee331
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
@@ -41,8 +42,12 @@ jobs:
 
           pip3 install "sqlglot[rs]"
 
-          curl -LJO https://dev.mysql.com/get/Downloads/MySQL-Shell/mysql-shell_9.1.0-1debian12_amd64.deb
-          sudo apt-get install -y ./mysql-shell_9.1.0-1debian12_amd64.deb
+          mysql_shell_deb=mysql-shell_9.1.0-1debian12_amd64.deb
+          curl --fail --location --show-error --output "$mysql_shell_deb" \
+            "https://dev.mysql.com/get/Downloads/MySQL-Shell/$mysql_shell_deb"
+          echo "feffebc3e0f0dae3e2b7fc3d2783f557860f60aef557c7f972f95f61fba9c630  $mysql_shell_deb" | sha256sum --check -
+          sudo apt-get install -y "./$mysql_shell_deb"
+          mysqlsh --version
 
       - name: Setup test data in source MySQL
         run: |
@@ -115,5 +120,3 @@ jobs:
 
             diff source_data_$table.tsv copied_data_$table.tsv
           done
-
-


### PR DESCRIPTION
## Summary

- run the client compatibility jobs on Ubuntu 24.04 and install their apt dependencies explicitly, with `cpanm --version` as a postcondition
- pin the copy-instance MySQL service to the immutable MySQL 8.4.7 linux/amd64 digest
- verify the existing MySQL Shell 9.1.0 package with its published SHA-256 before installation

## Validation

- `actionlint` v1.7.7
- `git diff --check`
- verified MySQL Shell package checksum
- verified the pinned image digest resolves to MySQL 8.4.7 for linux/amd64
- verified required packages are available on Ubuntu 24.04

## Scope

This PR changes only the two CI workflows. It does not change product code or assertions, and it does not reclassify the PostgreSQL logical-replication binder failure or the BATS COPY server-exit failure seen on PR #471.
