### PR TITLE
fix: support Dolt 2.3.1 GTID replication

### DIFF
--- a/.github/scripts/replication-test.sh
+++ b/.github/scripts/replication-test.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SOURCE=${1:?usage: replication-test.sh postgres|mysql|mariadb|dolt}
+MYDUCK_IMAGE=${MYDUCK_IMAGE:-myduckserver:replication-test}
+DOLT_IMAGE='dolthub/dolt-sql-server@sha256:dbd13efe2e19e02c079efd2152bca5032071a3cd6f79a9b2a7b404d19ff3ee3f'
+RESOURCE_SUFFIX="${GITHUB_RUN_ID:-local}-${SOURCE}-$$"
+NETWORK="myduck-replication-${RESOURCE_SUFFIX}"
+DATA_VOLUME="myduck-replication-data-${RESOURCE_SUFFIX}"
+SOURCE_CONTAINER="source-db-${RESOURCE_SUFFIX}"
+MYDUCK_CONTAINER="myduck-${RESOURCE_SUFFIX}"
+DOLT_CONFIG_DIR=""
+SCHEMA='test'
+SOURCE_DSN=""
+
+cleanup() {
+  docker rm -f "$MYDUCK_CONTAINER" "$SOURCE_CONTAINER" >/dev/null 2>&1 || true
+  docker volume rm "$DATA_VOLUME" >/dev/null 2>&1 || true
+  docker network rm "$NETWORK" >/dev/null 2>&1 || true
+  if [[ -n "$DOLT_CONFIG_DIR" && -d "$DOLT_CONFIG_DIR" ]]; then
+    rm -rf "$DOLT_CONFIG_DIR"
+  fi
+}
+trap cleanup EXIT
+
+docker network create "$NETWORK" >/dev/null
+docker volume create "$DATA_VOLUME" >/dev/null
+docker run --rm --user root \
+  --volume "$DATA_VOLUME:/home/admin/data" \
+  --entrypoint /bin/sh "$MYDUCK_IMAGE" \
+  -c 'chown -R admin:admin /home/admin/data'
+
+wait_for_source() {
+  local attempt
+  for attempt in {1..60}; do
+    if ! docker inspect "$SOURCE_CONTAINER" --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+      docker logs "$SOURCE_CONTAINER" || true
+      return 1
+    fi
+
+    case "$SOURCE" in
+      postgres)
+        docker exec "$SOURCE_CONTAINER" pg_isready -U postgres >/dev/null 2>&1 && return 0
+        ;;
+      mysql)
+        docker exec "$SOURCE_CONTAINER" mysql -uroot -proot -e "SELECT 1" >/dev/null 2>&1 && return 0
+        ;;
+      mariadb)
+        docker exec "$SOURCE_CONTAINER" mariadb -uroot -proot -e "SELECT 1" >/dev/null 2>&1 && return 0
+        ;;
+      dolt)
+        docker exec "$SOURCE_CONTAINER" dolt sql -q "SELECT 1" >/dev/null 2>&1 && return 0
+        ;;
+    esac
+    sleep 2
+  done
+
+  docker logs "$SOURCE_CONTAINER" || true
+  return 1
+}
+
+source_sql() {
+  local statement=$1
+  case "$SOURCE" in
+    postgres)
+      docker exec "$SOURCE_CONTAINER" psql -v ON_ERROR_STOP=1 -U postgres -d test -c "$statement"
+      ;;
+    mysql)
+      docker exec "$SOURCE_CONTAINER" mysql -uroot -proot -e "$statement"
+      ;;
+    mariadb)
+      docker exec "$SOURCE_CONTAINER" mariadb -uroot -proot -e "$statement"
+      ;;
+    dolt)
+      docker exec "$SOURCE_CONTAINER" dolt sql -q "$statement"
+      ;;
+  esac
+}
+
+create_source_data() {
+  if [[ "$SOURCE" == "postgres" ]]; then
+    source_sql "
+      CREATE TABLE items (id INT PRIMARY KEY, name VARCHAR(50));
+      INSERT INTO items VALUES (1, 'test1'), (2, 'test2');"
+  else
+    source_sql "
+      CREATE DATABASE IF NOT EXISTS test;
+      CREATE TABLE test.items (id INT PRIMARY KEY, name VARCHAR(50));
+      INSERT INTO test.items VALUES (1, 'test1'), (2, 'test2');
+      CREATE TABLE test.skip (id INT PRIMARY KEY, name VARCHAR(50));
+      INSERT INTO test.skip VALUES (1, 'abc'), (2, 'def');"
+  fi
+}
+
+case "$SOURCE" in
+  postgres)
+    SCHEMA=public
+    SOURCE_DSN='postgres://postgres:postgres@source:5432/test'
+    docker run -d --name "$SOURCE_CONTAINER" --network "$NETWORK" --network-alias source \
+      -e POSTGRES_PASSWORD=postgres \
+      -e POSTGRES_DB=test \
+      postgres:latest \
+      -c wal_level=logical >/dev/null
+    ;;
+  mysql)
+    SOURCE_DSN="mysql://root:root@${SOURCE_CONTAINER}:3306/test?skip-tables=test.skip"
+    docker run -d --name "$SOURCE_CONTAINER" --network "$NETWORK" \
+      -e MYSQL_ROOT_PASSWORD=root \
+      -e MYSQL_ROOT_HOST=% \
+      -e MYSQL_DATABASE=test \
+      mysql:8.4 \
+      --gtid-mode=ON \
+      --enforce-gtid-consistency=ON \
+      --binlog-format=ROW >/dev/null
+    ;;
+  mariadb)
+    SOURCE_DSN="mysql://root:root@${SOURCE_CONTAINER}:3306/test?skip-tables=test.skip"
+    docker run -d --name "$SOURCE_CONTAINER" --network "$NETWORK" \
+      -e MARIADB_ROOT_PASSWORD=root \
+      -e MARIADB_ROOT_HOST=% \
+      -e MARIADB_DATABASE=test \
+      mariadb:11.4 \
+      --gtid-strict-mode=1 \
+      --log-bin=mybinlog \
+      --binlog-format=ROW >/dev/null
+    ;;
+  dolt)
+    SOURCE_DSN="mysql://replicator:replicator@${SOURCE_CONTAINER}:3306/test?skip-tables=test.skip"
+    DOLT_CONFIG_DIR=$(mktemp -d)
+    cat >"$DOLT_CONFIG_DIR/config.json" <<'JSON'
+{
+  "sqlserver.global.enforce_gtid_consistency": "ON",
+  "sqlserver.global.gtid_mode": "ON",
+  "sqlserver.global.log_bin": "1"
+}
+JSON
+    docker run -d --name "$SOURCE_CONTAINER" --network "$NETWORK" \
+      --volume "$DOLT_CONFIG_DIR/config.json:/etc/dolt/doltcfg.d/config.json:ro" \
+      "$DOLT_IMAGE" >/dev/null
+    ;;
+  *)
+    echo "unsupported source: $SOURCE" >&2
+    exit 2
+    ;;
+esac
+
+wait_for_source
+
+if [[ "$SOURCE" == "dolt" ]]; then
+  source_sql "
+    CREATE DATABASE test;
+    CREATE USER 'replicator'@'%' IDENTIFIED BY 'replicator';
+    GRANT SELECT, RELOAD, REPLICATION CLIENT, REPLICATION SLAVE, SHOW VIEW, EVENT
+      ON *.* TO 'replicator'@'%';"
+else
+  create_source_data
+fi
+
+start_myduck() {
+  local mode=$1
+  local args=(
+    -d --name "$MYDUCK_CONTAINER" --network "$NETWORK"
+    --volume "$DATA_VOLUME:/home/admin/data"
+    --env "SETUP_MODE=$mode"
+  )
+  if [[ "$mode" == "REPLICA" ]]; then
+    args+=(--env "SOURCE_DSN=$SOURCE_DSN")
+  fi
+  docker run "${args[@]}" "$MYDUCK_IMAGE" >/dev/null
+}
+
+wait_for_myduck_setup() {
+  local attempt
+  for attempt in {1..90}; do
+    if ! docker inspect "$MYDUCK_CONTAINER" --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+      docker logs "$MYDUCK_CONTAINER" || true
+      return 1
+    fi
+    if docker logs "$MYDUCK_CONTAINER" 2>&1 | grep -q 'Replica setup completed.'; then
+      return 0
+    fi
+    sleep 2
+  done
+  docker logs "$MYDUCK_CONTAINER" || true
+  return 1
+}
+
+wait_for_myduck_ready() {
+  local attempt
+  for attempt in {1..60}; do
+    if docker exec "$MYDUCK_CONTAINER" psql -XAt -h 127.0.0.1 -U postgres -c 'SELECT 1' 2>/dev/null | grep -qx 1; then
+      return 0
+    fi
+    if ! docker inspect "$MYDUCK_CONTAINER" --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+      docker logs "$MYDUCK_CONTAINER" || true
+      return 1
+    fi
+    sleep 2
+  done
+  docker logs "$MYDUCK_CONTAINER" || true
+  return 1
+}
+
+myduck_scalar() {
+  local statement=$1
+  docker exec "$MYDUCK_CONTAINER" psql -XAt -h 127.0.0.1 -U postgres -c "$statement" | tr -d '[:space:]'
+}
+
+myduck_mysql() {
+  local statement=$1
+  docker exec "$MYDUCK_CONTAINER" mysqlsh --sql --host 127.0.0.1 --port 3306 \
+    --user root --no-password --result-format=tabbed --execute "$statement"
+}
+
+myduck_mysql_scalar() {
+  local statement=$1
+  myduck_mysql "$statement" | tail -n 1 | tr -d '[:space:]'
+}
+
+source_rows() {
+  case "$SOURCE" in
+    postgres)
+      docker exec "$SOURCE_CONTAINER" psql -XAt -U postgres -d test \
+        -c "SELECT id || ':' || name FROM items ORDER BY id"
+      ;;
+    mysql)
+      docker exec "$SOURCE_CONTAINER" mysql --batch --skip-column-names -uroot -proot test \
+        -e "SELECT CONCAT(id, ':', name) FROM items ORDER BY id"
+      ;;
+    mariadb)
+      docker exec "$SOURCE_CONTAINER" mariadb --batch --skip-column-names -uroot -proot test \
+        -e "SELECT CONCAT(id, ':', name) FROM items ORDER BY id"
+      ;;
+    dolt)
+      docker exec "$SOURCE_CONTAINER" dolt sql --result-format csv -q \
+        "SELECT CONCAT(id, ':', name) AS row_value FROM test.items ORDER BY id" \
+        | tail -n +2 | tr -d '\r'
+      ;;
+  esac
+}
+
+myduck_rows() {
+  docker exec "$MYDUCK_CONTAINER" psql -XAt -h 127.0.0.1 -U postgres \
+    -c "SELECT id || ':' || name FROM ${SCHEMA}.items ORDER BY id"
+}
+
+wait_for_count() {
+  local expected=$1
+  local attempt got
+  # The attempt value is only used to bound retries.
+  # shellcheck disable=SC2034
+  for attempt in {1..60}; do
+    got=$(myduck_scalar "SELECT COUNT(*) FROM ${SCHEMA}.items" 2>/dev/null || true)
+    if [[ "$got" == "$expected" ]]; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "expected ${SCHEMA}.items count=$expected, got=${got:-query failed}" >&2
+  docker logs "$MYDUCK_CONTAINER" || true
+  return 1
+}
+
+record_phase() {
+  local phase=$1
+  echo "===== $SOURCE / $phase ====="
+  myduck_mysql "
+    SELECT @@GLOBAL.gtid_executed AS gtid_executed;
+    SELECT * FROM __sys__.binlog_position;
+    SELECT COUNT(*) AS total_rows, COUNT(DISTINCT id) AS unique_rows FROM ${SCHEMA}.items;
+    SHOW REPLICA STATUS\G"
+}
+
+assert_row_count() {
+  local expected=$1
+  local counts
+  counts=$(myduck_scalar "SELECT CONCAT(COUNT(*), ':', COUNT(DISTINCT id)) FROM ${SCHEMA}.items")
+  [[ "$counts" == "$expected:$expected" ]]
+}
+
+assert_rows_match_source() {
+  local expected=$1 source_values replica_values actual_count
+  source_values=$(source_rows | tr -d '\r')
+  replica_values=$(myduck_rows | tr -d '\r')
+  if [[ "$replica_values" != "$source_values" ]]; then
+    echo "source rows: ${source_values@Q}" >&2
+    echo "replica rows: ${replica_values@Q}" >&2
+    return 1
+  fi
+  actual_count=$(printf '%s\n' "$replica_values" | awk 'NF { count++ } END { print count + 0 }')
+  [[ "$actual_count" == "$expected" ]]
+}
+
+assert_skip_table_absent() {
+  local skipped_tables skipped_rows
+  skipped_tables=$(myduck_scalar \
+    "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='test' AND table_name='skip'")
+  if [[ "$skipped_tables" == 0 ]]; then
+    return 0
+  fi
+  skipped_rows=$(myduck_scalar "SELECT COUNT(*) FROM test.skip")
+  [[ "$skipped_rows" == 0 ]]
+}
+
+start_myduck REPLICA
+wait_for_myduck_setup
+
+if [[ "$SOURCE" == "dolt" ]]; then
+  create_source_data
+fi
+
+wait_for_count 2
+assert_rows_match_source 2
+if [[ "$SOURCE" != "postgres" ]]; then
+  assert_skip_table_absent
+fi
+record_phase initial
+
+source_sql "INSERT INTO ${SCHEMA}.items VALUES (3, 'test3');"
+wait_for_count 3
+assert_rows_match_source 3
+record_phase incremental
+
+if [[ "$SOURCE" == "dolt" ]]; then
+  position_before_stop=$(myduck_mysql_scalar 'SELECT @@GLOBAL.gtid_executed')
+  myduck_mysql 'STOP REPLICA;'
+  source_sql "INSERT INTO test.items VALUES (4, 'test4');"
+  sleep 3
+  assert_row_count 3
+  source_position_after_stop=$(docker exec "$SOURCE_CONTAINER" dolt sql --result-format csv -q \
+    'SELECT @@GLOBAL.gtid_executed' | tail -n 1 | tr -d '[:space:]')
+
+  myduck_mysql 'START REPLICA;'
+  wait_for_count 4
+  assert_rows_match_source 4
+  position_after_start=$(myduck_mysql_scalar 'SELECT @@GLOBAL.gtid_executed')
+  [[ "$position_after_start" == "$source_position_after_stop" ]]
+  [[ "$position_after_start" != "$position_before_stop" ]]
+  record_phase stop-start
+
+  docker rm -f "$MYDUCK_CONTAINER" >/dev/null
+  source_sql "INSERT INTO test.items VALUES (5, 'test5');"
+  source_position_before_restart=$(docker exec "$SOURCE_CONTAINER" dolt sql --result-format csv -q \
+    'SELECT @@GLOBAL.gtid_executed' | tail -n 1 | tr -d '[:space:]')
+  start_myduck SERVER
+  wait_for_myduck_ready
+  wait_for_count 5
+  assert_rows_match_source 5
+  [[ "$(myduck_mysql_scalar 'SELECT @@GLOBAL.gtid_executed')" == "$source_position_before_restart" ]]
+  record_phase process-restart
+fi
+
+expected_rows=3
+if [[ "$SOURCE" == "dolt" ]]; then
+  expected_rows=5
+fi
+
+assert_rows_match_source "$expected_rows"
+[[ "$(myduck_mysql_scalar "SELECT COUNT(*) FROM ${SCHEMA}.items")" == "$expected_rows" ]]
+
+if [[ "$SOURCE" != "postgres" ]]; then
+  assert_skip_table_absent
+fi
+
+if [[ "$SOURCE" != "postgres" ]]; then
+  status=$(myduck_mysql 'SHOW REPLICA STATUS\G')
+  grep -Eq 'Replica_IO_Running:[[:space:]]+Yes' <<<"$status"
+  grep -Eq 'Replica_SQL_Running:[[:space:]]+Yes' <<<"$status"
+  if [[ "$SOURCE" != "mariadb" ]]; then
+    grep -Eq 'Last_IO_Errno:[[:space:]]+0' <<<"$status"
+    grep -Eq 'Last_SQL_Errno:[[:space:]]+0' <<<"$status"
+  fi
+fi
+
+echo "$SOURCE replication regression passed"

