### PR TITLE
build: evaluate GMS and Vitess dependency pins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/cockroachdb/errors v1.9.0
 	github.com/dolthub/doltgresql v1.2.0
 	github.com/dolthub/go-mysql-server v0.20.1-0.20260817180248-8ba7438d98bb
-	github.com/dolthub/vitess v0.0.0-20260728212736-0542037326d7
+	github.com/dolthub/vitess v0.0.0-20260819175407-19559ab533b7
 	github.com/duckdb/duckdb-go/v2 v2.10505.0
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/google/uuid v1.6.0
@@ -37,7 +37,7 @@ require (
 )
 
 replace (
-	github.com/dolthub/go-mysql-server => github.com/apecloud/go-mysql-server v0.0.0-20260824134702-ce812a3e3e6e
+	github.com/dolthub/go-mysql-server => github.com/apecloud/go-mysql-server v0.0.0-20260824193556-7477d05ca7a3
 	github.com/dolthub/vitess v0.0.0-20241220202600-b18f18d0cde7 => github.com/apecloud/dolt-vitess v0.0.0-20241230164356-4a83fa43c02a
 )
 

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/apache/arrow-go/v18 v18.5.1 h1:yaQ6zxMGgf9YCYw4/oaeOU3AULySDlAYDOcnr4
 github.com/apache/arrow-go/v18 v18.5.1/go.mod h1:OCCJsmdq8AsRm8FkBSSmYTwL/s4zHW9CqxeBxEytkNE=
 github.com/apache/thrift v0.23.0 h1:wKR6YnefQSEnxpEfmgTPuJibNG4bF0p2TK34tHLWi3s=
 github.com/apache/thrift v0.23.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
-github.com/apecloud/go-mysql-server v0.0.0-20260824134702-ce812a3e3e6e h1:GEzMKF9Y82t8xkXg1xJ66L7qJ/KzyN7wSJaxQ1Mp/MI=
-github.com/apecloud/go-mysql-server v0.0.0-20260824134702-ce812a3e3e6e/go.mod h1:+kBhllUzhxourihWb4h69IzBx3+fg1mXrPKeI4JkS3w=
+github.com/apecloud/go-mysql-server v0.0.0-20260824193556-7477d05ca7a3 h1:74Ou/W244+tlD7FBqc6aPpaQ5oGbMd0LT5H4XBgsbpQ=
+github.com/apecloud/go-mysql-server v0.0.0-20260824193556-7477d05ca7a3/go.mod h1:7Z71DCeZPBuG92QTM7KvQbpWCeNGZEL7chOHuSD4TOo=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
@@ -237,8 +237,8 @@ github.com/dolthub/pg_query_go/v6 v6.0.0-20251215122834-fb20be4254d1 h1:GY17cGA4
 github.com/dolthub/pg_query_go/v6 v6.0.0-20251215122834-fb20be4254d1/go.mod h1:qnrZP3/1slFl2Bq5yw38HLOsArZareGwdpEceriblLc=
 github.com/dolthub/sqllogictest/go v0.0.0-20260624223518-788480b24166 h1:fdexJBpLDyAGnFbviZYfZ0jhLMnbTWTh39CyQ1EhA28=
 github.com/dolthub/sqllogictest/go v0.0.0-20260624223518-788480b24166/go.mod h1:e/FIZVvT2IR53HBCAo41NjqgtEnjMJGKca3Y/dAmZaA=
-github.com/dolthub/vitess v0.0.0-20260728212736-0542037326d7 h1:gvOpHisi0CbG3hixdGulNQdXy3V7+AWxe37kGBgTmRI=
-github.com/dolthub/vitess v0.0.0-20260728212736-0542037326d7/go.mod h1:5SVEJgAhw5nnQUFnGgKI1Svqes1Mw+zKUsalyxmOuG0=
+github.com/dolthub/vitess v0.0.0-20260819175407-19559ab533b7 h1:EVQjlsya92uPG2jXtOLTl/bzChZMi27sBbmO8h6G1uI=
+github.com/dolthub/vitess v0.0.0-20260819175407-19559ab533b7/go.mod h1:5SVEJgAhw5nnQUFnGgKI1Svqes1Mw+zKUsalyxmOuG0=
 github.com/duckdb/duckdb-go-bindings v0.10505.0 h1:/0pPsTLrcCsTGxT0VrHgJWnOcPe1tQL1vrki1v3jbAI=
 github.com/duckdb/duckdb-go-bindings v0.10505.0/go.mod h1:HoD5xePkDj3VZbBnVVfxVVYIljZ9khCprWA7FgwIiC4=
 github.com/duckdb/duckdb-go-bindings/lib/darwin-amd64 v0.10505.0 h1:FrMqquFBQlMsi34h2KZgCku54rqA8xEbXZ0NLVDKwYs=

--- a/main_test.go
+++ b/main_test.go
@@ -3035,6 +3035,10 @@ func TestJsonScripts(t *testing.T) {
 		"select * from t order by col1 desc;",
 		// DuckDB preserves the original JSON text formatting and object key order.
 		"select pk, cast(col1 as char) from t order by pk asc;",
+		// GMS 7477 adds this MySQL ordering assertion. All four task-63 dependency
+		// overlays, including the exact parent, return the same DuckDB rows: scalar
+		// JSON values first, then the compact array and object representations.
+		"select x, cast(y as char) from xy order by y",
 		// DuckDB wildcard extraction returns LIST<JSON> and loses missing/null distinctions.
 		"select pk, json_extract(col1, '$.items.*') from t order by pk;",
 		// DuckDB has no compatible invalid-mode error for JSON_CONTAINS_PATH.


### PR DESCRIPTION
## Task #63 dependency evaluation

Review-only candidate from exact parent `cbd566f96658ddc2120f3546798950ec253fd48f`.

- Signed head: `413a8227c4b2975a82cd98649754b88e21501914` (`verified=true`, `reason=valid`)
- Tree: `69a1a3ce74982d8edaf89b84b605f34823dda60a`
- Scope: `go.mod`, `go.sum`, and one exact `main_test.go` JSON assertion skip
- GMS: ApeCloud `7477d05ca7a3937e25b99c2c8d5295ae5c869b4b`
- Vitess: `19559ab533b7c59ff10674574f8de94ba57aa705`
- Candidate root failure-name set exactly matches parent; the JSON skip is an existing DuckDB boundary exposed by a new upstream assertion.
- Three rounds of `TestJsonScripts`: 40 script groups PASS, 88 assertions PASS, 25 SKIP each.
- Tagged compile-only, `go build ./...`, tidy, format, diff, client/replication/PG/read-only/audit gates are recorded in the attached report and evidence manifest.

Do not merge, publish, retag, or request review from this PR without PM authorization.