### PR TITLE
ci: allow promoting immutable dev images

### DIFF
--- a/.github/scripts/promote-image-validate-test.sh
+++ b/.github/scripts/promote-image-validate-test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/promote-image-validate.sh"
+
+source_sha=0123456789abcdef0123456789abcdef01234567
+source_digest=sha256:fddbbf0e7fff3013202d054216c829b20ff3d34f6e20b93e64f24fa6d6a7de13
+output_file="$(mktemp)"
+trap 'rm -f "$output_file"' EXIT
+
+promote_image_validate \
+  refs/heads/main \
+  "$source_sha" \
+  v0.1.0-dev.20260822.3 \
+  "$source_digest" \
+  v0.2.0 \
+  task-32-acceptance \
+  "$output_file"
+grep -Fxq "sha_tag=sha-01234567" "$output_file"
+
+promote_image_validate \
+  refs/heads/main \
+  "$source_sha" \
+  v0.2.0-rc.1 \
+  "$source_digest" \
+  v0.2.0 \
+  task-32-acceptance
+
+expect_invalid() {
+  if promote_image_validate "$@" 2>/dev/null; then
+    echo "expected promotion input validation to fail" >&2
+    exit 1
+  fi
+}
+
+expect_invalid refs/heads/release "$source_sha" v0.1.0-dev.20260822.3 "$source_digest" v0.2.0 task-32-acceptance
+expect_invalid refs/heads/main "$source_sha" v0.1.0 "$source_digest" v0.2.0 task-32-acceptance
+expect_invalid refs/heads/main "$source_sha" v0.1.0-dev.20260822.3 "$source_digest" v0.2 task-32-acceptance
+expect_invalid refs/heads/main "$source_sha" v0.1.0-dev.20260822.3 "$source_digest" v0.2.0 $'task-32\nacceptance'

--- a/.github/scripts/promote-image-validate.sh
+++ b/.github/scripts/promote-image-validate.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+promote_image_validate() {
+  if (( $# < 6 || $# > 7 )); then
+    echo "usage: promote_image_validate GITHUB_REF SOURCE_SHA SOURCE_VERSION SOURCE_DIGEST STABLE_VERSION ACCEPTANCE_REFERENCE [GITHUB_OUTPUT]" >&2
+    return 2
+  fi
+
+  local github_ref="$1"
+  local source_sha="$2"
+  local source_version="$3"
+  local source_digest="$4"
+  local stable_version="$5"
+  local acceptance_reference="$6"
+  local output_file="${7:-}"
+
+  if [[ "$github_ref" != "refs/heads/main" ]]; then
+    echo "promotion workflow must be dispatched from the main branch" >&2
+    return 1
+  fi
+  if [[ ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "source_sha must be a lowercase, full 40-character commit SHA" >&2
+    return 1
+  fi
+  if [[ ! "$source_version" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-(dev\.[0-9]{8}\.[1-9][0-9]*|rc\.[1-9][0-9]*)$ ]]; then
+    echo "source_version must be an immutable dev or release-candidate version" >&2
+    return 1
+  fi
+  if [[ ! "$stable_version" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+    echo "stable_version must match vX.Y.Z" >&2
+    return 1
+  fi
+  if [[ ! "$source_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "source_digest must be a full sha256 digest" >&2
+    return 1
+  fi
+  if [[ -z "${acceptance_reference//[[:space:]]/}" ]]; then
+    echo "acceptance_reference must contain a non-whitespace value" >&2
+    return 1
+  fi
+  if [[ "$acceptance_reference" == *$'\n'* || "$acceptance_reference" == *$'\r'* ]]; then
+    echo "acceptance_reference must be a single line" >&2
+    return 1
+  fi
+
+  if [[ -n "$output_file" ]]; then
+    printf 'sha_tag=sha-%s\n' "${source_sha:0:8}" >> "$output_file"
+  fi
+}

--- a/.github/workflows/promote-image.yml
+++ b/.github/workflows/promote-image.yml
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
       source_version:
-        description: Existing immutable release-candidate tag
+        description: Existing immutable dev or release-candidate tag
         required: true
         type: string
       source_digest:
@@ -39,6 +39,13 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout release history
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
       - name: Validate promotion inputs
         id: metadata
         shell: bash
@@ -50,46 +57,19 @@ jobs:
           ACCEPTANCE_REFERENCE: ${{ inputs.acceptance_reference }}
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
-            echo "promotion workflow must be dispatched from the main branch" >&2
-            exit 1
-          fi
-          if [[ ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "source_sha must be a lowercase, full 40-character commit SHA" >&2
-            exit 1
-          fi
-          if [[ ! "$SOURCE_VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-rc\.[1-9][0-9]*$ ]]; then
-            echo "source_version must be an immutable release-candidate version" >&2
-            exit 1
-          fi
-          if [[ ! "$STABLE_VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-            echo "stable_version must match vX.Y.Z" >&2
-            exit 1
-          fi
-          if [[ ! "$SOURCE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "source_digest must be a full sha256 digest" >&2
-            exit 1
-          fi
-          if [[ "${SOURCE_VERSION%%-*}" != "$STABLE_VERSION" ]]; then
-            echo "source_version and stable_version must have the same vX.Y.Z base" >&2
-            exit 1
-          fi
-          if [[ -z "${ACCEPTANCE_REFERENCE//[[:space:]]/}" ]]; then
-            echo "acceptance_reference must contain a non-whitespace value" >&2
-            exit 1
-          fi
-          if [[ "$ACCEPTANCE_REFERENCE" == *$'\n'* || "$ACCEPTANCE_REFERENCE" == *$'\r'* ]]; then
-            echo "acceptance_reference must be a single line" >&2
-            exit 1
-          fi
-          echo "sha_tag=sha-${SOURCE_SHA:0:8}" >> "$GITHUB_OUTPUT"
+          source .github/scripts/promote-image-validate.sh
+          promote_image_validate \
+            "$GITHUB_REF" \
+            "$SOURCE_SHA" \
+            "$SOURCE_VERSION" \
+            "$SOURCE_DIGEST" \
+            "$STABLE_VERSION" \
+            "$ACCEPTANCE_REFERENCE" \
+            "$GITHUB_OUTPUT"
 
-      - name: Checkout release history
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        with:
-          ref: ${{ github.sha }}
-          fetch-depth: 0
-          persist-credentials: false
+      - name: Test promotion input validation
+        shell: bash
+        run: bash .github/scripts/promote-image-validate-test.sh
 
       - name: Verify source is reachable from main
         shell: bash


### PR DESCRIPTION
## Summary
- accept immutable dev or release-candidate source tags in the promotion workflow
- allow an explicitly selected stable version to differ from the source prerelease base
- add shell input-validation tests before any registry operation

## Verification
- promotion input helper tests pass for dev -> v0.2.0 and rc inputs plus invalid branch/version/digest/reference cases
- shellcheck, bash -n, YAML parse, and git diff --check pass
- platform-signed commit 94a0c603a24b593ce6623675205d5abd12ef960c (parent c96fe9096e99a1df1f24123e75f3791221203e7b)

This PR changes workflow validation only. It performs no registry writes and does not dispatch promotion.