### PR TITLE
feat: add protocol read-only mode

### DIFF
--- a/backend/handler.go
+++ b/backend/handler.go
@@ -19,16 +19,22 @@ import (
 	"fmt"
 
 	"github.com/apecloud/myduckserver/catalog"
+	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/server"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/vitess/go/mysql"
 	"github.com/dolthub/vitess/go/sqltypes"
+	querypb "github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"github.com/sirupsen/logrus"
 )
 
 type MyHandler struct {
 	*server.Handler
 	provider *catalog.DatabaseProvider
+	engine   *sqle.Engine
+	readOnly bool
 }
 
 func (h *MyHandler) ConnectionClosed(c *mysql.Conn) {
@@ -61,6 +67,10 @@ func (h *MyHandler) ComMultiQuery(
 	query string,
 	callback mysql.ResultSpoolFn,
 ) (string, error) {
+	if err := h.rejectReadOnly(ctx, c, query); err != nil {
+		return query, err
+	}
+
 	var modifiers []ResultModifier
 	query, modifiers = applyRequestModifiers(query, defaultRequestModifiers)
 
@@ -85,6 +95,10 @@ func (h *MyHandler) ComQuery(
 	query string,
 	callback mysql.ResultSpoolFn,
 ) error {
+	if err := h.rejectReadOnly(ctx, c, query); err != nil {
+		return err
+	}
+
 	var modifiers []ResultModifier
 	query, modifiers = applyRequestModifiers(query, defaultRequestModifiers)
 
@@ -99,6 +113,62 @@ func (h *MyHandler) ComQuery(
 		return callback(&sqltypes.Result{}, false)
 	}
 	return err
+}
+
+func (h *MyHandler) ComPrepare(ctx context.Context, c *mysql.Conn, query string, prepare *mysql.PrepareData) ([]*querypb.Field, error) {
+	if err := h.rejectReadOnly(ctx, c, query); err != nil {
+		return nil, err
+	}
+	return h.Handler.ComPrepare(ctx, c, query, prepare)
+}
+
+func (h *MyHandler) ComPrepareParsed(ctx context.Context, c *mysql.Conn, query string, parsed sqlparser.Statement, prepare *mysql.PrepareData) (mysql.ParsedQuery, []*querypb.Field, error) {
+	if err := h.rejectReadOnly(ctx, c, query); err != nil {
+		return nil, nil, err
+	}
+	return h.Handler.ComPrepareParsed(ctx, c, query, parsed, prepare)
+}
+
+func (h *MyHandler) ComBind(ctx context.Context, c *mysql.Conn, query string, parsedQuery mysql.ParsedQuery, prepare *mysql.PrepareData) (mysql.BoundQuery, []*querypb.Field, error) {
+	if err := h.rejectReadOnly(ctx, c, query); err != nil {
+		return nil, nil, err
+	}
+	return h.Handler.ComBind(ctx, c, query, parsedQuery, prepare)
+}
+
+func (h *MyHandler) ComExecuteBound(ctx context.Context, c *mysql.Conn, query string, boundQuery mysql.BoundQuery, callback mysql.ResultSpoolFn) error {
+	if err := h.rejectReadOnly(ctx, c, query); err != nil {
+		return err
+	}
+	return h.Handler.ComExecuteBound(ctx, c, query, boundQuery, callback)
+}
+
+func (h *MyHandler) ComParsedQuery(ctx context.Context, c *mysql.Conn, query string, parsed sqlparser.Statement, callback mysql.ResultSpoolFn) error {
+	if err := h.rejectReadOnly(ctx, c, query); err != nil {
+		return err
+	}
+	return h.Handler.ComParsedQuery(ctx, c, query, parsed, callback)
+}
+
+func (h *MyHandler) rejectReadOnly(ctx context.Context, c *mysql.Conn, query string) error {
+	if !h.readOnly {
+		return nil
+	}
+
+	sqlCtx, err := h.Handler.NewContext(ctx, c, query)
+	if err == nil && h.engine != nil {
+		node, analyzeErr := h.engine.AnalyzeQuery(sqlCtx, query)
+		if analyzeErr == nil {
+			if !plan.IsReadOnly(node) {
+				return sql.ErrReadOnly.New()
+			}
+		}
+	}
+
+	if IsWriteQueryText(query) {
+		return sql.ErrReadOnly.New()
+	}
+	return nil
 }
 
 func isReplicaLoadingSnapshot() bool {
@@ -116,7 +186,7 @@ func isReplicaLoadingSnapshot() bool {
 	}
 }
 
-func WrapHandler(provider *catalog.DatabaseProvider) server.HandlerWrapper {
+func WrapHandler(provider *catalog.DatabaseProvider, engine *sqle.Engine, readOnly bool) server.HandlerWrapper {
 	return func(h mysql.Handler) (mysql.Handler, error) {
 		handler, ok := h.(*server.Handler)
 		if !ok {
@@ -126,6 +196,8 @@ func WrapHandler(provider *catalog.DatabaseProvider) server.HandlerWrapper {
 		return &MyHandler{
 			Handler:  handler,
 			provider: provider,
+			engine:   engine,
+			readOnly: readOnly,
 		}, nil
 	}
 }

--- a/backend/read_only.go
+++ b/backend/read_only.go
@@ -1,0 +1,62 @@
+package backend
+
+import (
+	"strings"
+	"unicode"
+)
+
+// IsWriteQueryText classifies statements that could not be parsed by the
+// protocol-specific engine. Parsed statements should use their AST instead.
+func IsWriteQueryText(query string) bool {
+	keyword := firstQueryKeyword(query)
+	switch keyword {
+	case "INSERT", "UPDATE", "DELETE", "REPLACE", "MERGE",
+		"CREATE", "ALTER", "DROP", "TRUNCATE", "RENAME",
+		"GRANT", "REVOKE", "CALL", "LOAD", "IMPORT":
+		return true
+	default:
+		return false
+	}
+}
+
+func firstQueryKeyword(query string) string {
+	for {
+		query = strings.TrimLeftFunc(query, unicode.IsSpace)
+		switch {
+		case strings.HasPrefix(query, "/*!"):
+			end := strings.Index(query[3:], "*/")
+			if end < 0 {
+				return ""
+			}
+			body := query[3 : 3+end]
+			body = strings.TrimLeftFunc(body, unicode.IsDigit)
+			query = body
+			continue
+		case strings.HasPrefix(query, "--"):
+			if newline := strings.IndexByte(query, '\n'); newline >= 0 {
+				query = query[newline+1:]
+				continue
+			}
+			return ""
+		case strings.HasPrefix(query, "#"):
+			if newline := strings.IndexByte(query, '\n'); newline >= 0 {
+				query = query[newline+1:]
+				continue
+			}
+			return ""
+		case strings.HasPrefix(query, "/*"):
+			if end := strings.Index(query[2:], "*/"); end >= 0 {
+				query = query[end+4:]
+				continue
+			}
+			return ""
+		}
+		break
+	}
+
+	end := 0
+	for end < len(query) && (unicode.IsLetter(rune(query[end])) || query[end] == '_') {
+		end++
+	}
+	return strings.ToUpper(query[:end])
+}

--- a/backend/request_modifier_test.go
+++ b/backend/request_modifier_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestSkipUnsupportedRoutineDDL(t *testing.T) {
 	cases := []struct {
-		name   string
-		input  string
-		skip   bool
+		name  string
+		input string
+		skip  bool
 	}{
 		{
 			name:  "versioned drop function",
@@ -118,4 +118,22 @@ func TestApplyRequestModifiersIssue329(t *testing.T) {
 	)
 	require.Contains(t, view, "VIEW log_report_count AS SELECT 1 WHERE 1 > 0")
 	require.NotContains(t, view, "AS (")
+}
+
+func TestIsWriteQueryText(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+		write bool
+	}{
+		{name: "select", query: "SELECT 1", write: false},
+		{name: "create table", query: "CREATE OR REPLACE TABLE t (id INT)", write: true},
+		{name: "versioned drop routine", query: "/*!50003 DROP FUNCTION IF EXISTS f */", write: true},
+		{name: "line comment", query: "-- dump\nINSERT INTO t VALUES (1)", write: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.write, IsWriteQueryText(tc.query))
+		})
+	}
 }

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ var (
 	defaultDb     = "myduck"
 	dataDirectory = "."
 	logLevel      = int(logrus.InfoLevel)
+	readOnly      = false
 
 	replicaOptions replica.ReplicaOptions
 
@@ -85,6 +86,7 @@ func init() {
 	flag.StringVar(&dataDirectory, "datadir", dataDirectory, "The directory to store the database.")
 	flag.StringVar(&defaultDb, "default-db", defaultDb, "The default database name to use.")
 	flag.IntVar(&logLevel, "loglevel", logLevel, "The log level to use.")
+	flag.BoolVar(&readOnly, "read-only", readOnly, "Start ordinary MySQL/Postgres client sessions in read-only mode.")
 
 	flag.StringVar(&superuserPassword, "superuser-password", superuserPassword, "The password for the superuser account.")
 
@@ -164,7 +166,7 @@ func main() {
 		Address:  fmt.Sprintf("%s:%d", address, port),
 		Socket:   socket,
 	}
-	myServer, err := server.NewServerWithHandler(serverConfig, engine, backend.NewSessionBuilder(provider, backend.WithQueryRowLimit(queryRowLimit)), nil, backend.WrapHandler(provider))
+	myServer, err := server.NewServerWithHandler(serverConfig, engine, backend.NewSessionBuilder(provider, backend.WithQueryRowLimit(queryRowLimit)), nil, backend.WrapHandler(provider, engine, readOnly))
 	if err != nil {
 		logrus.WithError(err).Fatalln("Failed to create MySQL-protocol server")
 	}
@@ -181,6 +183,7 @@ func main() {
 			pgserver.WithEngine(myServer.Engine),
 			pgserver.WithSessionManager(myServer.SessionManager()),
 			pgserver.WithConnID(&myServer.Listener.(*mysql.Listener).ConnectionID), // Shared connection ID counter
+			pgserver.WithReadOnly(readOnly),
 		)
 		if err != nil {
 			logrus.WithError(err).Fatalln("Failed to create Postgres-protocol server")

--- a/pgserver/connection_handler.go
+++ b/pgserver/connection_handler.go
@@ -31,6 +31,7 @@ import (
 	"sync/atomic"
 
 	"github.com/apecloud/myduckserver/adapter"
+	"github.com/apecloud/myduckserver/backend"
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/parser"
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 	gms "github.com/dolthub/go-mysql-server"
@@ -56,8 +57,9 @@ type ConnectionHandler struct {
 	// COPY DATA messages from the client to import data into tables.
 	copyFromStdinState *copyFromStdinState
 
-	server *Server
-	logger *logrus.Entry
+	server   *Server
+	readOnly bool
+	logger   *logrus.Entry
 }
 
 // Set this env var to disable panic handling in the connection, which is useful when debugging a panic
@@ -73,7 +75,7 @@ func init() {
 }
 
 // NewConnectionHandler returns a new ConnectionHandler for the connection provided
-func NewConnectionHandler(conn net.Conn, handler mysql.Handler, engine *gms.Engine, sm *server.SessionManager, connID uint32, server *Server) *ConnectionHandler {
+func NewConnectionHandler(conn net.Conn, handler mysql.Handler, engine *gms.Engine, sm *server.SessionManager, connID uint32, server *Server, readOnly bool) *ConnectionHandler {
 	mysqlConn := &mysql.Conn{
 		Conn:        conn,
 		PrepareData: make(map[uint32]*mysql.PrepareData),
@@ -104,7 +106,8 @@ func NewConnectionHandler(conn net.Conn, handler mysql.Handler, engine *gms.Engi
 		backend:            pgproto3.NewBackend(conn, conn),
 		pgTypeMap:          pgtype.NewMap(),
 
-		server: server,
+		server:   server,
+		readOnly: readOnly,
 		logger: logrus.WithFields(logrus.Fields{
 			"connectionID": connID,
 			"protocol":     "pg",
@@ -482,6 +485,9 @@ func (h *ConnectionHandler) handleQuery(message *pgproto3.Query) (endOfMessages 
 
 	for _, statement := range statements {
 		statement.IsExtendedQuery = false
+		if err := h.rejectReadOnly(statement); err != nil {
+			return true, err
+		}
 		// Certain statement types get handled directly by the handler instead of being passed to the engine
 		handled, endOfMessages, err = h.handleStatementOutsideEngine(statement)
 		if handled {
@@ -572,6 +578,9 @@ func (h *ConnectionHandler) handleParse(message *pgproto3.Parse) error {
 	// TODO(Noy): handle multiple statements
 	statement := statements[0]
 	statement.IsExtendedQuery = true
+	if err := h.rejectReadOnly(statement); err != nil {
+		return err
+	}
 	if statement.AST == nil && strings.TrimSpace(statement.String) == "" {
 		// special case: empty query
 		h.preparedStatements[message.Name] = PreparedStatementData{
@@ -1041,6 +1050,24 @@ func (h *ConnectionHandler) run(statement ConvertedStatement) error {
 	}
 
 	return h.send(makeCommandComplete(statement.Tag, rowsAffected))
+}
+
+func (h *ConnectionHandler) rejectReadOnly(statement ConvertedStatement) error {
+	if !h.readOnly {
+		return nil
+	}
+	if statement.SubscriptionConfig != nil || statement.BackupConfig != nil || statement.RestoreConfig != nil {
+		return sql.ErrReadOnly.New()
+	}
+	if statement.AST != nil {
+		if tree.CanWriteData(statement.AST) || tree.CanModifySchema(statement.AST) {
+			return sql.ErrReadOnly.New()
+		}
+	}
+	if backend.IsWriteQueryText(statement.String) {
+		return sql.ErrReadOnly.New()
+	}
+	return nil
 }
 
 // spoolRowsCallback returns a callback function that will send RowDescription message,

--- a/pgserver/duck_handler.go
+++ b/pgserver/duck_handler.go
@@ -121,6 +121,9 @@ func (h *DuckHandler) ComBind(ctx context.Context, c *mysql.Conn, prepared Prepa
 
 // ComExecuteBound implements the Handler interface.
 func (h *DuckHandler) ComExecuteBound(ctx context.Context, conn *mysql.Conn, portal PortalData, callback func(*Result) error) error {
+	if err := h.rejectReadOnly(portal.Statement); err != nil {
+		return err
+	}
 	err := h.doQuery(ctx, conn, portal.Statement.String, portal.Statement.AST, portal.Stmt, portal.Vars, portal.ResultFormatCodes, ExtendedQueryMode, h.executeBoundPlan, callback)
 	if err != nil {
 		err = sql.CastSQLError(err)
@@ -131,6 +134,9 @@ func (h *DuckHandler) ComExecuteBound(ctx context.Context, conn *mysql.Conn, por
 
 // ComPrepareParsed implements the Handler interface.
 func (h *DuckHandler) ComPrepareParsed(ctx context.Context, c *mysql.Conn, query string, parsed tree.Statement) (*duckdb.Stmt, []uint32, []pgproto3.FieldDescription, error) {
+	if err := h.rejectReadOnly(ConvertedStatement{String: query, AST: parsed}); err != nil {
+		return nil, nil, nil, err
+	}
 	// DuckDB's official Go binding exposes prepared statement parameter types but not result types.
 	// 1. For SELECT statements, we will supply all NULL values as parameters
 	//    to execute the query with a LIMIT 0 to get the result types.
@@ -234,11 +240,21 @@ func (h *DuckHandler) ComPrepareParsed(ctx context.Context, c *mysql.Conn, query
 
 // ComQuery implements the Handler interface.
 func (h *DuckHandler) ComQuery(ctx context.Context, c *mysql.Conn, query string, parsed tree.Statement, callback func(*Result) error) error {
+	if err := h.rejectReadOnly(ConvertedStatement{String: query, AST: parsed}); err != nil {
+		return err
+	}
 	err := h.doQuery(ctx, c, query, parsed, nil, nil, nil, SimpleQueryMode, h.executeQuery, callback)
 	if err != nil {
 		err = sql.CastSQLError(err)
 	}
 	return err
+}
+
+func (h *DuckHandler) rejectReadOnly(statement ConvertedStatement) error {
+	if h.connectionHandler == nil {
+		return nil
+	}
+	return h.connectionHandler.rejectReadOnly(statement)
 }
 
 // ComResetConnection implements the Handler interface.

--- a/pgserver/listener.go
+++ b/pgserver/listener.go
@@ -37,9 +37,10 @@ type Listener struct {
 	listener net.Listener
 	cfg      mysql.ListenerConfig
 
-	engine *gms.Engine
-	sm     *server.SessionManager
-	connID *atomic.Uint32
+	engine   *gms.Engine
+	sm       *server.SessionManager
+	connID   *atomic.Uint32
+	readOnly bool
 }
 
 type ListenerOpt func(*Listener)
@@ -65,6 +66,12 @@ func WithSessionManager(sm *server.SessionManager) ListenerOpt {
 func WithConnID(connID *atomic.Uint32) ListenerOpt {
 	return func(l *Listener) {
 		l.connID = connID
+	}
+}
+
+func WithReadOnly(readOnly bool) ListenerOpt {
+	return func(l *Listener) {
+		l.readOnly = readOnly
 	}
 }
 
@@ -104,7 +111,7 @@ func (l *Listener) Accept(server *Server) {
 			conn = netutil.NewConnWithTimeouts(conn, l.cfg.ConnReadTimeout, l.cfg.ConnWriteTimeout)
 		}
 
-		connectionHandler := NewConnectionHandler(conn, l.cfg.Handler, l.engine, l.sm, l.connID.Add(1), server)
+		connectionHandler := NewConnectionHandler(conn, l.cfg.Handler, l.engine, l.sm, l.connID.Add(1), server, l.readOnly)
 		go connectionHandler.HandleConnection()
 	}
 }

--- a/pgserver/server.go
+++ b/pgserver/server.go
@@ -12,6 +12,7 @@ type Server struct {
 	Listener       *Listener
 	Provider       *catalog.DatabaseProvider
 	NewInternalCtx func() *sql.Context
+	ReadOnly       bool
 }
 
 func NewServer(provider *catalog.DatabaseProvider, host string, port int, password string, newCtx func() *sql.Context, options ...ListenerOpt) (*Server, error) {
@@ -32,7 +33,7 @@ func NewServer(provider *catalog.DatabaseProvider, host string, port int, passwo
 	if err != nil {
 		return nil, err
 	}
-	return &Server{Listener: listener, Provider: provider, NewInternalCtx: newCtx}, nil
+	return &Server{Listener: listener, Provider: provider, NewInternalCtx: newCtx, ReadOnly: listener.readOnly}, nil
 }
 
 func (s *Server) Start() {

--- a/read_only_test.go
+++ b/read_only_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/apecloud/myduckserver/testutil"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadOnlyProtocols(t *testing.T) {
+	testDir := testutil.CreateTestDir(t)
+	testEnv := testutil.NewTestEnv()
+	workingDir, err := os.Getwd()
+	require.NoError(t, err)
+	// testutil starts `go run .` from the parent of OriginalWorkingDir.
+	testEnv.OriginalWorkingDir = filepath.Join(workingDir, "pgserver")
+	testEnv.ExtraArgs = []string{"--read-only"}
+	require.NoError(t, testutil.StartDuckSqlServer(t, testDir, nil, testEnv))
+	defer testutil.StopDuckSqlServer(t, testEnv.DuckProcess)
+
+	assertReadOnlyError := func(err error) {
+		require.Error(t, err)
+		require.Contains(t, strings.ToLower(err.Error()), "read only")
+	}
+
+	_, err = testEnv.MyDuckServer.Exec("SELECT 1")
+	require.NoError(t, err)
+	_, err = testEnv.MyDuckServer.Exec("INSERT INTO missing_table VALUES (1)")
+	assertReadOnlyError(err)
+	_, err = testEnv.MyDuckServer.Exec("CREATE TABLE blocked_table (id INT)")
+	assertReadOnlyError(err)
+	_, err = testEnv.MyDuckServer.Exec("CREATE OR REPLACE TABLE blocked_replace (id INT)")
+	assertReadOnlyError(err)
+
+	ctx := context.Background()
+	pgConn, err := pgx.Connect(ctx, "postgresql://postgres@127.0.0.1:"+strconv.Itoa(testEnv.DuckPgPort)+"/postgres")
+	require.NoError(t, err)
+	defer pgConn.Close(ctx)
+
+	_, err = pgConn.Exec(ctx, "SELECT 1")
+	require.NoError(t, err)
+	_, err = pgConn.Exec(ctx, "INSERT INTO missing_table VALUES (1)")
+	assertReadOnlyError(err)
+	_, err = pgConn.Exec(ctx, "CREATE TABLE blocked_table (id INT)")
+	assertReadOnlyError(err)
+	_, err = pgConn.Exec(ctx, "CREATE OR REPLACE TABLE blocked_replace (id INT)")
+	assertReadOnlyError(err)
+}
+
+func TestReadOnlyDefaultOff(t *testing.T) {
+	testDir := testutil.CreateTestDir(t)
+	testEnv := testutil.NewTestEnv()
+	workingDir, err := os.Getwd()
+	require.NoError(t, err)
+	testEnv.OriginalWorkingDir = filepath.Join(workingDir, "pgserver")
+	require.NoError(t, testutil.StartDuckSqlServer(t, testDir, nil, testEnv))
+	defer testutil.StopDuckSqlServer(t, testEnv.DuckProcess)
+
+	_, err = testEnv.MyDuckServer.Exec("CREATE DATABASE default_off_mysql")
+	require.NoError(t, err)
+	_, err = testEnv.MyDuckServer.Exec("USE default_off_mysql")
+	require.NoError(t, err)
+	_, err = testEnv.MyDuckServer.Exec("CREATE TABLE default_off_mysql (id INT)")
+	require.NoError(t, err)
+	_, err = testEnv.MyDuckServer.Exec("INSERT INTO default_off_mysql VALUES (1)")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	pgConn, err := pgx.Connect(ctx, "postgresql://postgres@127.0.0.1:"+strconv.Itoa(testEnv.DuckPgPort)+"/postgres")
+	require.NoError(t, err)
+	defer pgConn.Close(ctx)
+
+	_, err = pgConn.Exec(ctx, "CREATE TABLE default_off_pg (id INT)")
+	require.NoError(t, err)
+	_, err = pgConn.Exec(ctx, "INSERT INTO default_off_pg VALUES (1)")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- add default-off `--read-only` mode for ordinary MySQL/Postgres protocol sessions
- reject DML/DDL before request rewrites and across prepared/extended protocol paths
- keep binlog replication internal engine execution unchanged

## Verification
- `GOFLAGS='-tags=duckdb_arrow' go test . -run '^TestReadOnly' -count=1`
- `GOFLAGS='-tags=duckdb_arrow' go test ./backend ./pgserver -run 'Test(IsWriteQueryText|ReadOnly|.*ReadOnly)' -count=1`
- full root suite retains exact-main baseline failures in `TestQueriesSimple` and `TestAddColumn`

Parent: `506f891bd12ab80eef11df51e6d33762706d0d56`
Head: `3bc2e803d9ead253981674be1fe1b8d231d83ec6`
GitHub verification: `verified=true`, `reason=valid`, signer `web-flow`
Tree: `f8ce3f1060235b839f9d1f50898b79b375a3da6d`
