### PR TITLE
feat: add stable schema summary

### DIFF
--- a/catalog/schema_summary.go
+++ b/catalog/schema_summary.go
@@ -1,0 +1,32 @@
+package catalog
+
+// SchemaSummaryQuery is the stable, read-only schema discovery query for
+// clients and agent integrations. table_schema is the client-visible database
+// (MySQL) or schema (Postgres) name.
+//
+// Keep the projection and ordering explicit: callers can consume the result
+// without depending on information_schema's wider, version-specific schema.
+const SchemaSummaryQuery = `
+SELECT
+    c.table_schema,
+    c.table_name,
+    c.column_name,
+    LOWER(CASE
+        WHEN instr(c.data_type, '(') > 0 THEN left(c.data_type, instr(c.data_type, '(') - 1)
+        ELSE c.data_type
+    END) AS data_type,
+    c.ordinal_position,
+    t.table_type
+FROM information_schema.columns AS c
+JOIN information_schema.tables AS t
+  ON c.table_catalog = t.table_catalog
+ AND c.table_schema = t.table_schema
+ AND c.table_name = t.table_name
+WHERE c.table_schema NOT IN (
+    'information_schema',
+    'pg_catalog',
+    '__sys__',
+    'mysql',
+    'performance_schema'
+)
+ORDER BY c.table_schema, c.table_name, c.ordinal_position`

