### PR TITLE
feat: audit ordinary protocol queries

### DIFF
--- a/backend/handler.go
+++ b/backend/handler.go
@@ -61,30 +61,45 @@ func wrapResultCallback(callback mysql.ResultSpoolFn, modifiers ...ResultModifie
 	}
 }
 
+func auditResultCallback(audit *QueryAudit, callback mysql.ResultSpoolFn, modifiers ...ResultModifier) mysql.ResultSpoolFn {
+	return wrapResultCallback(func(res *sqltypes.Result, more bool) error {
+		if err := callback(res, more); err != nil {
+			return err
+		}
+		audit.AddRows(len(res.Rows))
+		return nil
+	}, modifiers...)
+}
+
 func (h *MyHandler) ComMultiQuery(
 	ctx context.Context,
 	c *mysql.Conn,
 	query string,
 	callback mysql.ResultSpoolFn,
-) (string, error) {
-	if err := h.rejectReadOnly(ctx, c, query); err != nil {
-		return query, err
+) (rest string, returnErr error) {
+	audit := NewQueryAudit(c, "mysql", query)
+	defer func() {
+		audit.Complete(returnErr)
+	}()
+
+	if returnErr = h.rejectReadOnly(ctx, c, query); returnErr != nil {
+		return query, returnErr
 	}
 
 	var modifiers []ResultModifier
 	query, modifiers = applyRequestModifiers(query, defaultRequestModifiers)
 
 	called := false
-	cb := func(res *sqltypes.Result, more bool) error {
+	cb := auditResultCallback(audit, func(res *sqltypes.Result, more bool) error {
 		called = true
-		return wrapResultCallback(callback, modifiers...)(res, more)
+		return callback(res, more)
+	}, modifiers...)
+	rest, returnErr = h.Handler.ComMultiQuery(ctx, c, query, cb)
+	if returnErr != nil && !called && shouldIgnoreFailedView(query, isReplicaLoadingSnapshot()) {
+		logrus.WithError(returnErr).Warn("skipping CREATE VIEW during replica snapshot")
+		returnErr = cb(&sqltypes.Result{}, false)
 	}
-	rest, err := h.Handler.ComMultiQuery(ctx, c, query, cb)
-	if err != nil && !called && shouldIgnoreFailedView(query, isReplicaLoadingSnapshot()) {
-		logrus.WithError(err).Warn("skipping CREATE VIEW during replica snapshot")
-		return rest, callback(&sqltypes.Result{}, false)
-	}
-	return rest, err
+	return rest, returnErr
 }
 
 // Naive query rewriting. This is just a temporary solution
@@ -94,25 +109,50 @@ func (h *MyHandler) ComQuery(
 	c *mysql.Conn,
 	query string,
 	callback mysql.ResultSpoolFn,
-) error {
-	if err := h.rejectReadOnly(ctx, c, query); err != nil {
-		return err
+) (returnErr error) {
+	audit := NewQueryAudit(c, "mysql", query)
+	defer func() {
+		audit.Complete(returnErr)
+	}()
+
+	if returnErr = h.rejectReadOnly(ctx, c, query); returnErr != nil {
+		return returnErr
 	}
 
 	var modifiers []ResultModifier
 	query, modifiers = applyRequestModifiers(query, defaultRequestModifiers)
 
 	called := false
-	cb := func(res *sqltypes.Result, more bool) error {
+	cb := auditResultCallback(audit, func(res *sqltypes.Result, more bool) error {
 		called = true
-		return wrapResultCallback(callback, modifiers...)(res, more)
+		return callback(res, more)
+	}, modifiers...)
+	returnErr = h.Handler.ComQuery(ctx, c, query, cb)
+	if returnErr != nil && !called && shouldIgnoreFailedView(query, isReplicaLoadingSnapshot()) {
+		logrus.WithError(returnErr).Warn("skipping CREATE VIEW during replica snapshot")
+		returnErr = cb(&sqltypes.Result{}, false)
 	}
-	err := h.Handler.ComQuery(ctx, c, query, cb)
-	if err != nil && !called && shouldIgnoreFailedView(query, isReplicaLoadingSnapshot()) {
-		logrus.WithError(err).Warn("skipping CREATE VIEW during replica snapshot")
-		return callback(&sqltypes.Result{}, false)
+	return returnErr
+}
+
+func (h *MyHandler) ComStmtExecute(ctx context.Context, c *mysql.Conn, prepare *mysql.PrepareData, callback func(*sqltypes.Result) error) (returnErr error) {
+	query := ""
+	if prepare != nil {
+		query = prepare.PrepareStmt
 	}
-	return err
+	audit := NewQueryAudit(c, "mysql", query)
+	defer func() {
+		audit.Complete(returnErr)
+	}()
+
+	returnErr = h.Handler.ComStmtExecute(ctx, c, prepare, func(res *sqltypes.Result) error {
+		if err := callback(res); err != nil {
+			return err
+		}
+		audit.AddRows(len(res.Rows))
+		return nil
+	})
+	return returnErr
 }
 
 func (h *MyHandler) ComPrepare(ctx context.Context, c *mysql.Conn, query string, prepare *mysql.PrepareData) ([]*querypb.Field, error) {
@@ -136,18 +176,28 @@ func (h *MyHandler) ComBind(ctx context.Context, c *mysql.Conn, query string, pa
 	return h.Handler.ComBind(ctx, c, query, parsedQuery, prepare)
 }
 
-func (h *MyHandler) ComExecuteBound(ctx context.Context, c *mysql.Conn, query string, boundQuery mysql.BoundQuery, callback mysql.ResultSpoolFn) error {
-	if err := h.rejectReadOnly(ctx, c, query); err != nil {
-		return err
+func (h *MyHandler) ComExecuteBound(ctx context.Context, c *mysql.Conn, query string, boundQuery mysql.BoundQuery, callback mysql.ResultSpoolFn) (returnErr error) {
+	audit := NewQueryAudit(c, "mysql", query)
+	defer func() {
+		audit.Complete(returnErr)
+	}()
+	if returnErr = h.rejectReadOnly(ctx, c, query); returnErr != nil {
+		return returnErr
 	}
-	return h.Handler.ComExecuteBound(ctx, c, query, boundQuery, callback)
+	returnErr = h.Handler.ComExecuteBound(ctx, c, query, boundQuery, auditResultCallback(audit, callback))
+	return returnErr
 }
 
-func (h *MyHandler) ComParsedQuery(ctx context.Context, c *mysql.Conn, query string, parsed sqlparser.Statement, callback mysql.ResultSpoolFn) error {
-	if err := h.rejectReadOnly(ctx, c, query); err != nil {
-		return err
+func (h *MyHandler) ComParsedQuery(ctx context.Context, c *mysql.Conn, query string, parsed sqlparser.Statement, callback mysql.ResultSpoolFn) (returnErr error) {
+	audit := NewQueryAudit(c, "mysql", query)
+	defer func() {
+		audit.Complete(returnErr)
+	}()
+	if returnErr = h.rejectReadOnly(ctx, c, query); returnErr != nil {
+		return returnErr
 	}
-	return h.Handler.ComParsedQuery(ctx, c, query, parsed, callback)
+	returnErr = h.Handler.ComParsedQuery(ctx, c, query, parsed, auditResultCallback(audit, callback))
+	return returnErr
 }
 
 func (h *MyHandler) rejectReadOnly(ctx context.Context, c *mysql.Conn, query string) error {

--- a/backend/query_audit.go
+++ b/backend/query_audit.go
@@ -1,0 +1,40 @@
+package backend
+
+import (
+	"github.com/dolthub/vitess/go/mysql"
+	"github.com/sirupsen/logrus"
+)
+
+// QueryAudit records the outcome of one ordinary protocol query.
+type QueryAudit struct {
+	entry *logrus.Entry
+	rows  uint64
+}
+
+// NewQueryAudit starts an audit record for a user-facing protocol query.
+func NewQueryAudit(conn *mysql.Conn, protocol, query string) *QueryAudit {
+	fields := logrus.Fields{
+		"audit":    "query",
+		"protocol": protocol,
+		"query":    query,
+		"user":     "",
+	}
+	if conn != nil {
+		fields["user"] = conn.User
+	}
+	return &QueryAudit{entry: logrus.WithFields(fields)}
+}
+
+// AddRows records rows successfully handed to the protocol callback.
+func (audit *QueryAudit) AddRows(rows int) {
+	audit.rows += uint64(rows)
+}
+
+// Complete emits the query's single structured audit record.
+func (audit *QueryAudit) Complete(err error) {
+	entry := audit.entry.WithField("rows", audit.rows)
+	if err != nil {
+		entry = entry.WithError(err)
+	}
+	entry.Info("query audit")
+}

--- a/pgserver/connection_data.go
+++ b/pgserver/connection_data.go
@@ -16,13 +16,14 @@ package pgserver
 
 import (
 	"fmt"
+	"sync/atomic"
+
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/duckdb/duckdb-go/v2"
 	"github.com/jackc/pgx/v5/pgproto3"
 	"github.com/lib/pq/oid"
-	"github.com/duckdb/duckdb-go/v2"
-	"sync/atomic"
 )
 
 // ErrorResponseSeverity represents the severity of an ErrorResponse message.
@@ -54,6 +55,7 @@ const (
 // otherwise always prefer to AST.
 type ConvertedStatement struct {
 	String             string
+	OriginalString     string
 	AST                tree.Statement
 	Tag                string
 	PgParsable         bool
@@ -67,6 +69,7 @@ type ConvertedStatement struct {
 func (cs ConvertedStatement) WithQueryString(queryString string) ConvertedStatement {
 	return ConvertedStatement{
 		String:             queryString,
+		OriginalString:     cs.OriginalString,
 		AST:                cs.AST,
 		Tag:                cs.Tag,
 		PgParsable:         cs.PgParsable,
@@ -76,6 +79,13 @@ func (cs ConvertedStatement) WithQueryString(queryString string) ConvertedStatem
 		BackupConfig:       cs.BackupConfig,
 		RestoreConfig:      cs.RestoreConfig,
 	}
+}
+
+func (cs ConvertedStatement) QueryForAudit() string {
+	if cs.OriginalString != "" {
+		return cs.OriginalString
+	}
+	return cs.String
 }
 
 // copyFromStdinState tracks the metadata for an import of data into a table using a COPY FROM STDIN statement. When

--- a/pgserver/connection_handler.go
+++ b/pgserver/connection_handler.go
@@ -328,7 +328,7 @@ func (h *ConnectionHandler) chooseInitialDatabase(startupMessage *pgproto3.Start
 	if err != nil {
 		return err
 	}
-	err = h.duckHandler.ComQuery(context.Background(), h.mysqlConn, useStmt, parsed.AST, func(res *Result) error {
+	err = h.duckHandler.ComQuery(context.Background(), h.mysqlConn, useStmt, "", parsed.AST, func(res *Result) error {
 		return nil
 	})
 	// If a database isn't specified, then we attempt to connect to a database with the same name as the user,
@@ -1043,6 +1043,7 @@ func (h *ConnectionHandler) run(statement ConvertedStatement) error {
 		context.Background(),
 		h.mysqlConn,
 		statement.String,
+		statement.QueryForAudit(),
 		statement.AST,
 		callback,
 	); err != nil {
@@ -1134,6 +1135,7 @@ func (h *ConnectionHandler) sendDescribeResponse(fields []pgproto3.FieldDescript
 
 // handledPSQLCommands handles the special PSQL commands, such as \l and \dt.
 func (h *ConnectionHandler) handledPSQLCommands(statement string) (bool, error) {
+	originalStatement := statement
 	statement = strings.ToLower(statement)
 	// Command: \l
 	if statement == "select d.datname as \"name\",\n       pg_catalog.pg_get_userbyid(d.datdba) as \"owner\",\n       pg_catalog.pg_encoding_to_char(d.encoding) as \"encoding\",\n       d.datcollate as \"collate\",\n       d.datctype as \"ctype\",\n       d.daticulocale as \"icu locale\",\n       case d.datlocprovider when 'c' then 'libc' when 'i' then 'icu' end as \"locale provider\",\n       pg_catalog.array_to_string(d.datacl, e'\\n') as \"access privileges\"\nfrom pg_catalog.pg_database d\norder by 1;" {
@@ -1141,6 +1143,7 @@ func (h *ConnectionHandler) handledPSQLCommands(statement string) (bool, error) 
 		if err != nil {
 			return false, err
 		}
+		query[0].OriginalString = originalStatement
 		return true, h.run(query[0])
 	}
 	// Command: \l on psql 16
@@ -1149,27 +1152,31 @@ func (h *ConnectionHandler) handledPSQLCommands(statement string) (bool, error) 
 		if err != nil {
 			return false, err
 		}
+		query[0].OriginalString = originalStatement
 		return true, h.run(query[0])
 	}
 	// Command: \dt
 	if statement == "select n.nspname as \"schema\",\n  c.relname as \"name\",\n  case c.relkind when 'r' then 'table' when 'v' then 'view' when 'm' then 'materialized view' when 'i' then 'index' when 's' then 'sequence' when 't' then 'toast table' when 'f' then 'foreign table' when 'p' then 'partitioned table' when 'i' then 'partitioned index' end as \"type\",\n  pg_catalog.pg_get_userbyid(c.relowner) as \"owner\"\nfrom pg_catalog.pg_class c\n     left join pg_catalog.pg_namespace n on n.oid = c.relnamespace\n     left join pg_catalog.pg_am am on am.oid = c.relam\nwhere c.relkind in ('r','p','')\n      and n.nspname <> 'pg_catalog'\n      and n.nspname !~ '^pg_toast'\n      and n.nspname <> 'information_schema'\n  and pg_catalog.pg_table_is_visible(c.oid)\norder by 1,2;" {
 		return true, h.run(ConvertedStatement{
-			String: `SELECT table_schema AS "Schema", TABLE_NAME AS "Name", 'table' AS "Type", 'postgres' AS "Owner" FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA <> 'pg_catalog' AND TABLE_SCHEMA <> 'information_schema' AND TABLE_TYPE = 'BASE TABLE' ORDER BY 2;`,
-			Tag:    "SELECT",
+			String:         `SELECT table_schema AS "Schema", TABLE_NAME AS "Name", 'table' AS "Type", 'postgres' AS "Owner" FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA <> 'pg_catalog' AND TABLE_SCHEMA <> 'information_schema' AND TABLE_TYPE = 'BASE TABLE' ORDER BY 2;`,
+			OriginalString: originalStatement,
+			Tag:            "SELECT",
 		})
 	}
 	// Command: \d
 	if statement == "select n.nspname as \"schema\",\n  c.relname as \"name\",\n  case c.relkind when 'r' then 'table' when 'v' then 'view' when 'm' then 'materialized view' when 'i' then 'index' when 's' then 'sequence' when 't' then 'toast table' when 'f' then 'foreign table' when 'p' then 'partitioned table' when 'i' then 'partitioned index' end as \"type\",\n  pg_catalog.pg_get_userbyid(c.relowner) as \"owner\"\nfrom pg_catalog.pg_class c\n     left join pg_catalog.pg_namespace n on n.oid = c.relnamespace\n     left join pg_catalog.pg_am am on am.oid = c.relam\nwhere c.relkind in ('r','p','v','m','s','f','')\n      and n.nspname <> 'pg_catalog'\n      and n.nspname !~ '^pg_toast'\n      and n.nspname <> 'information_schema'\n  and pg_catalog.pg_table_is_visible(c.oid)\norder by 1,2;" {
 		return true, h.run(ConvertedStatement{
-			String: `SELECT table_schema AS "Schema", TABLE_NAME AS "Name", IF(TABLE_TYPE = 'VIEW', 'view', 'table') AS "Type", 'postgres' AS "Owner" FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA <> 'pg_catalog' AND TABLE_SCHEMA <> 'information_schema' AND TABLE_TYPE = 'BASE TABLE' OR TABLE_TYPE = 'VIEW' ORDER BY 2;`,
-			Tag:    "SELECT",
+			String:         `SELECT table_schema AS "Schema", TABLE_NAME AS "Name", IF(TABLE_TYPE = 'VIEW', 'view', 'table') AS "Type", 'postgres' AS "Owner" FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA <> 'pg_catalog' AND TABLE_SCHEMA <> 'information_schema' AND TABLE_TYPE = 'BASE TABLE' OR TABLE_TYPE = 'VIEW' ORDER BY 2;`,
+			OriginalString: originalStatement,
+			Tag:            "SELECT",
 		})
 	}
 	// Alternate \d for psql 14
 	if statement == "select n.nspname as \"schema\",\n  c.relname as \"name\",\n  case c.relkind when 'r' then 'table' when 'v' then 'view' when 'm' then 'materialized view' when 'i' then 'index' when 's' then 'sequence' when 's' then 'special' when 't' then 'toast table' when 'f' then 'foreign table' when 'p' then 'partitioned table' when 'i' then 'partitioned index' end as \"type\",\n  pg_catalog.pg_get_userbyid(c.relowner) as \"owner\"\nfrom pg_catalog.pg_class c\n     left join pg_catalog.pg_namespace n on n.oid = c.relnamespace\n     left join pg_catalog.pg_am am on am.oid = c.relam\nwhere c.relkind in ('r','p','v','m','s','f','')\n      and n.nspname <> 'pg_catalog'\n      and n.nspname !~ '^pg_toast'\n      and n.nspname <> 'information_schema'\n  and pg_catalog.pg_table_is_visible(c.oid)\norder by 1,2;" {
 		return true, h.run(ConvertedStatement{
-			String: `SELECT table_schema AS "Schema", TABLE_NAME AS "Name", IF(TABLE_TYPE = 'VIEW', 'view', 'table') AS "Type", 'postgres' AS "Owner" FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA <> 'pg_catalog' AND TABLE_SCHEMA <> 'information_schema' AND TABLE_TYPE = 'BASE TABLE' OR TABLE_TYPE = 'VIEW' ORDER BY 2;`,
-			Tag:    "SELECT",
+			String:         `SELECT table_schema AS "Schema", TABLE_NAME AS "Name", IF(TABLE_TYPE = 'VIEW', 'view', 'table') AS "Type", 'postgres' AS "Owner" FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA <> 'pg_catalog' AND TABLE_SCHEMA <> 'information_schema' AND TABLE_TYPE = 'BASE TABLE' OR TABLE_TYPE = 'VIEW' ORDER BY 2;`,
+			OriginalString: originalStatement,
+			Tag:            "SELECT",
 		})
 	}
 	// Command: \d table_name
@@ -1181,30 +1188,34 @@ func (h *ConnectionHandler) handledPSQLCommands(statement string) (bool, error) 
 	// Command: \dn
 	if statement == "select n.nspname as \"name\",\n  pg_catalog.pg_get_userbyid(n.nspowner) as \"owner\"\nfrom pg_catalog.pg_namespace n\nwhere n.nspname !~ '^pg_' and n.nspname <> 'information_schema'\norder by 1;" {
 		return true, h.run(ConvertedStatement{
-			String: `SELECT 'public' AS "Name", 'pg_database_owner' AS "Owner";`,
-			Tag:    "SELECT",
+			String:         `SELECT 'public' AS "Name", 'pg_database_owner' AS "Owner";`,
+			OriginalString: originalStatement,
+			Tag:            "SELECT",
 		})
 	}
 	// Command: \df
 	if statement == "select n.nspname as \"schema\",\n  p.proname as \"name\",\n  pg_catalog.pg_get_function_result(p.oid) as \"result data type\",\n  pg_catalog.pg_get_function_arguments(p.oid) as \"argument data types\",\n case p.prokind\n  when 'a' then 'agg'\n  when 'w' then 'window'\n  when 'p' then 'proc'\n  else 'func'\n end as \"type\"\nfrom pg_catalog.pg_proc p\n     left join pg_catalog.pg_namespace n on n.oid = p.pronamespace\nwhere pg_catalog.pg_function_is_visible(p.oid)\n      and n.nspname <> 'pg_catalog'\n      and n.nspname <> 'information_schema'\norder by 1, 2, 4;" {
 		return true, h.run(ConvertedStatement{
-			String: `SELECT '' AS "Schema", '' AS "Name", '' AS "Result data type", '' AS "Argument data types", '' AS "Type" LIMIT 0;`,
-			Tag:    "SELECT",
+			String:         `SELECT '' AS "Schema", '' AS "Name", '' AS "Result data type", '' AS "Argument data types", '' AS "Type" LIMIT 0;`,
+			OriginalString: originalStatement,
+			Tag:            "SELECT",
 		})
 	}
 	// Command: \dv
 	if statement == "select n.nspname as \"schema\",\n  c.relname as \"name\",\n  case c.relkind when 'r' then 'table' when 'v' then 'view' when 'm' then 'materialized view' when 'i' then 'index' when 's' then 'sequence' when 't' then 'toast table' when 'f' then 'foreign table' when 'p' then 'partitioned table' when 'i' then 'partitioned index' end as \"type\",\n  pg_catalog.pg_get_userbyid(c.relowner) as \"owner\"\nfrom pg_catalog.pg_class c\n     left join pg_catalog.pg_namespace n on n.oid = c.relnamespace\nwhere c.relkind in ('v','')\n      and n.nspname <> 'pg_catalog'\n      and n.nspname !~ '^pg_toast'\n      and n.nspname <> 'information_schema'\n  and pg_catalog.pg_table_is_visible(c.oid)\norder by 1,2;" {
 		return true, h.run(ConvertedStatement{
-			String: `SELECT table_schema AS "Schema", TABLE_NAME AS "Name", 'view' AS "Type", 'postgres' AS "Owner" FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA <> 'pg_catalog' AND TABLE_SCHEMA <> 'information_schema' AND TABLE_TYPE = 'VIEW' ORDER BY 2;`,
-			Tag:    "SELECT",
+			String:         `SELECT table_schema AS "Schema", TABLE_NAME AS "Name", 'view' AS "Type", 'postgres' AS "Owner" FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA <> 'pg_catalog' AND TABLE_SCHEMA <> 'information_schema' AND TABLE_TYPE = 'VIEW' ORDER BY 2;`,
+			OriginalString: originalStatement,
+			Tag:            "SELECT",
 		})
 	}
 	// Command: \du
 	if statement == "select r.rolname, r.rolsuper, r.rolinherit,\n  r.rolcreaterole, r.rolcreatedb, r.rolcanlogin,\n  r.rolconnlimit, r.rolvaliduntil,\n  array(select b.rolname\n        from pg_catalog.pg_auth_members m\n        join pg_catalog.pg_roles b on (m.roleid = b.oid)\n        where m.member = r.oid) as memberof\n, r.rolreplication\n, r.rolbypassrls\nfrom pg_catalog.pg_roles r\nwhere r.rolname !~ '^pg_'\norder by 1;" {
 		// We don't support users yet, so we'll just return nothing for now
 		return true, h.run(ConvertedStatement{
-			String: `SELECT '' FROM dual LIMIT 0;`,
-			Tag:    "SELECT",
+			String:         `SELECT '' FROM dual LIMIT 0;`,
+			OriginalString: originalStatement,
+			Tag:            "SELECT",
 		})
 	}
 	return false, nil
@@ -1215,14 +1226,16 @@ func (h *ConnectionHandler) handledWorkbenchCommands(statement string) (bool, er
 	lower := strings.ToLower(statement)
 	if lower == "select * from current_schema()" || lower == "select * from current_schema();" {
 		return true, h.run(ConvertedStatement{
-			String: `SELECT search_path AS "current_schema";`,
-			Tag:    "SELECT",
+			String:         `SELECT search_path AS "current_schema";`,
+			OriginalString: statement,
+			Tag:            "SELECT",
 		})
 	}
 	if lower == "select * from current_database()" || lower == "select * from current_database();" {
 		return true, h.run(ConvertedStatement{
-			String: `SELECT DATABASE() AS "current_database";`,
-			Tag:    "SELECT",
+			String:         `SELECT DATABASE() AS "current_database";`,
+			OriginalString: statement,
+			Tag:            "SELECT",
 		})
 	}
 	return false, nil
@@ -1260,6 +1273,7 @@ func (h *ConnectionHandler) sendError(err error) {
 
 // convertQuery takes the given Postgres query, and converts it as a list of ast.ConvertedStatement that will work with the handler.
 func (h *ConnectionHandler) convertQuery(query string, modifiers ...QueryModifier) ([]ConvertedStatement, error) {
+	originalQuery := query
 	for _, modifier := range modifiers {
 		query = modifier(query)
 	}
@@ -1269,6 +1283,7 @@ func (h *ConnectionHandler) convertQuery(query string, modifiers ...QueryModifie
 	if subscriptionConfig != nil && err == nil {
 		return []ConvertedStatement{{
 			String:             query,
+			OriginalString:     originalQuery,
 			PgParsable:         true,
 			SubscriptionConfig: subscriptionConfig,
 		}}, nil
@@ -1278,17 +1293,19 @@ func (h *ConnectionHandler) convertQuery(query string, modifiers ...QueryModifie
 	backupConfig, err := parseBackupSQL(query)
 	if backupConfig != nil && err == nil {
 		return []ConvertedStatement{{
-			String:       query,
-			PgParsable:   true,
-			BackupConfig: backupConfig,
+			String:         query,
+			OriginalString: originalQuery,
+			PgParsable:     true,
+			BackupConfig:   backupConfig,
 		}}, nil
 	}
 	restoreConfig, err := parseRestoreSQL(query)
 	if restoreConfig != nil && err == nil {
 		return []ConvertedStatement{{
-			String:        query,
-			PgParsable:    true,
-			RestoreConfig: restoreConfig,
+			String:         query,
+			OriginalString: originalQuery,
+			PgParsable:     true,
+			RestoreConfig:  restoreConfig,
 		}}, nil
 	}
 
@@ -1297,15 +1314,16 @@ func (h *ConnectionHandler) convertQuery(query string, modifiers ...QueryModifie
 		// DuckDB syntax is not fully compatible with PostgreSQL, so we need to handle some queries differently.
 		stmts, _ = parser.Parse("SELECT 'SQL syntax is incompatible with PostgreSQL' AS error")
 		return []ConvertedStatement{{
-			String:     query,
-			AST:        stmts[0].AST,
-			Tag:        GuessStatementTag(query),
-			PgParsable: false,
+			String:         query,
+			OriginalString: originalQuery,
+			AST:            stmts[0].AST,
+			Tag:            GuessStatementTag(query),
+			PgParsable:     false,
 		}}, nil
 	}
 
 	if len(stmts) == 0 {
-		return []ConvertedStatement{{String: query}}, nil
+		return []ConvertedStatement{{String: query, OriginalString: originalQuery}}, nil
 	}
 
 	convertedStmts := make([]ConvertedStatement, len(stmts))
@@ -1316,6 +1334,11 @@ func (h *ConnectionHandler) convertQuery(query string, modifiers ...QueryModifie
 			convertedStmts[i].String = fullMatchQuery
 		} else {
 			convertedStmts[i].String = stmt.SQL
+		}
+		if len(stmts) == 1 {
+			convertedStmts[i].OriginalString = originalQuery
+		} else {
+			convertedStmts[i].OriginalString = stmt.SQL
 		}
 		convertedStmts[i].AST = stmt.AST
 		convertedStmts[i].Tag = stmt.AST.StatementTag()

--- a/pgserver/duck_handler.go
+++ b/pgserver/duck_handler.go
@@ -124,7 +124,7 @@ func (h *DuckHandler) ComExecuteBound(ctx context.Context, conn *mysql.Conn, por
 	if err := h.rejectReadOnly(portal.Statement); err != nil {
 		return err
 	}
-	err := h.doQuery(ctx, conn, portal.Statement.String, portal.Statement.AST, portal.Stmt, portal.Vars, portal.ResultFormatCodes, ExtendedQueryMode, h.executeBoundPlan, callback)
+	err := h.doQuery(ctx, conn, portal.Statement.String, portal.Statement.QueryForAudit(), portal.Statement.AST, portal.Stmt, portal.Vars, portal.ResultFormatCodes, ExtendedQueryMode, h.executeBoundPlan, callback)
 	if err != nil {
 		err = sql.CastSQLError(err)
 	}
@@ -239,11 +239,11 @@ func (h *DuckHandler) ComPrepareParsed(ctx context.Context, c *mysql.Conn, query
 }
 
 // ComQuery implements the Handler interface.
-func (h *DuckHandler) ComQuery(ctx context.Context, c *mysql.Conn, query string, parsed tree.Statement, callback func(*Result) error) error {
+func (h *DuckHandler) ComQuery(ctx context.Context, c *mysql.Conn, query string, auditQuery string, parsed tree.Statement, callback func(*Result) error) error {
 	if err := h.rejectReadOnly(ConvertedStatement{String: query, AST: parsed}); err != nil {
 		return err
 	}
-	err := h.doQuery(ctx, c, query, parsed, nil, nil, nil, SimpleQueryMode, h.executeQuery, callback)
+	err := h.doQuery(ctx, c, query, auditQuery, parsed, nil, nil, nil, SimpleQueryMode, h.executeQuery, callback)
 	if err != nil {
 		err = sql.CastSQLError(err)
 	}
@@ -327,7 +327,22 @@ func (h *DuckHandler) getStatementTag(mysqlConn *mysql.Conn, query string) (stri
 
 var queryLoggingRegex = regexp.MustCompile(`[\r\n\t ]+`)
 
-func (h *DuckHandler) doQuery(ctx context.Context, c *mysql.Conn, query string, parsed tree.Statement, stmt *duckdb.Stmt, vars []any, resultFormatCodes []int16, mode QueryMode, queryExec QueryExecutor, callback func(*Result) error) error {
+func (h *DuckHandler) doQuery(ctx context.Context, c *mysql.Conn, query string, auditQuery string, parsed tree.Statement, stmt *duckdb.Stmt, vars []any, resultFormatCodes []int16, mode QueryMode, queryExec QueryExecutor, callback func(*Result) error) (returnErr error) {
+	if auditQuery != "" {
+		audit := backend.NewQueryAudit(c, "postgres", auditQuery)
+		originalCallback := callback
+		callback = func(res *Result) error {
+			if err := originalCallback(res); err != nil {
+				return err
+			}
+			audit.AddRows(len(res.Rows))
+			return nil
+		}
+		defer func() {
+			audit.Complete(returnErr)
+		}()
+	}
+
 	sqlCtx, err := h.sm.NewContextWithQuery(ctx, c, query)
 	if err != nil {
 		return err

--- a/pgserver/handler.go
+++ b/pgserver/handler.go
@@ -20,8 +20,8 @@ import (
 	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/vitess/go/mysql"
-	"github.com/jackc/pgx/v5/pgproto3"
 	"github.com/duckdb/duckdb-go/v2"
+	"github.com/jackc/pgx/v5/pgproto3"
 )
 
 type Handler interface {
@@ -33,7 +33,7 @@ type Handler interface {
 	ComPrepareParsed(ctx context.Context, c *mysql.Conn, query string, parsed tree.Statement) (*duckdb.Stmt, []uint32, []pgproto3.FieldDescription, error)
 	// ComQuery is called when a connection receives a query. Note the contents of the query slice may change
 	// after the first call to callback. So the DoltgresHandler should not hang on to the byte slice.
-	ComQuery(ctx context.Context, c *mysql.Conn, query string, parsed tree.Statement, callback func(*Result) error) error
+	ComQuery(ctx context.Context, c *mysql.Conn, query string, auditQuery string, parsed tree.Statement, callback func(*Result) error) error
 	// ComResetConnection resets the connection's session, clearing out any cached prepared statements, locks, user and
 	// session variables. The currently selected database is preserved.
 	ComResetConnection(c *mysql.Conn) error

--- a/pgserver/in_place_handler.go
+++ b/pgserver/in_place_handler.go
@@ -323,8 +323,9 @@ var inPlaceHandlers = map[string]InPlaceHandler{
 					return false, err
 				}
 				return true, h.run(ConvertedStatement{
-					String: fmt.Sprintf(`SELECT '%s' AS "%s";`, fmt.Sprintf("%v", setting), key),
-					Tag:    "SELECT",
+					String:         fmt.Sprintf(`SELECT '%s' AS "%s";`, fmt.Sprintf("%v", setting), key),
+					OriginalString: query.QueryForAudit(),
+					Tag:            "SELECT",
 				})
 			}
 			// TODO(sean): Implement SHOW ALL

--- a/query_audit_test.go
+++ b/query_audit_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apecloud/myduckserver/testutil"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrdinaryQueryAuditProtocols(t *testing.T) {
+	testDir := testutil.CreateTestDir(t)
+	testEnv := testutil.NewTestEnv()
+	workingDir, err := os.Getwd()
+	require.NoError(t, err)
+	testEnv.OriginalWorkingDir = filepath.Join(workingDir, "pgserver")
+	require.NoError(t, testutil.StartDuckSqlServer(t, testDir, nil, testEnv))
+	defer testutil.StopDuckSqlServer(t, testEnv.DuckProcess)
+
+	mysqlSimple := "SELECT 'utf8mb4_uca1400_ai_ci' AS audit_mysql_simple UNION ALL SELECT '4302' UNION ALL SELECT '4303'"
+	mysqlRows, err := testEnv.MyDuckServer.Query(mysqlSimple)
+	requireSQLRows(t, mysqlRows, err, 3)
+
+	mysqlPrepared := "SELECT ? AS audit_mysql_prepared UNION ALL SELECT 4305"
+	stmt, err := testEnv.MyDuckServer.Prepare(mysqlPrepared)
+	require.NoError(t, err)
+	mysqlRows, err = stmt.Query(4304)
+	requireSQLRows(t, mysqlRows, err, 2)
+	require.NoError(t, stmt.Close())
+
+	mysqlMulti := "SELECT 4310 AS audit_mysql_multi_first; SELECT 4311 AS audit_mysql_multi_second UNION ALL SELECT 4312"
+	multiDB, err := sql.Open("mysql", fmt.Sprintf("root@tcp(127.0.0.1:%d)/?multiStatements=true", testEnv.DuckPort))
+	require.NoError(t, err)
+	defer multiDB.Close()
+	mysqlRows, err = multiDB.Query(mysqlMulti)
+	requireSQLResultSets(t, mysqlRows, err, []int{1, 2})
+
+	ctx := context.Background()
+	pgConfig, err := pgx.ParseConfig("postgresql://audit_pg_user@127.0.0.1:" + strconv.Itoa(testEnv.DuckPgPort) + "/postgres")
+	require.NoError(t, err)
+	pgConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+	pgConn, err := pgx.ConnectConfig(ctx, pgConfig)
+	require.NoError(t, err)
+	defer pgConn.Close(ctx)
+
+	pgSimple := "SELECT generate_series AS audit_pg_simple FROM generate_series(1, 130)"
+	requirePgQueryRows(t, ctx, pgConn, pgSimple, 130)
+
+	pgPrepared := "SELECT $1::INTEGER AS audit_pg_prepared UNION ALL SELECT 4309"
+	_, err = pgConn.Prepare(ctx, "audit_pg_prepared", pgPrepared)
+	require.NoError(t, err)
+	requirePgQueryRows(t, ctx, pgConn, "audit_pg_prepared", 2, 4308)
+
+	pgShowSimple := "SHOW search_path"
+	requirePgQueryRows(t, ctx, pgConn, pgShowSimple, 1)
+
+	pgShowPrepared := "SHOW application_name"
+	_, err = pgConn.Prepare(ctx, "audit_pg_show", pgShowPrepared)
+	require.NoError(t, err)
+	requirePgQueryRows(t, ctx, pgConn, "audit_pg_show", 1)
+
+	pgPSQL := "select n.nspname as \"name\",\n  pg_catalog.pg_get_userbyid(n.nspowner) as \"owner\"\nfrom pg_catalog.pg_namespace n\nwhere n.nspname !~ '^pg_' and n.nspname <> 'information_schema'\norder by 1;"
+	requirePgQueryRows(t, ctx, pgConn, pgPSQL, 1)
+
+	pgWorkbench := "SELECT * FROM CURRENT_DATABASE();"
+	_, err = pgConn.Exec(ctx, pgWorkbench)
+	require.Error(t, err)
+
+	require.NoError(t, testEnv.DuckLogFile.Sync())
+	expectations := [][]string{
+		{"audit=query", "protocol=mysql", "user=root", "rows=3", fmt.Sprintf("query=%q", mysqlSimple)},
+		{"audit=query", "protocol=mysql", "user=root", "rows=2", fmt.Sprintf("query=%q", mysqlPrepared)},
+		{"audit=query", "protocol=mysql", "user=root", "rows=1", fmt.Sprintf("query=%q", mysqlMulti)},
+		{"audit=query", "protocol=mysql", "user=root", "rows=2", `query=" SELECT 4311 AS audit_mysql_multi_second UNION ALL SELECT 4312"`},
+		{"audit=query", "protocol=postgres", "user=audit_pg_user", "rows=130", fmt.Sprintf("query=%q", pgSimple)},
+		{"audit=query", "protocol=postgres", "user=audit_pg_user", "rows=2", fmt.Sprintf("query=%q", pgPrepared)},
+		{"audit=query", "protocol=postgres", "user=audit_pg_user", "rows=1", fmt.Sprintf("query=%q", pgShowSimple)},
+		{"audit=query", "protocol=postgres", "user=audit_pg_user", "rows=1", fmt.Sprintf("query=%q", pgShowPrepared)},
+		{"audit=query", "protocol=postgres", "user=audit_pg_user", "rows=1", fmt.Sprintf("query=%q", pgPSQL)},
+		{"audit=query", "protocol=postgres", "user=audit_pg_user", "rows=0", "error=", fmt.Sprintf("query=%q", pgWorkbench)},
+	}
+
+	var logContents string
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		contents, readErr := os.ReadFile(testEnv.DuckLogFilePath)
+		assert.NoError(collect, readErr)
+		logContents = string(contents)
+		for _, expectation := range expectations {
+			assertAuditLine(collect, logContents, expectation)
+		}
+		assert.Len(collect, auditLines(logContents), len(expectations))
+	}, 3*time.Second, 25*time.Millisecond, "query audit records not found in %s:\n%s", testEnv.DuckLogFilePath, logContents)
+}
+
+func requireSQLRows(t *testing.T, rows *sql.Rows, err error, expected int) {
+	t.Helper()
+	require.NoError(t, err)
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		count++
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, expected, count)
+}
+
+func requireSQLResultSets(t *testing.T, rows *sql.Rows, err error, expected []int) {
+	t.Helper()
+	require.NoError(t, err)
+	defer rows.Close()
+
+	actual := make([]int, 0, len(expected))
+	for {
+		count := 0
+		for rows.Next() {
+			count++
+		}
+		require.NoError(t, rows.Err())
+		actual = append(actual, count)
+		if !rows.NextResultSet() {
+			break
+		}
+	}
+	require.Equal(t, expected, actual)
+}
+
+func requirePgQueryRows(t *testing.T, ctx context.Context, conn *pgx.Conn, query string, expected int, args ...any) {
+	t.Helper()
+	rows, err := conn.Query(ctx, query, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		count++
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, expected, count)
+}
+
+func assertAuditLine(t assert.TestingT, contents string, fields []string) {
+	for _, line := range strings.Split(contents, "\n") {
+		matches := true
+		for _, field := range fields {
+			if !strings.Contains(line, field) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return
+		}
+	}
+	assert.Fail(t, "query audit record not found", "required fields: %v", fields)
+}
+
+func auditLines(contents string) []string {
+	var lines []string
+	for _, line := range strings.Split(contents, "\n") {
+		if strings.Contains(line, "audit=query") {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}


### PR DESCRIPTION
## Summary
- emit one structured `audit=query` info record for completed ordinary MySQL/Postgres query executions
- record protocol user, pre-rewrite SQL text, and rows successfully returned through protocol callbacks
- cover MySQL text, multi-statement, prepared/extended execution and PostgreSQL simple/extended execution while leaving internal engine/replication paths unaudited
- preserve original PostgreSQL text across `SHOW`, PSQL, and Workbench in-place rewrites, including failed executions

## Verification
- exact-main first red: all four initial wire queries succeeded, then all audit-record assertions failed because no records existed
- `GOFLAGS='-tags=duckdb_arrow' go test . -run '^TestOrdinaryQueryAuditProtocols$' -count=3`
- `GOFLAGS='-tags=duckdb_arrow' go test ./backend -count=1`
- `GOFLAGS='-tags=duckdb_arrow' go test . -run '^(TestReadOnlyProtocols|TestReadOnlyDefaultOff)$' -count=1`
- `GOFLAGS='-tags=duckdb_arrow' go test ./pgserver -run '^TestQueryRowLimitOnMySQLAndPostgresSessions$' -count=1`
- `GOFLAGS='-tags=duckdb_arrow' go test ./pgserver -run '^(TestFuncReplacement|TestSessParam)$' -count=1` (each focused test also passed separately)
- `GOFLAGS='-tags=duckdb_arrow' go test ./... -run '^$' -count=1`
- `GOFLAGS='-tags=duckdb_arrow' go build ./...`
- `git diff --check`

The full same-process `pgserver` package still reproduces the existing testutil working-directory leak after earlier server-spawning tests; affected focused tests pass independently.

Parent: `db85a7d10977b058ea8172528b0825e17bc7f9c2`
Head: `fb89e316b714a1624d1668fc38c7a42a057906cb`
Tree: `b61c62377eda4ff70cfe3cdaa2537ca49b26b01f`
GitHub verification: `verified=true`, `reason=valid`, signer `web-flow`