--- a/.github/workflows/replication-test.yml
+++ b/.github/workflows/replication-test.yml
@@ -2,239 +2,33 @@ name: Docker Replica Mode Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
+  pull_request:
 
 jobs:
   test-replication:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        source: ['postgres', 'mysql', 'mariadb', 'dolt']
+        source: ["postgres", "mysql", "mariadb", "dolt"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build MyDuck from current checkout
         run: |
-          # Only install DuckDB for data comparison
-          curl -LJO https://github.com/duckdb/duckdb/releases/latest/download/duckdb_cli-linux-amd64.zip
-          unzip duckdb_cli-linux-amd64.zip
-          chmod +x duckdb
-          sudo mv duckdb /usr/local/bin
+          docker buildx build \
+            --load \
+            --platform linux/amd64 \
+            --file docker/Dockerfile \
+            --tag myduckserver:replication-test \
+            --build-arg VERSION=replication-test \
+            --build-arg GIT_COMMIT="${GITHUB_SHA}" \
+            .
 
-      - name: Start source ${{ matrix.source }} database
-        run: |
-          if [ "${{ matrix.source }}" = "mysql" ]; then
-            docker run -d --name source-db -p 3306:3306 \
-              -e MYSQL_ROOT_PASSWORD=root \
-              -e MYSQL_DATABASE=test \
-              mysql:lts
-
-          elif [ "${{ matrix.source }}" = "mariadb" ]; then
-            docker run -d --name source-db -p 3306:3306 \
-              -e MARIADB_ROOT_PASSWORD=root \
-              -e MARIADB_DATABASE=test \
-              mariadb:latest \
-              --gtid-strict-mode=1 \
-              --log-bin=mybinlog \
-              --binlog-format=ROW
-
-          elif [ "${{ matrix.source }}" = "dolt" ]; then
-            # Create Dolt config
-            mkdir -p doltcfg
-            cat <<EOF > doltcfg/config.json
-          {
-            "sqlserver.global.enforce_gtid_consistency": "ON",
-            "sqlserver.global.gtid_mode": "ON",
-            "sqlserver.global.log_bin": "1"
-          }
-          EOF
-
-            docker run -d --name source-db -p 3306:3306 \
-              -v "$(pwd)/doltcfg":/etc/dolt/doltcfg.d/ \
-              dolthub/dolt-sql-server:latest \
-              -u root -p root
-
-          elif [ "${{ matrix.source }}" = "postgres" ]; then
-            docker run -d --name source-db -p 5432:5432 \
-              -e POSTGRES_PASSWORD=postgres \
-              -e POSTGRES_DB=test \
-              postgres:latest \
-              -c wal_level=logical
-          fi
-
-          # Wait for database to be ready
-          if [ "${{ matrix.source }}" = "postgres" ]; then
-            until docker exec source-db pg_isready; do
-              sleep 1
-            done
-          elif [ "${{ matrix.source }}" = "dolt" ]; then
-            until docker exec source-db dolt sql -q "SELECT 1"; do
-              sleep 1
-            done
-          elif [ "${{ matrix.source }}" = "mariadb" ]; then
-            until docker exec source-db mariadb -uroot -proot -e "SELECT 1"; do
-              sleep 1
-            done
-          else
-            until docker exec source-db mysql -uroot -proot -e "SELECT 1"; do
-              sleep 1
-            done
-          fi
-
-          # Create test data
-          if [ "${{ matrix.source }}" = "postgres" ]; then
-            docker exec source-db psql -U postgres test -c "
-              CREATE TABLE items (id INT PRIMARY KEY, name VARCHAR(50));
-              INSERT INTO items VALUES (1, 'test1'), (2, 'test2');"
-          elif [ "${{ matrix.source }}" = "dolt" ]; then
-            docker exec source-db dolt sql -q "
-              CREATE DATABASE test;
-              CREATE TABLE test.items (id INT PRIMARY KEY, name VARCHAR(50));
-              INSERT INTO test.items VALUES (1, 'test1'), (2, 'test2');
-              CREATE TABLE test.skip (id INT PRIMARY KEY, name VARCHAR(50));
-              INSERT INTO test.skip VALUES (1, 'abc'), (2, 'def');"
-          elif [ "${{ matrix.source }}" = "mariadb" ]; then
-            docker exec source-db mariadb -uroot -proot test -e "
-              CREATE TABLE items (id INT PRIMARY KEY, name VARCHAR(50));
-              INSERT INTO items VALUES (1, 'test1'), (2, 'test2');
-              CREATE TABLE skip (id INT PRIMARY KEY, name VARCHAR(50));
-              INSERT INTO skip VALUES (1, 'abc'), (2, 'def');"
-          else
-            docker exec source-db mysql -uroot -proot test -e "
-              CREATE TABLE items (id INT PRIMARY KEY, name VARCHAR(50));
-              INSERT INTO items VALUES (1, 'test1'), (2, 'test2');
-              CREATE TABLE skip (id INT PRIMARY KEY, name VARCHAR(50));
-              INSERT INTO skip VALUES (1, 'abc'), (2, 'def');"
-          fi
-
-      - name: Start MyDuck Server in replica mode
-        run: |
-          if [ "${{ matrix.source }}" = "postgres" ]; then
-            SOURCE_DSN="postgres://postgres:postgres@host.docker.internal:5432/test"
-          else
-            SOURCE_DSN="mysql://root:root@host.docker.internal:3306/test?skip-tables=test.skip"
-          fi
-
-          docker run -d --name myduck \
-            --add-host=host.docker.internal:host-gateway \
-            -p 13306:3306 \
-            -p 15432:5432 \
-            --env=SETUP_MODE=REPLICA \
-            --env=SOURCE_DSN="$SOURCE_DSN" \
-            apecloud/myduckserver:latest
-
-          # Wait and check container status
-          for i in {1..15}; do
-            if ! docker ps | grep -q myduck; then
-              echo "MyDuck container exited unexpectedly"
-              docker logs myduck
-              exit 1
-            fi
-            sleep 1
-          done
-
-      - name: Verify initial replication
-        run: |
-          # Query source data
-          SCHEMA=""
-          if [ "${{ matrix.source }}" = "postgres" ]; then
-            docker exec source-db psql -U postgres -h 127.0.0.1 test \
-              -c "\COPY (SELECT * FROM items ORDER BY id) TO STDOUT WITH CSV;" | tee source_data.csv
-            SCHEMA=public
-          elif [ "${{ matrix.source }}" = "dolt" ]; then
-            docker exec source-db dolt sql --result-format csv -q "SELECT * FROM test.items ORDER BY id" | tee source_data.csv
-            SCHEMA=test
-          elif [ "${{ matrix.source }}" = "mariadb" ]; then
-            docker exec source-db mariadb -uroot -proot test \
-              -e "SELECT * FROM items ORDER BY id;" | tee source_data.csv
-            SCHEMA=test
-          else
-            docker exec source-db mysql -uroot -proot test \
-              -e "SELECT * FROM items ORDER BY id;" | tee source_data.csv
-            SCHEMA=test
-          fi
-
-          # Query MyDuck data
-          docker exec myduck psql -U postgres -h 127.0.0.1 \
-            -c "\COPY (SELECT * FROM ${SCHEMA}.items ORDER BY id) TO STDOUT WITH CSV;" | tee myduck_data.csv
-
-          # Compare data using DuckDB
-          duckdb --csv -c "
-            CREATE TABLE source AS FROM 'source_data.csv';
-            CREATE TABLE myduck AS FROM 'myduck_data.csv';
-            SELECT COUNT(*) FROM (
-              SELECT * FROM source EXCEPT SELECT * FROM myduck
-            ) diff;" | tail -n 1 | tee diff_count.txt
-
-          # Verify no differences
-          if grep -q '^0$' diff_count.txt; then
-            echo 'Initial replication verification successful'
-          else
-            echo 'Initial replication verification failed'
-            exit 1
-          fi
-
-      - name: Test replication of new data
-        run: |
-          # Insert new data in source
-          SCHEMA=""
-          if [ "${{ matrix.source }}" = "postgres" ]; then
-            docker exec source-db psql -U postgres test \
-              -c "INSERT INTO items VALUES (3, 'test3');"
-            SCHEMA=public
-          elif [ "${{ matrix.source }}" = "dolt" ]; then
-            docker exec source-db dolt sql -q "INSERT INTO test.items VALUES (3, 'test3');"
-            SCHEMA=test
-          elif [ "${{ matrix.source }}" = "mariadb" ]; then
-            docker exec source-db mariadb -uroot -proot test \
-              -e "INSERT INTO items VALUES (3, 'test3');"
-            SCHEMA=test
-          else
-            docker exec source-db mysql -uroot -proot test \
-              -e "INSERT INTO items VALUES (3, 'test3');"
-            SCHEMA=test
-          fi
-
-          # Wait for replication
-          sleep 10
-
-          # Verify new data was replicated
-          docker exec myduck psql -t -U postgres -h 127.0.0.1 -c \
-            "SELECT COUNT(*) FROM ${SCHEMA}.items WHERE id = 3;" | tr -d ' ' | tee count.txt
-
-          if grep -q '^1$' count.txt; then
-            echo 'Replication of new data verified successfully'
-          else
-            echo 'Replication of new data verification failed'
-            exit 1
-          fi
-
-          # Print the logs
-          docker logs myduck
-
-      - name: Verify skip tables
-        run: |
-          # Verify skipped table is empty (for MySQL-compatible databases only)
-          if [ "${{ matrix.source }}" != "postgres" ]; then
-            # Check if skip table exists and has any rows
-            TABLE_EXISTS=$(docker exec myduck psql -t -U postgres -h 127.0.0.1 -c \
-              "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '${SCHEMA}' AND table_name = 'skip';" | tr -d ' ')
-
-            if [ "$TABLE_EXISTS" -ne "0" ]; then
-              COUNT=$(docker exec myduck psql -t -U postgres -h 127.0.0.1 -c \
-                "SELECT COUNT(*) FROM ${SCHEMA}.skip;" | tr -d ' ')
-              if [ "$COUNT" -eq "0" ]; then
-                echo "Successfully verified that skipped table exists but is empty"
-              else
-                echo "Error: Skipped table 'skip' contains $COUNT rows when it should be empty"
-                exit 1
-              fi
-            else
-              echo "Successfully verified that skipped table does not exist in destination"
-            fi
-          fi
-
-      - name: Cleanup
-        if: always()
-        run: |
-          docker rm -f source-db myduck || true
+      - name: Test ${{ matrix.source }} replication
+        env:
+          MYDUCK_IMAGE: myduckserver:replication-test
+        run: bash .github/scripts/replication-test.sh "${{ matrix.source }}"

--- a/binlogreplication/binlog_dump_test.go
+++ b/binlogreplication/binlog_dump_test.go
@@ -1,0 +1,234 @@
+package binlogreplication
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dolthub/vitess/go/mysql"
+	"github.com/dolthub/vitess/go/sqltypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectBinlogDumpGTIDFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		results map[string]fetchResult
+		want    uint16
+	}{
+		{
+			name: "Dolt 2.3.1",
+			results: map[string]fetchResult{
+				"SELECT @@VERSION_COMMENT": {value: "Dolt"},
+				"SELECT DOLT_VERSION()":    {value: "2.3.1"},
+			},
+			want: mysql.BinlogThroughGTID,
+		},
+		{
+			name: "standard MySQL",
+			results: map[string]fetchResult{
+				"SELECT @@VERSION_COMMENT": {value: "MySQL Community Server - GPL"},
+			},
+		},
+		{
+			name: "version comment unavailable",
+			results: map[string]fetchResult{
+				"SELECT @@VERSION_COMMENT": {err: errors.New("unknown system variable")},
+			},
+		},
+		{
+			name: "Dolt version function unavailable",
+			results: map[string]fetchResult{
+				"SELECT @@VERSION_COMMENT": {value: "Dolt"},
+				"SELECT DOLT_VERSION()":    {err: errors.New("function DOLT_VERSION does not exist")},
+			},
+		},
+		{
+			name: "different Dolt version",
+			results: map[string]fetchResult{
+				"SELECT @@VERSION_COMMENT": {value: "Dolt"},
+				"SELECT DOLT_VERSION()":    {value: "2.3.2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, detectBinlogDumpGTIDFlags(fakeQueryExecutor(tt.results)))
+		})
+	}
+}
+
+func TestDetectSourceCapabilitiesToleratesOptionalProbeFailures(t *testing.T) {
+	tests := []struct {
+		name        string
+		probeResult fetchResult
+		results     map[string]fetchResult
+	}{
+		{
+			name:        "version comment unavailable",
+			probeResult: fetchResult{err: errors.New("unknown system variable")},
+		},
+		{
+			name:        "Dolt version function unavailable",
+			probeResult: fetchResult{value: "Dolt"},
+			results: map[string]fetchResult{
+				"SELECT DOLT_VERSION()": {err: errors.New("function DOLT_VERSION does not exist")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := map[string]fetchResult{
+				"SELECT VERSION()":          {value: "8.0.31"},
+				"SELECT @@VERSION_COMMENT":  tt.probeResult,
+				"SELECT @@GLOBAL.GTID_MODE": {value: "ON"},
+			}
+			for query, result := range tt.results {
+				results[query] = result
+			}
+
+			capabilities, err := detectSourceCapabilitiesFromQueries(fakeQueryExecutor(results))
+			require.NoError(t, err)
+			require.True(t, capabilities.gtidMode)
+			require.Equal(t, mysql56FlavorID, capabilities.flavorName)
+			require.Zero(t, capabilities.binlogDumpGTIDFlags)
+		})
+	}
+}
+
+func TestDetectSourceCapabilitiesLocksDumpFlags(t *testing.T) {
+	tests := []struct {
+		name       string
+		results    map[string]fetchResult
+		gtidMode   bool
+		flavorName string
+		flags      uint16
+	}{
+		{
+			name: "Dolt 2.3.1",
+			results: map[string]fetchResult{
+				"SELECT VERSION()":          {value: "8.0.31"},
+				"SELECT @@VERSION_COMMENT":  {value: "Dolt"},
+				"SELECT DOLT_VERSION()":     {value: "2.3.1"},
+				"SELECT @@GLOBAL.GTID_MODE": {value: "ON"},
+			},
+			gtidMode:   true,
+			flavorName: mysql56FlavorID,
+			flags:      mysql.BinlogThroughGTID,
+		},
+		{
+			name: "standard MySQL",
+			results: map[string]fetchResult{
+				"SELECT VERSION()":          {value: "8.0.31"},
+				"SELECT @@VERSION_COMMENT":  {value: "MySQL Community Server - GPL"},
+				"SELECT @@GLOBAL.GTID_MODE": {value: "ON"},
+			},
+			gtidMode:   true,
+			flavorName: mysql56FlavorID,
+		},
+		{
+			name: "MariaDB",
+			results: map[string]fetchResult{
+				"SELECT VERSION()":                 {value: "10.11.8-MariaDB"},
+				"SELECT @@GLOBAL.GTID_STRICT_MODE": {value: "ON"},
+			},
+			gtidMode:   true,
+			flavorName: mariadbFlavorID,
+		},
+		{
+			name: "identity query failure",
+			results: map[string]fetchResult{
+				"SELECT VERSION()":          {value: "8.0.31"},
+				"SELECT @@VERSION_COMMENT":  {err: errors.New("unknown system variable")},
+				"SELECT @@GLOBAL.GTID_MODE": {value: "ON"},
+			},
+			gtidMode:   true,
+			flavorName: mysql56FlavorID,
+		},
+		{
+			name: "Dolt not 2.3.1",
+			results: map[string]fetchResult{
+				"SELECT VERSION()":          {value: "8.0.31"},
+				"SELECT @@VERSION_COMMENT":  {value: "Dolt"},
+				"SELECT DOLT_VERSION()":     {value: "2.3.2"},
+				"SELECT @@GLOBAL.GTID_MODE": {value: "ON"},
+			},
+			gtidMode:   true,
+			flavorName: mysql56FlavorID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capabilities, err := detectSourceCapabilitiesFromQueries(fakeQueryExecutor(tt.results))
+			require.NoError(t, err)
+			require.Equal(t, tt.gtidMode, capabilities.gtidMode)
+			require.Equal(t, tt.flavorName, capabilities.flavorName)
+			require.Equal(t, tt.flags, capabilities.binlogDumpGTIDFlags)
+		})
+	}
+}
+
+func TestWriteComBinlogDumpGTIDOnlyForConfirmedDoltMySQL56(t *testing.T) {
+	mysql56, err := mysql.ParsePosition(
+		mysql56FlavorID,
+		"568333e9-2b06-4d33-9a6b-c2308c930c95:1-5",
+	)
+	require.NoError(t, err)
+	filePos, err := newFilePosition("binlog.000001", 4)
+	require.NoError(t, err)
+
+	require.True(t, useWriteComBinlogDumpGTID(mysql56, mysql.BinlogThroughGTID))
+	require.False(t, useWriteComBinlogDumpGTID(mysql56, 0))
+	require.False(t, useWriteComBinlogDumpGTID(filePos, mysql.BinlogThroughGTID))
+	require.False(t, useWriteComBinlogDumpGTID(filePos, 0))
+}
+
+func TestMySQL56BinlogDumpRequest(t *testing.T) {
+	position, err := mysql.ParsePosition(
+		mysql56FlavorID,
+		"568333e9-2b06-4d33-9a6b-c2308c930c95:1-5,"+
+			"a4f6b11d-5f66-4fca-9c4a-d871e1d09a52:1-3",
+	)
+	require.NoError(t, err)
+	wantSIDBlock := position.GTIDSet.(mysql.Mysql56GTIDSet).SIDBlock()
+
+	request, ok := newMySQL56BinlogDumpRequest(42, "mysql-bin.000007", position, mysql.BinlogThroughGTID)
+	require.True(t, ok)
+	require.Equal(t, uint32(42), request.serverID)
+	require.Equal(t, "mysql-bin.000007", request.binlogFile)
+	require.Equal(t, uint64(4), request.binlogPos)
+	require.Equal(t, uint16(mysql.BinlogThroughGTID), request.flags)
+	require.Equal(t, wantSIDBlock, request.sidBlock)
+
+	request, ok = newMySQL56BinlogDumpRequest(42, "mysql-bin.000007", position, 0)
+	require.True(t, ok)
+	require.Zero(t, request.flags)
+	require.Equal(t, "mysql-bin.000007", request.binlogFile)
+	require.Equal(t, uint64(4), request.binlogPos)
+	require.Equal(t, wantSIDBlock, request.sidBlock)
+
+	filePosition, err := newFilePosition("binlog.000001", 4)
+	require.NoError(t, err)
+	_, ok = newMySQL56BinlogDumpRequest(42, "binlog.000001", filePosition, mysql.BinlogThroughGTID)
+	require.False(t, ok)
+}
+
+type fetchResult struct {
+	value string
+	err   error
+}
+
+type fakeQueryExecutor map[string]fetchResult
+
+func (f fakeQueryExecutor) ExecuteFetch(query string, _ int, _ bool) (*sqltypes.Result, error) {
+	result, ok := f[query]
+	if !ok {
+		return nil, errors.New("unexpected query: " + query)
+	}
+	if result.err != nil {
+		return nil, result.err
+	}
+	return &sqltypes.Result{Rows: [][]sqltypes.Value{{sqltypes.NewVarChar(result.value)}}}, nil
+}