--- a/docs/tutorial/mcp.md
+++ b/docs/tutorial/mcp.md
@@ -18,6 +18,38 @@ The [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP)
     EOSQL
     ```
 
+### Discovering the schema
+
+The same read-only schema summary is available through both the MySQL and PostgreSQL wire protocols. Use this query when an agent needs to discover databases/schemas, tables, columns, and types:
+
+```sql
+SELECT
+    c.table_schema,
+    c.table_name,
+    c.column_name,
+    LOWER(CASE
+        WHEN instr(c.data_type, '(') > 0 THEN left(c.data_type, instr(c.data_type, '(') - 1)
+        ELSE c.data_type
+    END) AS data_type,
+    c.ordinal_position,
+    t.table_type
+FROM information_schema.columns AS c
+JOIN information_schema.tables AS t
+  ON c.table_catalog = t.table_catalog
+ AND c.table_schema = t.table_schema
+ AND c.table_name = t.table_name
+WHERE c.table_schema NOT IN (
+    'information_schema',
+    'pg_catalog',
+    '__sys__',
+    'mysql',
+    'performance_schema'
+)
+ORDER BY c.table_schema, c.table_name, c.ordinal_position;
+```
+
+`table_schema` is the client-visible database name for MySQL connections and schema name for PostgreSQL connections. `table_type` distinguishes `BASE TABLE` from `VIEW`, and `ordinal_position` is one-based. The explicit projection and ordering are intentional so an agent does not depend on the wider, version-specific `information_schema` column layout.
+
 4. Add the following configuration to the "mcpServers" section of your Claude Desktop configuration file. This file can be found by clicking `Settings -> Developer -> Edit Config`.
     ```json
     {

--- a/main_test.go
+++ b/main_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/apecloud/myduckserver/backend"
+	"github.com/apecloud/myduckserver/catalog"
 	"github.com/apecloud/myduckserver/harness"
 	"github.com/stretchr/testify/require"
 
@@ -800,6 +801,29 @@ func TestQueryErrors(t *testing.T) {
 func TestInfoSchema(t *testing.T) {
 	t.Skip("wait for fix")
 	enginetest.TestInfoSchema(t, NewDuckHarness("default", 1, testNumPartitions, true, mergableIndexDriver))
+}
+
+func TestSchemaSummary(t *testing.T) {
+	h := NewDuckHarness("default", 1, 1, true, nil)
+	h.Setup([]setup.SetupScript{
+		{
+			"CREATE DATABASE analytics",
+			"USE analytics",
+			"CREATE TABLE events (id BIGINT PRIMARY KEY, label VARCHAR(32), score DECIMAL(10, 2))",
+			"CREATE VIEW recent_events AS SELECT id FROM events",
+		},
+	})
+	e, err := h.NewEngine(t)
+	require.NoError(t, err)
+	defer e.Close()
+
+	ctx := enginetest.NewContext(h)
+	enginetest.TestQueryWithContext(t, ctx, e, h, catalog.SchemaSummaryQuery, []sql.Row{
+		{"analytics", "events", "id", "bigint", uint64(1), "BASE TABLE"},
+		{"analytics", "events", "label", "varchar", uint64(2), "BASE TABLE"},
+		{"analytics", "events", "score", "decimal", uint64(3), "BASE TABLE"},
+		{"analytics", "recent_events", "id", "bigint", uint64(1), "VIEW"},
+	}, nil, nil, nil)
 }
 
 func TestMySqlDb(t *testing.T) {

--- a/pgserver/schema_summary_test.go
+++ b/pgserver/schema_summary_test.go
@@ -1,0 +1,77 @@
+package pgserver
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/apecloud/myduckserver/catalog"
+	"github.com/apecloud/myduckserver/testutil"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+type schemaSummaryRow struct {
+	Schema    string
+	Table     string
+	Column    string
+	DataType  string
+	Ordinal   uint64
+	TableType string
+}
+
+func TestSchemaSummaryWireProtocols(t *testing.T) {
+	testDir := testutil.CreateTestDir(t)
+	testEnv := testutil.NewTestEnv()
+	require.NoError(t, testutil.StartDuckSqlServer(t, testDir, nil, testEnv))
+	defer testutil.StopDuckSqlServer(t, testEnv.DuckProcess)
+
+	_, err := testEnv.MyDuckServer.Exec("CREATE DATABASE wire_schema")
+	require.NoError(t, err)
+	_, err = testEnv.MyDuckServer.Exec("CREATE TABLE wire_schema.events (id BIGINT PRIMARY KEY, label VARCHAR(32), score DECIMAL(10, 2))")
+	require.NoError(t, err)
+	_, err = testEnv.MyDuckServer.Exec("CREATE VIEW wire_schema.recent_events AS SELECT id FROM wire_schema.events")
+	require.NoError(t, err)
+
+	expected := []schemaSummaryRow{
+		{Schema: "wire_schema", Table: "events", Column: "id", DataType: "bigint", Ordinal: 1, TableType: "BASE TABLE"},
+		{Schema: "wire_schema", Table: "events", Column: "label", DataType: "varchar", Ordinal: 2, TableType: "BASE TABLE"},
+		{Schema: "wire_schema", Table: "events", Column: "score", DataType: "decimal", Ordinal: 3, TableType: "BASE TABLE"},
+		{Schema: "wire_schema", Table: "recent_events", Column: "id", DataType: "bigint", Ordinal: 1, TableType: "VIEW"},
+	}
+
+	t.Run("mysql", func(t *testing.T) {
+		rows, err := testEnv.MyDuckServer.Queryx(catalog.SchemaSummaryQuery)
+		require.NoError(t, err)
+		defer rows.Close()
+
+		actual := make([]schemaSummaryRow, 0, len(expected))
+		for rows.Next() {
+			var row schemaSummaryRow
+			require.NoError(t, rows.Scan(&row.Schema, &row.Table, &row.Column, &row.DataType, &row.Ordinal, &row.TableType))
+			actual = append(actual, row)
+		}
+		require.NoError(t, rows.Err())
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("postgres", func(t *testing.T) {
+		ctx := context.Background()
+		conn, err := pgx.Connect(ctx, "postgresql://postgres@127.0.0.1:"+strconv.Itoa(testEnv.DuckPgPort)+"/postgres")
+		require.NoError(t, err)
+		defer conn.Close(ctx)
+
+		rows, err := conn.Query(ctx, catalog.SchemaSummaryQuery)
+		require.NoError(t, err)
+		defer rows.Close()
+
+		actual := make([]schemaSummaryRow, 0, len(expected))
+		for rows.Next() {
+			var row schemaSummaryRow
+			require.NoError(t, rows.Scan(&row.Schema, &row.Table, &row.Column, &row.DataType, &row.Ordinal, &row.TableType))
+			actual = append(actual, row)
+		}
+		require.NoError(t, rows.Err())
+		require.Equal(t, expected, actual)
+	})
+}


### PR DESCRIPTION
## Summary

- expose `catalog.SchemaSummaryQuery` as a stable read-only `information_schema.columns`/`tables` join
- return schema/database, table, column, normalized type, one-based ordinal position, and `BASE TABLE`/`VIEW` kind
- document the query in the existing MCP tutorial; no MCP service added
- cover the harness plus real MySQL and PostgreSQL wire protocols

## Verification

- `GOFLAGS=-tags=duckdb_arrow go test . -run '^TestSchemaSummary$' -count=1 -timeout=120s`\n- `GOFLAGS=-tags=duckdb_arrow go test ./pgserver -run '^TestSchemaSummaryWireProtocols$' -count=1 -timeout=180s`\n- `GOFLAGS=-tags=duckdb_arrow go test ./catalog ./pgserver -run '^$' -count=1 -timeout=180s`\n- `git diff --check`\n\nFull `TestInfoSchema` remains intentionally skipped because its unrelated FK/index/charset compatibility gaps are outside this task.\n\nBase: `9c15080919e8ce96d57d94c9dce3a9565c267aec`\nSigned head: `fec12ac7e0a5b2645dd37c605c4f917496133539`\nTree: `334e558cd893f4113f24e1f00b1ebbea4c27bfc1`