### PR TITLE
feat: add configurable query row limit

### DIFF
--- a/backend/executor.go
+++ b/backend/executor.go
@@ -51,7 +51,17 @@ func (b *DuckBuilder) Provider() *catalog.DatabaseProvider {
 	return b.provider
 }
 
-func (b *DuckBuilder) Build(ctx *sql.Context, root sql.Node, r sql.Row) (sql.RowIter, error) {
+func (b *DuckBuilder) Build(ctx *sql.Context, root sql.Node, r sql.Row) (iter sql.RowIter, err error) {
+	// The engine passes a nil input row for the top-level result iterator.
+	// Subquery iterators must not count intermediate rows against the limit.
+	if r == nil {
+		defer func() {
+			if err == nil {
+				iter = ApplyQueryRowLimit(ctx, root.Schema(), iter)
+			}
+		}()
+	}
+
 	// Flush the delta buffer before executing the query.
 	// TODO(fan): Be fine-grained and flush only when the replicated tables are touched.
 	if b.FlushDeltaBuffer != nil {

--- a/backend/iter.go
+++ b/backend/iter.go
@@ -16,6 +16,7 @@ package backend
 
 import (
 	stdsql "database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -33,6 +34,64 @@ import (
 )
 
 var _ sql.RowIter = (*SQLRowIter)(nil)
+
+const queryRowLimitError = "query returned more than the configured row limit of %d"
+
+type queryRowLimitIter struct {
+	child       sql.RowIter
+	limit       uint64
+	rows        uint64
+	closed      bool
+	closeErr    error
+	overflowErr error
+}
+
+// ApplyQueryRowLimit wraps result rows with the limit configured on the
+// current session. Non-row results and sessions with no limit are unchanged.
+func ApplyQueryRowLimit(ctx *sql.Context, schema sql.Schema, iter sql.RowIter) sql.RowIter {
+	if iter == nil || schema == nil || types.IsOkResultSchema(schema) {
+		return iter
+	}
+	sess, ok := ctx.Session.(interface{ QueryRowLimit() uint64 })
+	if !ok || sess.QueryRowLimit() == 0 {
+		return iter
+	}
+	return &queryRowLimitIter{child: iter, limit: sess.QueryRowLimit()}
+}
+
+func (iter *queryRowLimitIter) Next(ctx *sql.Context) (sql.Row, error) {
+	if iter.overflowErr != nil {
+		return nil, iter.overflowErr
+	}
+	if iter.closed {
+		return nil, io.EOF
+	}
+	if iter.rows < iter.limit {
+		row, err := iter.child.Next(ctx)
+		if err == nil {
+			iter.rows++
+		}
+		return row, err
+	}
+
+	_, err := iter.child.Next(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	limitErr := fmt.Errorf(queryRowLimitError, iter.limit)
+	iter.overflowErr = errors.Join(limitErr, iter.Close(ctx))
+	return nil, iter.overflowErr
+}
+
+func (iter *queryRowLimitIter) Close(ctx *sql.Context) error {
+	if iter.closed {
+		return nil
+	}
+	iter.closed = true
+	iter.closeErr = iter.child.Close(ctx)
+	return iter.closeErr
+}
 
 type typeConversion struct {
 	idx  int

--- a/backend/iter_test.go
+++ b/backend/iter_test.go
@@ -3,15 +3,93 @@ package backend
 import (
 	"context"
 	stdsql "database/sql"
+	"io"
 	"testing"
 
 	"github.com/apecloud/myduckserver/pgtypes"
+	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/duckdb/duckdb-go/v2"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 )
+
+type trackingRowIter struct {
+	rows       []sql.Row
+	nextCalls  int
+	closeCalls int
+}
+
+func (iter *trackingRowIter) Next(*sql.Context) (sql.Row, error) {
+	iter.nextCalls++
+	if len(iter.rows) == 0 {
+		return nil, io.EOF
+	}
+	row := iter.rows[0]
+	iter.rows = iter.rows[1:]
+	return row, nil
+}
+
+func (iter *trackingRowIter) Close(*sql.Context) error {
+	iter.closeCalls++
+	return nil
+}
+
+func TestQueryRowLimitIter(t *testing.T) {
+	tests := []struct {
+		name      string
+		rows      []sql.Row
+		wantError bool
+	}{
+		{name: "below limit", rows: []sql.Row{{1}}},
+		{name: "at limit", rows: []sql.Row{{1}, {2}}},
+		{name: "over limit", rows: []sql.Row{{1}, {2}, {3}}, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			child := &trackingRowIter{rows: tt.rows}
+			iter := &queryRowLimitIter{child: child, limit: 2}
+			rows, err := sql.RowIterToRows(sql.NewEmptyContext(), iter)
+			if tt.wantError {
+				require.ErrorContains(t, err, "query returned more than the configured row limit of 2")
+				require.Nil(t, rows)
+				require.Equal(t, 3, child.nextCalls)
+				require.Equal(t, 1, child.closeCalls, "overflow must close the source immediately and only once")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.rows, rows)
+			require.Equal(t, 1, child.closeCalls)
+		})
+	}
+}
+
+func TestQueryRowLimitIsOnlyConfiguredForOptedInSessions(t *testing.T) {
+	schema := sql.Schema{&sql.Column{Name: "value", Type: types.Int32}}
+	newBase := func() *memory.Session {
+		return memory.NewSession(sql.NewBaseSession(), nil)
+	}
+
+	internalSession := NewSession(newBase(), nil)
+	internalCtx := sql.NewContext(context.Background(), sql.WithSession(internalSession))
+	internalIter := &trackingRowIter{rows: []sql.Row{{1}, {2}, {3}}}
+	unlimited := ApplyQueryRowLimit(internalCtx, schema, internalIter)
+	require.Same(t, internalIter, unlimited)
+	require.Zero(t, internalSession.QueryRowLimit())
+	rows, err := sql.RowIterToRows(internalCtx, unlimited)
+	require.NoError(t, err)
+	require.Equal(t, []sql.Row{{1}, {2}, {3}}, rows)
+
+	ordinarySession := NewSession(newBase(), nil, WithQueryRowLimit(2))
+	ordinaryCtx := sql.NewContext(context.Background(), sql.WithSession(ordinarySession))
+	ordinaryIter := &trackingRowIter{rows: []sql.Row{{1}, {2}, {3}}}
+	limited := ApplyQueryRowLimit(ordinaryCtx, schema, ordinaryIter)
+	require.NotSame(t, ordinaryIter, limited)
+	_, err = sql.RowIterToRows(ordinaryCtx, limited)
+	require.ErrorContains(t, err, "query returned more than the configured row limit of 2")
+}
 
 func TestSQLRowIterNormalizesDuckDBJSONValues(t *testing.T) {
 	connector, err := duckdb.NewConnector("", nil)

--- a/backend/session.go
+++ b/backend/session.go
@@ -31,11 +31,26 @@ import (
 
 type Session struct {
 	*memory.Session
-	db *catalog.DatabaseProvider
+	db            *catalog.DatabaseProvider
+	queryRowLimit uint64
 }
 
-func NewSession(base *memory.Session, provider *catalog.DatabaseProvider) *Session {
-	return &Session{base, provider}
+type SessionOption func(*Session)
+
+// WithQueryRowLimit limits the number of rows returned by queries in a session.
+// A limit of zero leaves query results unlimited.
+func WithQueryRowLimit(limit uint64) SessionOption {
+	return func(sess *Session) {
+		sess.queryRowLimit = limit
+	}
+}
+
+func NewSession(base *memory.Session, provider *catalog.DatabaseProvider, opts ...SessionOption) *Session {
+	sess := &Session{Session: base, db: provider}
+	for _, opt := range opts {
+		opt(sess)
+	}
+	return sess
 }
 
 // Provider returns the database provider for the session.
@@ -43,12 +58,18 @@ func (sess *Session) Provider() *catalog.DatabaseProvider {
 	return sess.db
 }
 
+// QueryRowLimit returns the maximum number of rows a query may return. Zero
+// means unlimited.
+func (sess *Session) QueryRowLimit() uint64 {
+	return sess.queryRowLimit
+}
+
 func (sess *Session) CurrentSchemaOfUnderlyingConn() string {
 	return sess.db.Pool().CurrentSchema(sess.ID())
 }
 
 // NewSessionBuilder returns a session builder for the given database provider.
-func NewSessionBuilder(provider *catalog.DatabaseProvider) func(ctx context.Context, conn *mysql.Conn, addr string) (sql.Session, error) {
+func NewSessionBuilder(provider *catalog.DatabaseProvider, opts ...SessionOption) func(ctx context.Context, conn *mysql.Conn, addr string) (sql.Session, error) {
 	return func(ctx context.Context, conn *mysql.Conn, addr string) (sql.Session, error) {
 		host := ""
 		user := ""
@@ -68,7 +89,7 @@ func NewSessionBuilder(provider *catalog.DatabaseProvider) func(ctx context.Cont
 			memSession.SetCurrentDatabase(schema)
 		}
 
-		return &Session{memSession, provider}, nil
+		return NewSession(memSession, provider, opts...), nil
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ var (
 	superuserPassword = ""
 
 	defaultTimeZone = ""
+	queryRowLimit   uint64
 
 	// for Restore
 	restoreFile            = ""
@@ -94,6 +95,7 @@ func init() {
 
 	flag.IntVar(&postgresPort, "pg-port", postgresPort, "The port to bind to for PostgreSQL wire protocol.")
 	flag.StringVar(&defaultTimeZone, "default-time-zone", defaultTimeZone, "The default time zone to use.")
+	flag.Uint64Var(&queryRowLimit, "query-row-limit", queryRowLimit, "Maximum rows returned by a query in ordinary MySQL and PostgreSQL sessions; 0 means unlimited.")
 
 	flag.StringVar(&restoreFile, "restore-file", restoreFile, "The file to restore from.")
 	flag.StringVar(&restoreEndpoint, "restore-endpoint", restoreEndpoint, "The endpoint of object storage service to restore from.")
@@ -162,7 +164,7 @@ func main() {
 		Address:  fmt.Sprintf("%s:%d", address, port),
 		Socket:   socket,
 	}
-	myServer, err := server.NewServerWithHandler(serverConfig, engine, backend.NewSessionBuilder(provider), nil, backend.WrapHandler(provider))
+	myServer, err := server.NewServerWithHandler(serverConfig, engine, backend.NewSessionBuilder(provider, backend.WithQueryRowLimit(queryRowLimit)), nil, backend.WrapHandler(provider))
 	if err != nil {
 		logrus.WithError(err).Fatalln("Failed to create MySQL-protocol server")
 	}

--- a/pgserver/duck_handler.go
+++ b/pgserver/duck_handler.go
@@ -355,6 +355,7 @@ func (h *DuckHandler) doQuery(ctx context.Context, c *mysql.Conn, query string, 
 		sqlCtx.GetLogger().WithError(err).Warn("error running query")
 		return err
 	}
+	rowIter = backend.ApplyQueryRowLimit(sqlCtx, schema, rowIter)
 
 	// If the query is "USE <database>", we need to update the current database in the session.
 	if currentSchema := sqlCtx.Session.(*backend.Session).CurrentSchemaOfUnderlyingConn(); len(currentSchema) > 0 {

--- a/pgserver/duck_handler_test.go
+++ b/pgserver/duck_handler_test.go
@@ -2,6 +2,7 @@ package pgserver
 
 import (
 	"context"
+	"os"
 	"strconv"
 	"testing"
 
@@ -31,6 +32,109 @@ func TestNormalizePGWireValue(t *testing.T) {
 	value, err = normalizePGWireValue(types.JSONDocument{Val: map[string]any{"key": "value"}})
 	require.NoError(t, err)
 	require.JSONEq(t, `{"key":"value"}`, value.(string))
+}
+
+func TestQueryRowLimitOnMySQLAndPostgresSessions(t *testing.T) {
+	originalWorkingDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.Chdir(originalWorkingDir))
+	}()
+
+	testDir := testutil.CreateTestDir(t)
+	testEnv := testutil.NewTestEnv()
+	testEnv.ExtraArgs = []string{"--query-row-limit=2"}
+	require.NoError(t, testutil.StartDuckSqlServer(t, testDir, nil, testEnv))
+	t.Cleanup(func() {
+		require.NoError(t, testEnv.MyDuckServer.Close())
+		testutil.StopDuckSqlServer(t, testEnv.DuckProcess)
+	})
+
+	t.Run("mysql", func(t *testing.T) {
+		ctx := context.Background()
+		rows, err := testEnv.MyDuckServer.QueryContext(ctx, "SELECT 1 AS n UNION ALL SELECT 2 AS n ORDER BY n")
+		require.NoError(t, err)
+		var got []int
+		for rows.Next() {
+			var value int
+			require.NoError(t, rows.Scan(&value))
+			got = append(got, value)
+		}
+		require.NoError(t, rows.Err())
+		require.NoError(t, rows.Close())
+		require.Equal(t, []int{1, 2}, got)
+
+		err = mysqlQueryError(ctx, testEnv, "SELECT 1 AS n UNION ALL SELECT 2 AS n UNION ALL SELECT 3 AS n ORDER BY n")
+		require.ErrorContains(t, err, "query returned more than the configured row limit of 2")
+
+		stmt, err := testEnv.MyDuckServer.PrepareContext(ctx, "SELECT 1 AS n UNION ALL SELECT 2 AS n UNION ALL SELECT 3 AS n ORDER BY n")
+		require.NoError(t, err)
+		preparedRows, err := stmt.QueryContext(ctx)
+		if err == nil {
+			for preparedRows.Next() {
+			}
+			err = preparedRows.Err()
+			require.NoError(t, preparedRows.Close())
+		}
+		require.ErrorContains(t, err, "query returned more than the configured row limit of 2")
+		require.NoError(t, stmt.Close())
+
+		var value int
+		require.NoError(t, testEnv.MyDuckServer.QueryRowContext(ctx, "SELECT 42").Scan(&value))
+		require.Equal(t, 42, value)
+		require.NoError(t, testEnv.MyDuckServer.QueryRowContext(
+			ctx,
+			"SELECT 42 WHERE 3 IN (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3) AND @@autocommit = 1",
+		).Scan(&value))
+		require.Equal(t, 42, value)
+		_, err = testEnv.MyDuckServer.ExecContext(ctx, "CREATE DATABASE IF NOT EXISTS query_row_limit_mysql")
+		require.NoError(t, err)
+	})
+
+	t.Run("postgres", func(t *testing.T) {
+		ctx := context.Background()
+		conn, err := pgx.Connect(ctx, "postgresql://postgres@127.0.0.1:"+strconv.Itoa(testEnv.DuckPgPort)+"/postgres")
+		require.NoError(t, err)
+		defer conn.Close(ctx)
+
+		rows, err := conn.Query(ctx, "SELECT 1 AS n UNION ALL SELECT 2 AS n ORDER BY n")
+		require.NoError(t, err)
+		var got []int
+		for rows.Next() {
+			var value int
+			require.NoError(t, rows.Scan(&value))
+			got = append(got, value)
+		}
+		require.NoError(t, rows.Err())
+		rows.Close()
+		require.Equal(t, []int{1, 2}, got)
+
+		rows, err = conn.Query(ctx, "SELECT 1 AS n UNION ALL SELECT 2 AS n UNION ALL SELECT 3 AS n ORDER BY n")
+		if err == nil {
+			for rows.Next() {
+			}
+			err = rows.Err()
+			rows.Close()
+		}
+		require.ErrorContains(t, err, "query returned more than the configured row limit of 2")
+
+		var value int
+		require.NoError(t, conn.QueryRow(ctx, "SELECT 42").Scan(&value))
+		require.Equal(t, 42, value)
+		_, err = conn.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS query_row_limit_postgres")
+		require.NoError(t, err)
+	})
+}
+
+func mysqlQueryError(ctx context.Context, testEnv *testutil.TestEnv, query string) error {
+	rows, err := testEnv.MyDuckServer.QueryContext(ctx, query)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+	}
+	return rows.Err()
 }
 
 func TestPostgresDuckDBOnlyCreateOrReplaceTable(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `--query-row-limit` for ordinary MySQL and PostgreSQL sessions; `0` preserves unlimited behavior
- stop after detecting row `limit + 1`, close the source iterator immediately, and return `query returned more than the configured row limit of N`
- keep internal replication sessions unlimited by applying the option only in the wire-session builder
- cover MySQL text and prepared execution, PostgreSQL execution, exact-limit success, overflow, connection reuse, DDL, and internal-session isolation

## Verification

- `go test ./backend -count=1`
- `go test ./backend -run '^TestQueryRowLimit' -count=3`
- `go test ./pgserver -run '^TestQueryRowLimitOnMySQLAndPostgresSessions$' -count=3`
- `go test . -run '^TestSchemaSummary$' -count=1`
- `go test ./pgserver -run '^TestSchemaSummaryWireProtocols$' -count=1`
- `go build ./...`
- existing `go test -run '^TestRowLimit$' -count=1 -v .` remains an expected skip because it covers MySQL maximum row width, not result-row count

The query-limit patch was replayed without behavior changes after PR #476 merged: the old and new stable patch IDs are both `fb64dc8d68f8d326fbc61fe19db42fca57a0433f`. The seven-file diff is unchanged and the schema-summary files from the new base are untouched.

The full `pgserver` package has a pre-existing test-harness cwd failure: `TestPostgresDuckDBOnlyCreateOrReplaceTable` leaves the process in the repository root, so the following server test starts `go run .` from the parent and cannot find `go.mod`. This was reproduced on original exact base `9c150809`; the focused query-limit regression passes three consecutive runs after the replay.

Base: `506f891bd12ab80eef11df51e6d33762706d0d56`
Signed head: `7796ecee85fbfa03f9576e71d6e39d8a0fd81879`