--- a/binlogreplication/binlog_position_atomicity_test.go
+++ b/binlogreplication/binlog_position_atomicity_test.go
@@ -1,0 +1,100 @@
+package binlogreplication
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apecloud/myduckserver/adapter"
+	"github.com/apecloud/myduckserver/backend"
+	"github.com/apecloud/myduckserver/catalog"
+	"github.com/dolthub/go-mysql-server/memory"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/vitess/go/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBinlogPositionAndAppliedDataShareCommitBoundary(t *testing.T) {
+	dataDir := t.TempDir()
+	provider, err := catalog.NewDBProvider("", dataDir, "myduck")
+	require.NoError(t, err)
+
+	_, err = provider.Storage().ExecContext(
+		context.Background(),
+		"CREATE SCHEMA test; CREATE TABLE test.commit_boundary (id INTEGER)",
+	)
+	require.NoError(t, err)
+
+	position, err := mysql.ParsePosition(
+		mysql56FlavorID,
+		"568333e9-2b06-4d33-9a6b-c2308c930c95:1",
+	)
+	require.NoError(t, err)
+
+	apply := func(applyCtx *sql.Context, id int, commit bool) {
+		dataTxn, err := adapter.GetTxn(applyCtx, nil)
+		require.NoError(t, err)
+		catalogTxn, err := adapter.GetCatalogTxn(applyCtx, nil)
+		require.NoError(t, err)
+		require.Same(t, dataTxn, catalogTxn)
+
+		_, err = dataTxn.ExecContext(applyCtx, "INSERT INTO test.commit_boundary VALUES (?)", id)
+		require.NoError(t, err)
+		require.NoError(t, positionStore.Save(applyCtx, nil, position))
+
+		if commit {
+			require.NoError(t, dataTxn.Commit())
+		} else {
+			require.NoError(t, dataTxn.Rollback())
+		}
+		adapter.CloseTxn(applyCtx)
+	}
+
+	// Simulate a failure after Save and before commit. Neither side may persist.
+	applyCtx := newBinlogTestContext(provider, 1, "test")
+	observerCtx := newBinlogTestContext(provider, 2, "")
+	apply(applyCtx, 1, false)
+	assertBinlogCommitCounts(t, observerCtx, 0, 0)
+	adapter.CloseConn(applyCtx)
+	adapter.CloseConn(observerCtx)
+	require.NoError(t, provider.Close())
+
+	provider, err = catalog.NewDBProvider("", dataDir, "myduck")
+	require.NoError(t, err)
+	observerCtx = newBinlogTestContext(provider, 3, "")
+	assertBinlogCommitCounts(t, observerCtx, 0, 0)
+
+	applyCtx = newBinlogTestContext(provider, 4, "test")
+	apply(applyCtx, 2, true)
+	assertBinlogCommitCounts(t, observerCtx, 1, 1)
+	adapter.CloseConn(applyCtx)
+	adapter.CloseConn(observerCtx)
+	require.NoError(t, provider.Close())
+
+	provider, err = catalog.NewDBProvider("", dataDir, "myduck")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, provider.Close()) })
+	assertBinlogCommitCounts(t, newBinlogTestContext(provider, 5, ""), 1, 1)
+}
+
+func newBinlogTestContext(provider *catalog.DatabaseProvider, id uint32, database string) *sql.Context {
+	base := sql.NewBaseSessionWithClientServer("", sql.Client{}, id)
+	session := backend.NewSession(memory.NewSession(base, provider), provider)
+	session.SetCurrentDatabase(database)
+	return sql.NewContext(context.Background(), sql.WithSession(session))
+}
+
+func assertBinlogCommitCounts(t *testing.T, ctx *sql.Context, dataRows, positions int) {
+	t.Helper()
+
+	var gotDataRows, gotPositions int
+	require.NoError(t, adapter.QueryRowCatalog(
+		ctx,
+		"SELECT COUNT(*) FROM test.commit_boundary",
+	).Scan(&gotDataRows))
+	require.NoError(t, adapter.QueryRowCatalog(
+		ctx,
+		catalog.InternalTables.BinlogPosition.CountAllStmt(),
+	).Scan(&gotPositions))
+	require.Equal(t, dataRows, gotDataRows)
+	require.Equal(t, positions, gotPositions)
+}

--- a/binlogreplication/binlog_replica_applier.go
+++ b/binlogreplication/binlog_replica_applier.go
@@ -59,6 +59,16 @@ type queryFlushRequest struct {
 	response chan error
 }
 
+type sourceCapabilities struct {
+	gtidMode            bool
+	flavorName          string
+	binlogDumpGTIDFlags uint16
+}
+
+type queryExecutor interface {
+	ExecuteFetch(query string, maxrows int, wantfields bool) (*sqltypes.Result, error)
+}
+
 // binlogReplicaApplier represents the process that applies updates from a binlog connection.
 //
 // This type is NOT used concurrently – there is currently only one single applier process running to process binlog
@@ -189,44 +199,77 @@ func (a *binlogReplicaApplier) RequestQueryFlush(ctx context.Context) error {
 	}
 }
 
-// This function will connect to the MySQL server and check the GTID_MODE.
-func detectVersionAndGTIDMode(ctx *sql.Context, params mysql.ConnParams) (mariaDB, gtidMode bool, err error) {
+// detectSourceCapabilities connects to the MySQL server and detects the
+// replication capabilities needed for the binlog stream.
+func detectSourceCapabilities(ctx *sql.Context, params mysql.ConnParams) (sourceCapabilities, error) {
+	capabilities := sourceCapabilities{flavorName: filePosFlavorID}
 	conn, err := mysql.Connect(ctx, &params)
 	if err != nil {
-		return false, false, err
+		return capabilities, err
 	}
 	defer conn.Close()
+	return detectSourceCapabilitiesFromQueries(conn)
+}
 
-	var qr *sqltypes.Result
-	qr, err = conn.ExecuteFetch("SELECT VERSION()", 1, true)
+func detectSourceCapabilitiesFromQueries(conn queryExecutor) (sourceCapabilities, error) {
+	capabilities := sourceCapabilities{flavorName: filePosFlavorID}
+
+	qr, err := conn.ExecuteFetch("SELECT VERSION()", 1, true)
 	if err != nil {
-		return false, false, fmt.Errorf("failed to check MySQL version: %w", err)
+		return capabilities, fmt.Errorf("failed to check MySQL version: %w", err)
 	}
 	if len(qr.Rows) == 0 {
-		return false, false, errors.New("no rows returned when checking MySQL version")
+		return capabilities, errors.New("no rows returned when checking MySQL version")
 	}
 	version := string(qr.Rows[0][0].Raw())
 
-	mariaDB = strings.Contains(version, "MariaDB")
+	mariaDB := strings.Contains(version, "MariaDB")
 	if mariaDB {
 		qr, err = conn.ExecuteFetch("SELECT @@GLOBAL.GTID_STRICT_MODE", 1, true)
 		if err != nil {
-			return mariaDB, false, fmt.Errorf("failed to check GTID_STRICT_MODE: %w", err)
+			return capabilities, fmt.Errorf("failed to check GTID_STRICT_MODE: %w", err)
 		}
 	} else {
+		capabilities.binlogDumpGTIDFlags = detectBinlogDumpGTIDFlags(conn)
 		qr, err = conn.ExecuteFetch("SELECT @@GLOBAL.GTID_MODE", 1, true)
 		if err != nil {
-			return mariaDB, false, fmt.Errorf("failed to check GTID_MODE: %w", err)
+			return capabilities, fmt.Errorf("failed to check GTID_MODE: %w", err)
 		}
 	}
 	if len(qr.Rows) == 0 {
-		return mariaDB, false, errors.New("no rows returned when checking GTID_MODE")
+		return capabilities, errors.New("no rows returned when checking GTID mode")
 	}
 
 	gtidModeValue := qr.Rows[0][0].ToString()
-	gtidMode = strings.EqualFold(gtidModeValue, "ON") || gtidModeValue == "1"
+	gtidMode := strings.EqualFold(gtidModeValue, "ON") || gtidModeValue == "1"
+	capabilities.gtidMode = gtidMode
 
-	return mariaDB, gtidMode, nil
+	if !gtidMode {
+		capabilities.flavorName = filePosFlavorID
+	} else if mariaDB {
+		capabilities.flavorName = mariadbFlavorID
+	} else {
+		capabilities.flavorName = mysql56FlavorID
+	}
+
+	return capabilities, nil
+}
+
+// detectBinlogDumpGTIDFlags probes optional source-specific behavior. A source
+// that rejects either identity query is treated as standard MySQL.
+func detectBinlogDumpGTIDFlags(conn queryExecutor) uint16 {
+	qr, err := conn.ExecuteFetch("SELECT @@VERSION_COMMENT", 1, true)
+	if err != nil || qr == nil || len(qr.Rows) == 0 || string(qr.Rows[0][0].Raw()) != "Dolt" {
+		return 0
+	}
+
+	qr, err = conn.ExecuteFetch("SELECT DOLT_VERSION()", 1, true)
+	if err != nil || qr == nil || len(qr.Rows) == 0 || string(qr.Rows[0][0].Raw()) != "2.3.1" {
+		return 0
+	}
+
+	// Dolt 2.3.1 only decodes the SID block when this flag is set.
+	return mysql.BinlogThroughGTID
 }
 
 // connectAndStartReplicationEventStream connects to the configured MySQL replication source, including pausing
@@ -242,11 +285,9 @@ func (a *binlogReplicaApplier) connectAndStartReplicationEventStream(ctx *sql.Co
 	})
 
 	var (
-		conn       *mysql.Conn
-		err        error
-		gtidMode   = false
-		mariaDB    = false
-		flavorName = ""
+		conn         *mysql.Conn
+		err          error
+		capabilities sourceCapabilities
 	)
 	for connectionAttempts := uint64(0); ; connectionAttempts++ {
 		replicaSourceInfo, err := loadReplicationConfiguration(ctx, a.engine.Analyzer.Catalog.MySQLDb)
@@ -275,19 +316,11 @@ func (a *binlogReplicaApplier) connectAndStartReplicationEventStream(ctx *sql.Co
 			ConnectTimeoutMs: 4_000,
 		}
 
-		mariaDB, gtidMode, err = detectVersionAndGTIDMode(ctx, connParams)
+		capabilities, err = detectSourceCapabilities(ctx, connParams)
 		if err != nil && connectionAttempts >= maxConnectionAttempts {
 			return nil, err
 		}
-
-		if !gtidMode {
-			flavorName = filePosFlavorID
-		} else if mariaDB {
-			flavorName = mariadbFlavorID
-		} else {
-			flavorName = mysql56FlavorID
-		}
-		connParams.Flavor = flavorName
+		connParams.Flavor = capabilities.flavorName
 
 		conn, err = mysql.Connect(ctx, &connParams)
 		if err != nil {
@@ -316,7 +349,7 @@ func (a *binlogReplicaApplier) connectAndStartReplicationEventStream(ctx *sql.Co
 
 	// Request binlog events to start
 	// TODO: This should also have retry logic
-	err = a.startReplicationEventStream(ctx, conn, gtidMode, flavorName)
+	err = a.startReplicationEventStream(ctx, conn, capabilities)
 	if err != nil {
 		return nil, err
 	}
@@ -395,7 +428,7 @@ func (a *binlogReplicaApplier) loadLogFilePosition(ctx *sql.Context, positionSto
 
 // startReplicationEventStream sends a request over |conn|, the connection to the MySQL source server, to begin
 // sending binlog events.
-func (a *binlogReplicaApplier) startReplicationEventStream(ctx *sql.Context, conn *mysql.Conn, gtidMode bool, flavorName string) error {
+func (a *binlogReplicaApplier) startReplicationEventStream(ctx *sql.Context, conn *mysql.Conn, capabilities sourceCapabilities) error {
 	// A disconnected stream may have applied keyless changes directly into the
 	// applier transaction or buffered indexed changes in delta. Neither may
 	// survive reconnection without its matching commit event and position.
@@ -409,8 +442,8 @@ func (a *binlogReplicaApplier) startReplicationEventStream(ctx *sql.Context, con
 	}
 
 	var position mysql.Position
-	if gtidMode {
-		position, err = a.loadGtidPosition(ctx, positionStore, flavorName)
+	if capabilities.gtidMode {
+		position, err = a.loadGtidPosition(ctx, positionStore, capabilities.flavorName)
 		if err != nil {
 			return err
 		}
@@ -418,7 +451,7 @@ func (a *binlogReplicaApplier) startReplicationEventStream(ctx *sql.Context, con
 			ctx.GetLogger().Errorf("unable to set @@GLOBAL.gtid_executed: %s", err.Error())
 		}
 	} else {
-		position, err = a.loadLogFilePosition(ctx, positionStore, flavorName)
+		position, err = a.loadLogFilePosition(ctx, positionStore, capabilities.flavorName)
 		if err != nil {
 			return err
 		}
@@ -457,7 +490,59 @@ func (a *binlogReplicaApplier) startReplicationEventStream(ctx *sql.Context, con
 		"position":   position.String(),
 	}).Trace("Sending binlog dump command to source")
 
-	return conn.SendBinlogDumpCommand(serverId, position)
+	return sendBinlogDumpCommand(conn, serverId, binlogFile, position, capabilities.binlogDumpGTIDFlags)
+}
+
+type mysql56BinlogDumpRequest struct {
+	serverID   uint32
+	binlogFile string
+	binlogPos  uint64
+	flags      uint16
+	sidBlock   []byte
+}
+
+func sendBinlogDumpCommand(conn *mysql.Conn, serverID uint32, binlogFile string, position mysql.Position, flags uint16) error {
+	if !useWriteComBinlogDumpGTID(position, flags) {
+		return conn.SendBinlogDumpCommand(serverID, position)
+	}
+
+	request, ok := newMySQL56BinlogDumpRequest(serverID, binlogFile, position, flags)
+	if !ok {
+		return conn.SendBinlogDumpCommand(serverID, position)
+	}
+
+	return conn.WriteComBinlogDumpGTID(
+		request.serverID,
+		request.binlogFile,
+		request.binlogPos,
+		request.flags,
+		request.sidBlock,
+	)
+}
+
+// useWriteComBinlogDumpGTID is true only for a MySQL56 GTID set after Dolt 2.3.1
+// identity confirmed BinlogThroughGTID. Every other source keeps main's two-arg dump.
+func useWriteComBinlogDumpGTID(position mysql.Position, flags uint16) bool {
+	if flags != mysql.BinlogThroughGTID {
+		return false
+	}
+	_, ok := position.GTIDSet.(mysql.Mysql56GTIDSet)
+	return ok
+}
+
+func newMySQL56BinlogDumpRequest(serverID uint32, binlogFile string, position mysql.Position, flags uint16) (mysql56BinlogDumpRequest, bool) {
+	gtidSet, ok := position.GTIDSet.(mysql.Mysql56GTIDSet)
+	if !ok {
+		return mysql56BinlogDumpRequest{}, false
+	}
+
+	return mysql56BinlogDumpRequest{
+		serverID:   serverID,
+		binlogFile: binlogFile,
+		binlogPos:  4,
+		flags:      flags,
+		sidBlock:   gtidSet.SIDBlock(),
+	}, true
 }
 
 // replicaBinlogEventHandler runs a loop, processing binlog events until the applier's stop replication channel

--- a/docs/dolt-2.3.1-replication.md
+++ b/docs/dolt-2.3.1-replication.md
@@ -1,0 +1,129 @@
+# Dolt 2.3.1 Replication Compatibility
+
+Date: 2026-08-26
+
+## Scope and source identity
+
+- Exact post-#484 source parent: `ba805622a2b0c855e904e44e158112b216c8724b`
+- Parent ancestry: `ba805622` is the signed #484 Dockerfile fix on `cbd566f9`; this PR does not include the Dockerfile change.
+- Dolt source: `dolthub/dolt-sql-server@sha256:dbd13efe2e19e02c079efd2152bca5032071a3cd6f79a9b2a7b404d19ff3ee3f`
+- Dolt SQL identity: `@@VERSION_COMMENT = Dolt`, `DOLT_VERSION() = 2.3.1`, `VERSION() = 8.0.31`
+- Candidate image: `myduckserver:task61-post484`, digest `sha256:cd15802b761da1f4ee6763c0bbcc7c094f7f07375cc6a2803ad91dca677405c9`
+- Exact-parent image: `myduckserver:task61-parent-ba805`, digest `sha256:518653912d43d5bd9aab96abce9c8606f54f319093da6d80403b6569a107c5ee`
+
+The effective change is the six-file Dolt replication patch replayed onto the
+post-#484 main. It does not change `go.mod`, the product version, release tags,
+or image registry tags. PR #480 remains review-only; no merge, auto-merge,
+release, or `latest` update is implied by this evidence.
+
+## Conflict composition
+
+The old PR #480 applier patch was originally based on `cbd566f9` and had seven
+overlapping hunks. The replay preserves the current-main behavior introduced
+by the DoltgreSQL work:
+
+- `RequestQueryFlush` and the applier-owned flush channel
+- `discardOngoingTxn` before reconnect and after the run exits
+- `positionStore.Load` / `LoadEncoded` and the current `mysql.Position`
+- two-argument `SendBinlogDumpCommand(serverId, position)` for non-Dolt paths
+- current reconnect and transaction ordering, including `pendingPosition`
+
+It adds only the Dolt 2.3.1 capability check and the `BinlogThroughGTID`
+(`0x04`) flag. `@@VERSION_COMMENT = 'Dolt'` and `DOLT_VERSION() = '2.3.1'`
+must both match. Only a MySQL56 GTID position with that confirmed identity
+uses `WriteComBinlogDumpGTID`; all other sources and probe failures retain the
+main two-argument dump path and flags `0`. GTID mode parsing remains the
+main-tree `ToString()` plus `ON` / `1` logic.
+
+The replication script now derives source and MyDuck container names from its
+`RESOURCE_SUFFIX`. All `run`, `inspect`, `exec`, `logs`, `rm`, and DSN uses share
+those names, so concurrent runs cannot collide and cleanup cannot remove a
+pre-existing fixed-name container.
+
+## Runtime matrix
+
+All official script runs used the same pinned Dolt digest and the candidate or
+exact-parent image named above. The script compares ordered `id:name` rows.
+
+| Source | Candidate | Exact parent | Result |
+| --- | --- | --- | --- |
+| Dolt 2.3.1 | exit 0; initial/incremental/STOP-START/process restart rows 2 -> 3 -> 4 -> 5; GTID advances through `:1-8`; IO/SQL Yes, errno 0 | exit 1 at STOP-START: expected 4 rows, got 7; initial/incremental errno 0 | Candidate fixes the duplicate replay; parent mismatch is the locked baseline |
+| MySQL | exit 0; initial and incremental rows/GTID/position pass | exit 0 | No candidate-only red |
+| PostgreSQL | exit 1; incremental phase remains at 2 rows | exit 1; same 2-row incremental boundary | Shared replication baseline, not candidate-only |
+| MariaDB | exit 0; known `Last_SQL_Errno=1105` unknown-event baseline | exit 0; same `1105` baseline | No candidate-only red |
+
+Log paths and SHA-256:
+
+- candidate Dolt: `/private/tmp/task61-post484-dolt.log` - `8044f44ee0949ed59018f13c85b247db84acfe2c0cc00f4c5b2d02faedc15cea`
+- candidate MySQL: `/private/tmp/task61-post484-mysql.log` - `8eba72edc20dbade655dda450866af645dc2755027ba3552b64578d356037024`
+- candidate PostgreSQL: `/private/tmp/task61-post484-postgres.log` - `3ab4fa592c91381c8290fbc3a4dc322c50592f24498a8a752e1a74aad4a8ec3e`
+- candidate MariaDB: `/private/tmp/task61-post484-mariadb.log` - `d745a7fe83114e03996e82efb4dfe5118cdd1b832f63a7fb6bdb0a1c3a2f681d`
+- parent Dolt: `/private/tmp/task61-post484-parent-dolt.log` - `095371a931aff3f7ed99ab4f40a31806269ed34b8b421ca83496172af7a05c7f`
+- parent MySQL: `/private/tmp/task61-post484-parent-mysql.log` - `f34183373515cdf534fb5a2d8e07fed1d4c5ae53bb5d906142ec8512efcd06ff`
+- parent PostgreSQL: `/private/tmp/task61-post484-parent-postgres.log` - `86880ecfd51fb9eb4fa88eb9a24f7c9ff5778ee7346a82853c9ba3e711899319`
+- parent MariaDB: `/private/tmp/task61-post484-parent-mariadb-ba805.log` - `209c0c3371739cdcf8e89520219ea3fb3b15b485b851e82985e551b1f3ac3d7c`
+
+## Focused and shared gates
+
+The focused capability, dump-packet, QueryFlush/reconnect, position-load, and
+transaction-boundary tests passed. Candidate and parent precompiled
+file-position, GTID-restart, and QueryFlush integration probes passed. The
+full precompiled binlog package has only the shared `TestAutoRestartReplica`
+baseline (`Last_SQL_Errno=1105`, row-event flags `0x10`) when compared with the
+exact parent.
+
+The host-only command
+`go test -tags=duckdb_arrow ./binlogreplication -count=1` was allowed to run
+to completion and timed out after 601 seconds because the macOS `go run .`
+harness service never listened on its ephemeral port. Every fixture showed
+connection refused before a product assertion; this is retained as harness
+environment evidence, not a candidate product regression.
+
+Focused log: `/private/tmp/task61-post484-binlog-candidate.log` -
+`c57cee9d1404d73dd2ea454ba5acfb05cd762d2634a1af8d122700fb60e9a82a`.
+
+## Static and cleanup gates
+
+The candidate tree passed `gofmt`, `go mod tidy`/module-graph checks,
+compile-only tests, `go build ./...`, `bash -n`, ShellCheck, and
+`git diff --check`. Candidate and parent focused binlog tests both passed:
+
+- candidate focused binlog package: `ok .../binlogreplication 0.302s`
+- exact-parent focused binlog package: `ok .../binlogreplication 0.289s`
+
+The two-round static evidence was generated before the report-only update;
+the report is the only post-runtime file change. Final cleanup removed the
+post-#484 `task61-fresh` and MySQL fixture containers. Historical
+`task51-dolt-source`, `myduck-repro-pg`, `myduck-debug-pg`, and MinIO resources
+were not touched.
+
+Static evidence hashes:
+
+- round 1: `/private/tmp/task61-post484-static1.log` - `0b5159a7b0495d1e2df1c470d55c370877247438a9a7357365b114cccbafb802`
+- round 2: `/private/tmp/task61-post484-static2.log` - `8529f7135ceb56aaa7adc7dfb9e9ce12894ff344eb5b0720d2967cf2d8597ef9`
+
+The final tree contains exactly these six paths relative to `ba805622`:
+
+```text
+A .github/scripts/replication-test.sh
+M .github/workflows/replication-test.yml
+A binlogreplication/binlog_dump_test.go
+A binlogreplication/binlog_position_atomicity_test.go
+M binlogreplication/binlog_replica_applier.go
+A docs/dolt-2.3.1-replication.md
+```
+
+## Reproduction
+
+```text
+MYDUCK_IMAGE=<image-built-from-this-tree> bash .github/scripts/replication-test.sh dolt
+MYDUCK_IMAGE=<image-built-from-this-tree> bash .github/scripts/replication-test.sh mysql
+MYDUCK_IMAGE=<image-built-from-this-tree> bash .github/scripts/replication-test.sh postgres
+MYDUCK_IMAGE=<image-built-from-this-tree> bash .github/scripts/replication-test.sh mariadb
+CI=true go test -tags=duckdb_arrow ./binlogreplication -count=1
+```
+
+The next review object must be one platform-signed commit whose unique parent
+is `ba805622`, with this report, the six-file manifest, and the evidence
+hashes recomputed from the final tree. The new head requires a fresh
+non-author review; the old PR #480 approvals do not transfer.


### PR DESCRIPTION
## Review-only Dolt 2.3.1 replication update

This PR is the post-#484 rebuild of the Dolt 2.3.1 replication change. It is
not a release or merge authorization.

### Locked identity

- Signed head: `e20e51bc77345d898ae3dd4c6f7cfcd03986348b`
- Unique parent: `ba805622a2b0c855e904e44e158112b216c8724b`
- Tree: `26c91f5ffefec93fccf1149fd175e91b80c94c03`
- GitHub signature: `verified=true`, `reason=valid`
- Scope: exactly 6 files, `+977/-259`
- Report SHA-256: `e7ae857904d85463951dce5a85450455b9a4152b850d265725be3b46a9039d1e`
- Evidence archive SHA-256: `f6ab77f8c613421628ccf7633cf97b7b4c936d954ab8be95a6babc7f060e8153`

The parent is the merged PR #484 Dockerfile fix (`ba805622`); the Dockerfile
is not part of this PR. Rejected heads `3a0d73b5`, `d54fcc18`, and local
unsigned `bce4878` are not in the signed commit ancestry. Old approvals do not
transfer.

### Implementation boundary

The applier preserves main's QueryFlush barrier, reconnect transaction discard,
encoded/current file-position loading, two-argument non-Dolt dump path, and
transaction ordering. It adds only dual Dolt identity detection and
`BinlogThroughGTID` (`0x04`) for confirmed Dolt 2.3.1 MySQL56 GTID positions.
The replication script now suffixes both container names and uses those names
for all Docker operations and DSNs, preventing concurrent collisions and
cleanup of pre-existing fixed-name containers.

### Fresh evidence

- Candidate image `myduckserver:task61-post484`:
  `sha256:cd15802b761da1f4ee6763c0bbcc7c094f7f07375cc6a2803ad91dca677405c9`
- Exact-parent image `myduckserver:task61-parent-ba805`:
  `sha256:518653912d43d5bd9aab96abce9c8606f54f319093da6d80403b6569a107c5ee`
- Dolt candidate: exit 0 through initial/incremental/STOP-START/process-restart,
  exact rows 2 -> 3 -> 4 -> 5, GTID through `:1-8`, IO/SQL Yes, errno 0.
- Dolt exact parent: STOP/START exit 1 at the locked main baseline (expected 4,
  got 7); initial/incremental errno 0.
- MySQL candidate and parent: exit 0.
- MariaDB candidate and parent: exit 0 with the same known `Last_SQL_Errno=1105`
  unknown-event baseline.
- PostgreSQL candidate and parent: both stop at the same 2-row incremental
  boundary; this is shared replication behavior, not candidate-only.
- Focused capability/dump/QueryFlush/position tests, precompiled restart probes,
  compile-only tests, build, tidy, format, shell syntax, ShellCheck and
  diff-check pass. Two static rounds are recorded as
  `0b5159a7b0495d1e2df1c470d55c370877247438a9a7357365b114cccbafb802` and
  `8529f7135ceb56aaa7adc7dfb9e9ce12894ff344eb5b0720d2967cf2d8597ef9`.
- The macOS host full-binlog command timed out after 601 seconds because its
  `go run .` service never listened; all fixtures failed with connection
  refused before product assertions. This is environment evidence, not a
  candidate-only regression. The precompiled candidate/parent package result
  is the shared AutoRestartReplica `1105` / row-event flag `0x10` baseline.

Do not merge, enable auto-merge, publish an image, move a release tag, or move
`latest` from this PR. A new independent non-author review must bind this exact
head before any integration decision.
