### PR TITLE
feat: persist CREATE TABLE storage selection

### DIFF
--- a/backend/engine.go
+++ b/backend/engine.go
@@ -22,6 +22,7 @@ import (
 	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer"
+	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/dolthub/vitess/go/vt/sqlparser"
 )
@@ -33,11 +34,35 @@ func NewEngine(provider *catalog.DatabaseProvider) (*sqle.Engine, *DuckBuilder) 
 	parser := &mysqlParser{Parser: sql.NewMysqlParser()}
 	overrides := sql.EngineOverrides{
 		Builder: sql.BuilderOverrides{Parser: parser},
+		Hooks: sql.ExecutionHooks{
+			CreateTable: sql.CreateTable{
+				PreSQLExecution: prepareMySQLCreateTableStorage,
+			},
+		},
 	}
 	engine := sqle.New(analyzer.NewBuilder(provider).AddOverrides(overrides).Build(), nil)
 	builder := NewDuckBuilder(engine.Analyzer.ExecBuilder, provider)
 	engine.Analyzer.ExecBuilder.PriorityBuilder = builder
 	return engine, builder
+}
+
+// prepareMySQLCreateTableStorage bridges the planner's table-option map to
+// the catalog's request-scoped storage selector. The catalog consumes the
+// selector while creating the table and persists it in the managed comment;
+// no credentials, endpoints, or object paths are accepted from SQL.
+func prepareMySQLCreateTableStorage(ctx *sql.Context, _ sql.StatementRunner, node sql.Node) (sql.Node, error) {
+	create, ok := node.(*plan.CreateTable)
+	if !ok {
+		return node, nil
+	}
+	selection, err := catalog.ResolveMySQLTableStorage(create.TableOpts)
+	if err != nil {
+		return nil, err
+	}
+	if err := catalog.SetTableStorageSelection(ctx, selection); err != nil {
+		return nil, err
+	}
+	return create, nil
 }
 
 // registerMySQLCompatibilitySystemVariables keeps MyDuck's advertised SQL
@@ -67,13 +92,21 @@ type mysqlParser struct {
 func (p *mysqlParser) ParseSimple(query string) (sqlparser.Statement, error) {
 	compat := rewriteMySQLCompatibility(query)
 	stmt, err := p.Parser.ParseSimple(compat.query)
-	return normalizeMySQLStatement(stmt, compat.replacements), err
+	stmt = normalizeMySQLStatement(stmt, compat.replacements)
+	if err == nil {
+		err = validateMySQLTableStorageStatement(stmt)
+	}
+	return stmt, err
 }
 
 func (p *mysqlParser) Parse(ctx *sql.Context, query string, multi bool) (sqlparser.Statement, string, string, error) {
 	compat := rewriteMySQLCompatibility(query)
 	stmt, parsed, remainder, err := p.Parser.Parse(ctx, compat.query, multi)
-	return normalizeMySQLStatement(stmt, compat.replacements), compat.restoreParsedQuery(parsed), remainder, err
+	stmt = normalizeMySQLStatement(stmt, compat.replacements)
+	if err == nil {
+		err = validateMySQLTableStorageStatement(stmt)
+	}
+	return stmt, compat.restoreParsedQuery(parsed), remainder, err
 }
 
 func (p *mysqlParser) ParseWithOptions(
@@ -85,7 +118,11 @@ func (p *mysqlParser) ParseWithOptions(
 ) (sqlparser.Statement, string, string, error) {
 	compat := rewriteMySQLCompatibility(query)
 	stmt, parsed, remainder, err := p.Parser.ParseWithOptions(ctx, compat.query, delimiter, multi, options)
-	return normalizeMySQLStatement(stmt, compat.replacements), compat.restoreParsedQuery(parsed), remainder, err
+	stmt = normalizeMySQLStatement(stmt, compat.replacements)
+	if err == nil {
+		err = validateMySQLTableStorageStatement(stmt)
+	}
+	return stmt, compat.restoreParsedQuery(parsed), remainder, err
 }
 
 func (p *mysqlParser) ParseOneWithOptions(
@@ -95,7 +132,33 @@ func (p *mysqlParser) ParseOneWithOptions(
 ) (sqlparser.Statement, int, error) {
 	compat := rewriteMySQLCompatibility(query)
 	stmt, index, err := p.Parser.ParseOneWithOptions(ctx, compat.query, options)
-	return normalizeMySQLStatement(stmt, compat.replacements), compat.originalOffset(index), err
+	stmt = normalizeMySQLStatement(stmt, compat.replacements)
+	if err == nil {
+		err = validateMySQLTableStorageStatement(stmt)
+	}
+	return stmt, compat.originalOffset(index), err
+}
+
+// validateMySQLTableStorageStatement runs before the planner turns table
+// options into a map. That preserves duplicate ENGINE/myduck_storage
+// declarations, which would otherwise be silently overwritten by the map.
+func validateMySQLTableStorageStatement(stmt sqlparser.Statement) error {
+	ddl, ok := stmt.(*sqlparser.DDL)
+	if !ok || ddl.TableSpec == nil || len(ddl.TableSpec.TableOpts) == 0 {
+		return nil
+	}
+	options := make([]catalog.TableStorageOption, 0, len(ddl.TableSpec.TableOpts))
+	for _, option := range ddl.TableSpec.TableOpts {
+		if option == nil {
+			continue
+		}
+		options = append(options, catalog.TableStorageOption{
+			Name:  option.Name,
+			Value: option.Value,
+		})
+	}
+	_, err := catalog.NormalizeTableStorageOptions(options)
+	return err
 }
 
 type mysqlOptionReplacement struct {

--- a/backend/engine_test.go
+++ b/backend/engine_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/apecloud/myduckserver/catalog"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"github.com/stretchr/testify/require"
@@ -153,4 +154,37 @@ func TestMySQLParserRestoresDatabaseFiltersInMultiQuery(t *testing.T) {
 	_, index, err := parser.ParseOneWithOptions(context.Background(), query, sqlparser.ParserOptions{})
 	require.NoError(t, err)
 	require.Equal(t, strings.Index(query, " SELECT 1"), index)
+}
+
+func TestMySQLParserTableStorageOptions(t *testing.T) {
+	parser := &mysqlParser{Parser: sql.NewMysqlParser()}
+	for _, query := range []string{
+		"CREATE TABLE object_table (id INT) ENGINE=DUCKLAKE",
+		"CREATE TABLE local_table (id INT) ENGINE=InnoDB",
+	} {
+		stmt, _, _, err := parser.ParseWithOptions(context.Background(), query, ';', false, sqlparser.ParserOptions{})
+		require.NoError(t, err, query)
+		ddl, ok := stmt.(*sqlparser.DDL)
+		require.True(t, ok, query)
+		require.NotNil(t, ddl.TableSpec, query)
+		require.NotEmpty(t, ddl.TableSpec.TableOpts, query)
+		for _, option := range ddl.TableSpec.TableOpts {
+			t.Logf("%s => name=%q value=%q", query, option.Name, option.Value)
+		}
+	}
+}
+
+func TestMySQLParserRejectsConflictingTableStorageOptions(t *testing.T) {
+	parser := &mysqlParser{Parser: sql.NewMysqlParser()}
+	for _, test := range []struct {
+		query string
+		want  error
+	}{
+		{query: "CREATE TABLE duplicate_engine (id INT) ENGINE=DUCKLAKE ENGINE=DUCKLAKE", want: catalog.ErrTableStorageDuplicate},
+		{query: "CREATE TABLE conflicting_engine (id INT) ENGINE=DUCKLAKE ENGINE=LOCAL", want: catalog.ErrTableStorageConflict},
+	} {
+		_, _, _, err := parser.ParseWithOptions(context.Background(), test.query, ';', false, sqlparser.ParserOptions{})
+		require.Error(t, err, test.query)
+		require.ErrorIs(t, err, test.want, test.query)
+	}
 }

--- a/catalog/database.go
+++ b/catalog/database.go
@@ -146,7 +146,16 @@ func (d *Database) Name() string {
 	return d.name
 }
 
-func (d *Database) createAllTable(ctx *sql.Context, name string, schema sql.PrimaryKeySchema, collation sql.CollationID, comment string, temporary bool) error {
+func (d *Database) createAllTable(ctx *sql.Context, name string, schema sql.PrimaryKeySchema, collation sql.CollationID, comment string, storage TableStorageSelection, temporary bool) error {
+	if err := storage.Validate(); err != nil {
+		return err
+	}
+	if temporary && storage.IsObjectStorage() {
+		return fmt.Errorf("%w: temporary tables cannot use object storage", ErrInvalidTableStorage)
+	}
+	if storage.Kind == "" {
+		storage = DefaultTableStorageSelection()
+	}
 	var columns []string
 	var columnCommentSQLs []string
 	var fullTableName string
@@ -269,7 +278,13 @@ func (d *Database) createAllTable(ctx *sql.Context, name string, schema sql.Prim
 	b.WriteString(")")
 
 	// Add comment to the table
-	info := ExtraTableInfo{schema.PkOrdinals, withoutIndex, fullSequenceName, nil}
+	info := ExtraTableInfo{
+		PkOrdinals: schema.PkOrdinals,
+		Replicated: withoutIndex,
+		Sequence:   fullSequenceName,
+		Checks:     nil,
+		Storage:    storage.Kind,
+	}
 	b.WriteString(fmt.Sprintf(
 		"; COMMENT ON TABLE %s IS '%s'",
 		fullTableName,
@@ -322,14 +337,88 @@ func isIndexCreationDisabled(ctx *sql.Context) bool {
 func (d *Database) CreateTable(ctx *sql.Context, name string, schema sql.PrimaryKeySchema, collation sql.CollationID, comment string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	return d.createAllTable(ctx, name, schema, collation, comment, false)
+	storage := DefaultTableStorageSelection()
+	if selected, ok := TableStorageSelectionFromContext(ctx); ok {
+		storage = selected
+	}
+	return d.createAllTable(ctx, name, schema, collation, comment, storage, false)
+}
+
+// CreateTableWithStorage is the explicit catalog boundary for protocol
+// adapters that already normalized a table selector. It is intentionally
+// limited to selection propagation and metadata; object-table physical
+// routing is owned by the follow-up storage implementation.
+func (d *Database) CreateTableWithStorage(ctx *sql.Context, name string, schema sql.PrimaryKeySchema, collation sql.CollationID, comment string, storage TableStorageSelection) error {
+	if err := storage.Validate(); err != nil {
+		return err
+	}
+	if err := SetTableStorageSelection(ctx, storage); err != nil {
+		return err
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.createAllTable(ctx, name, schema, collation, comment, storage, false)
+}
+
+// RecordTableStorageSelection updates the managed table metadata for a table
+// created by a protocol path that bypasses sql.TableCreator (currently the
+// PostgreSQL handler). It preserves the user-visible table comment and makes
+// the selection available after a fresh catalog reload.
+func (d *Database) RecordTableStorageSelection(ctx *sql.Context, name string, storage TableStorageSelection) error {
+	if err := storage.Validate(); err != nil {
+		return err
+	}
+	if d.catalog == "temp" && storage.IsObjectStorage() {
+		return fmt.Errorf("%w: temporary tables cannot use object storage", ErrInvalidTableStorage)
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	rows, err := adapter.QueryCatalog(ctx, `
+		SELECT comment
+		FROM duckdb_tables()
+		WHERE database_name = ? AND schema_name = ? AND table_name = ?
+	`, d.catalog, d.name, name)
+	if err != nil {
+		return ErrDuckDB.New(err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return ErrDuckDB.New(err)
+		}
+		return sql.ErrTableNotFound.New(name)
+	}
+
+	var rawComment stdsql.NullString
+	if err := rows.Scan(&rawComment); err != nil {
+		_ = rows.Close()
+		return ErrDuckDB.New(err)
+	}
+	if err := rows.Close(); err != nil {
+		return ErrDuckDB.New(err)
+	}
+	comment := DecodeComment[ExtraTableInfo](rawComment.String)
+	info := comment.Meta
+	info.Storage = storage.Kind
+	encoded := NewCommentWithMeta(comment.Text, info).Encode()
+	_, err = adapter.Exec(ctx, fmt.Sprintf(`COMMENT ON TABLE %s IS '%s'`, FullTableName(d.catalog, d.name, name), encoded))
+	if err != nil {
+		return ErrDuckDB.New(err)
+	}
+	return nil
 }
 
 // CreateTemporaryTable implements sql.CreateTemporaryTable.
 func (d *Database) CreateTemporaryTable(ctx *sql.Context, name string, schema sql.PrimaryKeySchema, collation sql.CollationID) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	return d.createAllTable(ctx, name, schema, collation, "", true)
+	storage := DefaultTableStorageSelection()
+	if selected, ok := TableStorageSelectionFromContext(ctx); ok {
+		storage = selected
+	}
+	return d.createAllTable(ctx, name, schema, collation, "", storage, true)
 }
 
 // DropTable implements sql.TableDropper.

--- a/catalog/table.go
+++ b/catalog/table.go
@@ -32,6 +32,26 @@ type ExtraTableInfo struct {
 	Replicated bool
 	Sequence   string
 	Checks     []sql.CheckDefinition
+	// Storage records the table's durable storage class. An empty value is
+	// treated as local for metadata written before table-level storage
+	// selection existed; newly-created tables always write the explicit value.
+	Storage TableStorageKind `json:"storage,omitempty"`
+}
+
+// StorageKind returns the effective storage class for this metadata. Missing
+// storage metadata is the backwards-compatible local-table behavior.
+func (info ExtraTableInfo) StorageKind() TableStorageKind {
+	if info.Storage == TableStorageObject {
+		return TableStorageObject
+	}
+	return TableStorageLocal
+}
+
+func (info *ExtraTableInfo) normalizeStorage() {
+	if info == nil {
+		return
+	}
+	info.Storage = info.StorageKind()
 }
 
 type ColumnInfo struct {
@@ -75,6 +95,10 @@ func NewTable(db *Database, name string, hasPrimaryKey bool) *Table {
 }
 
 func (t *Table) withComment(comment *Comment[ExtraTableInfo]) *Table {
+	if comment == nil {
+		comment = NewComment[ExtraTableInfo]("")
+	}
+	comment.Meta.normalizeStorage()
 	t.comment = comment
 	return t
 }
@@ -100,7 +124,12 @@ func (t *Table) withSchema(ctx *sql.Context) error {
 }
 
 func (t *Table) ExtraTableInfo() ExtraTableInfo {
-	return t.comment.Meta
+	if t.comment == nil {
+		return ExtraTableInfo{Storage: TableStorageLocal}
+	}
+	info := t.comment.Meta
+	info.normalizeStorage()
+	return info
 }
 
 func (t *Table) HasPrimaryKey() bool {

--- a/catalog/table_storage.go
+++ b/catalog/table_storage.go
@@ -1,0 +1,423 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// TableStorageKind is the durable storage class for a user table. Resolver
+// functions use local when no selector is present; object is the DuckLake-
+// backed class selected by the 0.3 table-storage slice.
+type TableStorageKind string
+
+const (
+	TableStorageLocal  TableStorageKind = "local"
+	TableStorageObject TableStorageKind = "object"
+
+	// TableStorageDuckLake is an explicit spelling for callers that think in
+	// terms of the underlying implementation. It has the same durable value as
+	// TableStorageObject.
+	TableStorageDuckLake = TableStorageObject
+	// TableStorageObjectStorage is retained as a descriptive alias for API
+	// callers; object is the only persisted value.
+	TableStorageObjectStorage = TableStorageObject
+)
+
+const (
+	// TableStorageOptionName is the protocol-neutral PostgreSQL storage
+	// parameter. MySQL clients use ENGINE=DUCKLAKE because Vitess accepts only
+	// its built-in table-option grammar.
+	TableStorageOptionName  = "myduck_storage"
+	TableStorageObjectValue = "object"
+	TableStorageLocalValue  = "local"
+	TableStorageMySQLEngine = "ducklake"
+)
+
+var (
+	ErrInvalidTableStorage       = errors.New("invalid table storage selection")
+	ErrTableStorageConflict      = errors.New("conflicting table storage selections")
+	ErrTableStorageDuplicate     = errors.New("duplicate table storage selection")
+	ErrTableStorageCredentialSQL = errors.New("table storage credentials must come from service configuration")
+	ErrTableStoragePathSQL       = errors.New("table storage paths must come from service configuration")
+)
+
+// TableStorageSelection is the normalized result of a CREATE TABLE storage
+// selector. Explicit is false only when no selector was supplied, in which case
+// Kind is always TableStorageLocal.
+type TableStorageSelection struct {
+	Kind     TableStorageKind
+	Explicit bool
+	Source   string
+}
+
+func DefaultTableStorageSelection() TableStorageSelection {
+	return TableStorageSelection{Kind: TableStorageLocal, Source: "default"}
+}
+
+func (s TableStorageSelection) Validate() error {
+	if s.Kind != TableStorageLocal && s.Kind != TableStorageObject {
+		return fmt.Errorf("%w: unsupported kind %q", ErrInvalidTableStorage, s.Kind)
+	}
+	return nil
+}
+
+func (s TableStorageSelection) IsObjectStorage() bool {
+	return s.Kind == TableStorageObject
+}
+
+// EffectiveKind makes the local default explicit for callers that receive a
+// zero-valued selection from an optional context or metadata field.
+func (s TableStorageSelection) EffectiveKind() TableStorageKind {
+	if s.Kind == "" {
+		return TableStorageLocal
+	}
+	return s.Kind
+}
+
+// TableStorageOption is a parser-neutral name/value pair. Keeping options as a
+// slice lets protocol adapters preserve duplicates and reject them before a
+// map-based planner silently overwrites one declaration with another.
+type TableStorageOption struct {
+	Name  string
+	Value any
+}
+
+// NormalizeTableStorageOptions resolves the selectors that protocol parsers
+// expose. Ordinary MySQL/PostgreSQL table options are ignored and retain their
+// historical local behavior. Only the explicit selector and recognized
+// ENGINE alias affect the result.
+func NormalizeTableStorageOptions(options []TableStorageOption) (TableStorageSelection, error) {
+	selection := DefaultTableStorageSelection()
+	canonicalSeen := false
+	canonicalKind := TableStorageLocal
+	canonicalName := ""
+	engineSeen := false
+	engineKind := TableStorageLocal
+	engineSelected := false
+
+	for _, option := range options {
+		name := normalizeTableStorageOptionName(option.Name)
+		if name == "" {
+			return TableStorageSelection{}, fmt.Errorf("%w: empty option name", ErrInvalidTableStorage)
+		}
+
+		if isTableStorageCredentialOption(name) {
+			return TableStorageSelection{}, fmt.Errorf("%w: option %q", ErrTableStorageCredentialSQL, name)
+		}
+		if isTableStoragePathOption(name) {
+			return TableStorageSelection{}, fmt.Errorf("%w: option %q", ErrTableStoragePathSQL, name)
+		}
+
+		switch name {
+		case TableStorageOptionName:
+			if canonicalSeen {
+				return TableStorageSelection{}, fmt.Errorf("%w: %q and %q", ErrTableStorageDuplicate, canonicalName, name)
+			}
+			kind, err := parseTableStorageKind(option.Value)
+			if err != nil {
+				return TableStorageSelection{}, fmt.Errorf("%w: option %q: %v", ErrInvalidTableStorage, name, err)
+			}
+			canonicalSeen = true
+			canonicalKind = kind
+			canonicalName = name
+		case "engine":
+			kind, selected, err := parseMySQLEngine(option.Value)
+			if err != nil {
+				return TableStorageSelection{}, err
+			}
+			if engineSeen {
+				if engineSelected && selected && engineKind != kind {
+					return TableStorageSelection{}, fmt.Errorf("%w: ENGINE %s versus %s", ErrTableStorageConflict, engineKind, kind)
+				}
+				return TableStorageSelection{}, fmt.Errorf("%w: repeated ENGINE selector", ErrTableStorageDuplicate)
+			}
+			engineSeen = true
+			engineKind = kind
+			engineSelected = selected
+			if !selected {
+				// A normal MySQL engine (for example InnoDB) has always been
+				// accepted by MyDuck and maps to the local DuckDB table.
+				continue
+			}
+			if canonicalSeen {
+				if canonicalKind != engineKind {
+					return TableStorageSelection{}, fmt.Errorf("%w: %s versus ENGINE", ErrTableStorageConflict, canonicalKind)
+				}
+				return TableStorageSelection{}, fmt.Errorf("%w: %q and ENGINE", ErrTableStorageDuplicate, canonicalName)
+			}
+			selection.Kind = kind
+			selection.Explicit = true
+			selection.Source = "mysql-engine"
+		default:
+			// Do not silently accept a future MyDuck/DuckLake control option.
+			// Standard PostgreSQL WITH parameters and standard MySQL options
+			// remain untouched for compatibility.
+			if strings.HasPrefix(name, "myduck_") || strings.HasPrefix(name, "ducklake_") || isTableStorageAliasName(name) {
+				return TableStorageSelection{}, fmt.Errorf("%w: unsupported option %q", ErrInvalidTableStorage, name)
+			}
+		}
+	}
+
+	if canonicalSeen {
+		if engineSeen {
+			if engineSelected && engineKind == canonicalKind {
+				return TableStorageSelection{}, fmt.Errorf("%w: %q and ENGINE", ErrTableStorageDuplicate, canonicalName)
+			}
+			if engineKind != canonicalKind {
+				return TableStorageSelection{}, fmt.Errorf("%w: %s versus ENGINE", ErrTableStorageConflict, canonicalKind)
+			}
+		}
+		selection.Kind = canonicalKind
+		selection.Explicit = true
+		selection.Source = "storage-option"
+	}
+	if err := selection.Validate(); err != nil {
+		return TableStorageSelection{}, err
+	}
+	return selection, nil
+}
+
+// ResolveMySQLTableStorage consumes the map produced by go-mysql-server's
+// planner. The planner has already removed duplicate keys, so protocol adapters
+// that need duplicate detection should call NormalizeTableStorageOptions on a
+// token-preserving slice first.
+func ResolveMySQLTableStorage(options map[string]interface{}) (TableStorageSelection, error) {
+	if len(options) == 0 {
+		return DefaultTableStorageSelection(), nil
+	}
+	keys := make([]string, 0, len(options))
+	for key := range options {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	normalized := make([]TableStorageOption, 0, len(keys))
+	for _, key := range keys {
+		normalized = append(normalized, TableStorageOption{Name: key, Value: options[key]})
+	}
+	return NormalizeTableStorageOptions(normalized)
+}
+
+// ResolvePostgresStorageParams consumes literal values extracted from
+// Cockroach's tree.CreateTable.StorageParams. Values may retain SQL quoting;
+// the strict value parser removes one matching quote pair.
+func ResolvePostgresStorageParams(params map[string]string) (TableStorageSelection, error) {
+	if len(params) == 0 {
+		return DefaultTableStorageSelection(), nil
+	}
+	keys := make([]string, 0, len(params))
+	for key := range params {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	options := make([]TableStorageOption, 0, len(keys))
+	for _, key := range keys {
+		options = append(options, TableStorageOption{Name: key, Value: params[key]})
+	}
+	return NormalizeTableStorageOptions(options)
+}
+
+// ResolvePostgresStorageOptions is the duplicate-preserving form for callers
+// that walk tree.StorageParams directly.
+func ResolvePostgresStorageOptions(options []TableStorageOption) (TableStorageSelection, error) {
+	return NormalizeTableStorageOptions(options)
+}
+
+// tableStorageSelectionContextKey is deliberately private so a caller cannot
+// accidentally collide with another context value. The selector is request
+// scoped: callers set it immediately before invoking the generic table-create
+// executor, and the database consumes it while creating that table.
+type tableStorageSelectionContextKey struct{}
+
+// tableStorageSelectionParentKey lets the request-scoped value be consumed
+// without discarding cancellation, query-origin, or other context values.
+// SetTableStorageSelection mutates sql.Context for the GMS hook API, so the
+// original context is retained explicitly and restored by Clear...
+type tableStorageSelectionParentKey struct{}
+
+// SetTableStorageSelection attaches a validated selector to a GMS SQL
+// context. It mutates only the context wrapper passed by the caller; the
+// underlying request/session remains otherwise unchanged.
+func SetTableStorageSelection(ctx *sql.Context, selection TableStorageSelection) error {
+	if ctx == nil {
+		return fmt.Errorf("%w: nil SQL context", ErrInvalidTableStorage)
+	}
+	if err := selection.Validate(); err != nil {
+		return err
+	}
+	base := ctx.Context
+	if base == nil {
+		base = context.Background()
+	}
+	parent := base
+	if original, ok := base.Value(tableStorageSelectionParentKey{}).(context.Context); ok && original != nil {
+		parent = original
+	}
+	withParent := context.WithValue(base, tableStorageSelectionParentKey{}, parent)
+	ctx.Context = context.WithValue(withParent, tableStorageSelectionContextKey{}, selection)
+	return nil
+}
+
+// ClearTableStorageSelection consumes the request-scoped selector installed by
+// SetTableStorageSelection. This prevents a reusable sql.Context (for example
+// a session transaction context) from carrying one CREATE TABLE's choice into
+// a later statement.
+func ClearTableStorageSelection(ctx *sql.Context) {
+	if ctx == nil || ctx.Context == nil {
+		return
+	}
+	if parent, ok := ctx.Context.Value(tableStorageSelectionParentKey{}).(context.Context); ok && parent != nil {
+		ctx.Context = parent
+	}
+}
+
+// WithTableStorageSelection returns a copy of ctx carrying a validated table
+// selector. The copy form is useful in hooks that must not mutate a context
+// owned by another execution path.
+func WithTableStorageSelection(ctx *sql.Context, selection TableStorageSelection) (*sql.Context, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("%w: nil SQL context", ErrInvalidTableStorage)
+	}
+	copy := ctx.WithContext(ctx.Context)
+	if err := SetTableStorageSelection(copy, selection); err != nil {
+		return nil, err
+	}
+	return copy, nil
+}
+
+// TableStorageSelectionFromContext retrieves a selector attached by
+// SetTableStorageSelection or WithTableStorageSelection. A missing or invalid
+// value is reported as absent so callers can safely fall back to local.
+func TableStorageSelectionFromContext(ctx *sql.Context) (TableStorageSelection, bool) {
+	if ctx == nil || ctx.Context == nil {
+		return TableStorageSelection{}, false
+	}
+	selection, ok := ctx.Value(tableStorageSelectionContextKey{}).(TableStorageSelection)
+	if !ok || selection.Validate() != nil {
+		return TableStorageSelection{}, false
+	}
+	return selection, true
+}
+
+func normalizeTableStorageOptionName(raw string) string {
+	name := strings.ToLower(strings.TrimSpace(raw))
+	if len(name) >= 2 {
+		first, last := name[0], name[len(name)-1]
+		if (first == '`' && last == '`') || (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			name = strings.TrimSpace(name[1 : len(name)-1])
+		}
+	}
+	return name
+}
+
+func normalizeTableStorageValue(value any) (string, error) {
+	var raw string
+	switch v := value.(type) {
+	case string:
+		raw = v
+	case []byte:
+		raw = string(v)
+	case fmt.Stringer:
+		raw = v.String()
+	default:
+		return "", fmt.Errorf("value must be a literal string")
+	}
+	raw = strings.TrimSpace(raw)
+	if len(raw) >= 2 {
+		first, last := raw[0], raw[len(raw)-1]
+		if (first == '\'' && last == '\'') || (first == '"' && last == '"') || (first == '`' && last == '`') {
+			raw = strings.TrimSpace(raw[1 : len(raw)-1])
+		}
+	}
+	if raw == "" {
+		return "", fmt.Errorf("value is empty")
+	}
+	if strings.ContainsAny(raw, "\r\n\t;:/\\?#'\"") {
+		return "", fmt.Errorf("value must be a simple storage kind")
+	}
+	for _, r := range raw {
+		if unicode.IsSpace(r) || !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-') {
+			return "", fmt.Errorf("value must be a simple storage kind")
+		}
+	}
+	return strings.ToLower(raw), nil
+}
+
+func parseTableStorageKind(value any) (TableStorageKind, error) {
+	normalized, err := normalizeTableStorageValue(value)
+	if err != nil {
+		return "", err
+	}
+	switch normalized {
+	case TableStorageLocalValue:
+		return TableStorageLocal, nil
+	case TableStorageObjectValue:
+		return TableStorageObject, nil
+	default:
+		return "", errors.New("unknown storage kind")
+	}
+}
+
+func parseMySQLEngine(value any) (TableStorageKind, bool, error) {
+	normalized, err := normalizeTableStorageValue(value)
+	if err != nil {
+		return "", false, fmt.Errorf("%w: ENGINE: %v", ErrInvalidTableStorage, err)
+	}
+	switch normalized {
+	case TableStorageMySQLEngine:
+		return TableStorageObject, true, nil
+	case "local", "duckdb":
+		return TableStorageLocal, true, nil
+	}
+	// These are common MySQL/Dolt engine names. MyDuck historically accepts
+	// them as compatibility decorations while storing the table in DuckDB.
+	switch normalized {
+	case "innodb", "myisam", "memory", "heap", "merge", "archive", "csv", "blackhole", "ndbcluster", "federated", "rocksdb", "aria", "columnstore":
+		return TableStorageLocal, false, nil
+	default:
+		// ENGINE is a long-standing MySQL compatibility decoration. GMS and
+		// MyDuck have historically accepted engines they do not implement and
+		// still materialized those tables locally. Preserve that behavior for
+		// arbitrary simple engine identifiers; DUCKLAKE remains the sole object
+		// storage spelling.
+		return TableStorageLocal, false, nil
+	}
+}
+
+func isTableStorageAliasName(name string) bool {
+	switch name {
+	case "storage", "storage_kind", "storage_type", "myduck_storage_kind", "ducklake_storage":
+		return true
+	default:
+		return false
+	}
+}
+
+func isTableStorageCredentialOption(name string) bool {
+	for _, part := range []string{
+		"access_key", "access_key_id", "secret", "secret_key", "secret_access_key",
+		"credential", "credentials", "password", "token", "key_id", "session_token",
+	} {
+		if name == part || strings.HasPrefix(name, part+"_") || strings.HasSuffix(name, "_"+part) {
+			return true
+		}
+	}
+	return false
+}
+
+func isTableStoragePathOption(name string) bool {
+	for _, part := range []string{
+		"endpoint", "s3_endpoint", "data_path", "metadata_path", "object_path",
+		"lake_path", "bucket", "path", "region", "url_style", "use_ssl", "tls",
+	} {
+		if name == part || strings.HasPrefix(name, part+"_") || strings.HasSuffix(name, "_"+part) {
+			return true
+		}
+	}
+	return false
+}

--- a/catalog/table_storage_test.go
+++ b/catalog/table_storage_test.go
@@ -1,0 +1,215 @@
+package catalog
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeTableStorageOptionsDefaultsAndSelectors(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []TableStorageOption
+		want    TableStorageSelection
+	}{
+		{
+			name: "default",
+			want: DefaultTableStorageSelection(),
+		},
+		{
+			name: "postgres object",
+			options: []TableStorageOption{{
+				Name:  TableStorageOptionName,
+				Value: "'object'",
+			}},
+			want: TableStorageSelection{Kind: TableStorageObject, Explicit: true, Source: "storage-option"},
+		},
+		{
+			name: "postgres local",
+			options: []TableStorageOption{{
+				Name:  TableStorageOptionName,
+				Value: "local",
+			}},
+			want: TableStorageSelection{Kind: TableStorageLocal, Explicit: true, Source: "storage-option"},
+		},
+		{
+			name:    "mysql object",
+			options: []TableStorageOption{{Name: "ENGINE", Value: "DUCKLAKE"}},
+			want:    TableStorageSelection{Kind: TableStorageObject, Explicit: true, Source: "mysql-engine"},
+		},
+		{
+			name:    "mysql explicit local",
+			options: []TableStorageOption{{Name: "engine", Value: "LOCAL"}},
+			want:    TableStorageSelection{Kind: TableStorageLocal, Explicit: true, Source: "mysql-engine"},
+		},
+		{
+			name:    "ordinary mysql engine remains local",
+			options: []TableStorageOption{{Name: "engine", Value: "InnoDB"}},
+			want:    DefaultTableStorageSelection(),
+		},
+		{
+			name:    "ordinary options remain local",
+			options: []TableStorageOption{{Name: "comment", Value: "kept by the normal planner"}},
+			want:    DefaultTableStorageSelection(),
+		},
+		{
+			name:    "ordinary key option remains local",
+			options: []TableStorageOption{{Name: "key_block_size", Value: "8"}},
+			want:    DefaultTableStorageSelection(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeTableStorageOptions(tt.options)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveTableStorageProtocolMaps(t *testing.T) {
+	mysql, err := ResolveMySQLTableStorage(map[string]interface{}{"ENGINE": "DUCKLAKE"})
+	require.NoError(t, err)
+	require.Equal(t, TableStorageSelection{Kind: TableStorageObject, Explicit: true, Source: "mysql-engine"}, mysql)
+
+	postgres, err := ResolvePostgresStorageParams(map[string]string{TableStorageOptionName: "'object'"})
+	require.NoError(t, err)
+	require.Equal(t, TableStorageSelection{Kind: TableStorageObject, Explicit: true, Source: "storage-option"}, postgres)
+
+	local, err := ResolvePostgresStorageParams(nil)
+	require.NoError(t, err)
+	require.Equal(t, DefaultTableStorageSelection(), local)
+}
+
+func TestNormalizeTableStorageOptionsRejectsInvalidSelectors(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []TableStorageOption
+		want    error
+	}{
+		{
+			name: "duplicate postgres selector",
+			options: []TableStorageOption{
+				{Name: TableStorageOptionName, Value: "object"},
+				{Name: TableStorageOptionName, Value: "object"},
+			},
+			want: ErrTableStorageDuplicate,
+		},
+		{
+			name: "duplicate mysql selector",
+			options: []TableStorageOption{
+				{Name: "engine", Value: "DUCKLAKE"},
+				{Name: "engine", Value: "DUCKLAKE"},
+			},
+			want: ErrTableStorageDuplicate,
+		},
+		{
+			name: "same value through both selectors",
+			options: []TableStorageOption{
+				{Name: TableStorageOptionName, Value: "object"},
+				{Name: "engine", Value: "DUCKLAKE"},
+			},
+			want: ErrTableStorageDuplicate,
+		},
+		{
+			name: "same value through both selectors reversed",
+			options: []TableStorageOption{
+				{Name: "engine", Value: "DUCKLAKE"},
+				{Name: TableStorageOptionName, Value: "object"},
+			},
+			want: ErrTableStorageDuplicate,
+		},
+		{
+			name: "conflicting selectors",
+			options: []TableStorageOption{
+				{Name: TableStorageOptionName, Value: "object"},
+				{Name: "engine", Value: "LOCAL"},
+			},
+			want: ErrTableStorageConflict,
+		},
+		{
+			name:    "unknown postgres value",
+			options: []TableStorageOption{{Name: TableStorageOptionName, Value: "remote"}},
+			want:    ErrInvalidTableStorage,
+		},
+		{
+			name:    "unknown selector alias",
+			options: []TableStorageOption{{Name: "storage_kind", Value: "object"}},
+			want:    ErrInvalidTableStorage,
+		},
+		{
+			name:    "unknown mysql engine remains local",
+			options: []TableStorageOption{{Name: "engine", Value: "remote"}},
+			want:    nil,
+		},
+		{
+			name:    "credential option",
+			options: []TableStorageOption{{Name: "myduck_access_key_id", Value: "not persisted"}},
+			want:    ErrTableStorageCredentialSQL,
+		},
+		{
+			name:    "path option",
+			options: []TableStorageOption{{Name: "ducklake_bucket", Value: "test-bucket"}},
+			want:    ErrTableStoragePathSQL,
+		},
+		{
+			name:    "nonliteral value",
+			options: []TableStorageOption{{Name: TableStorageOptionName, Value: 42}},
+			want:    ErrInvalidTableStorage,
+		},
+		{
+			name:    "injected value",
+			options: []TableStorageOption{{Name: TableStorageOptionName, Value: "object;DROP TABLE t"}},
+			want:    ErrInvalidTableStorage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeTableStorageOptions(tt.options)
+			if tt.want == nil {
+				require.NoError(t, err)
+				require.Equal(t, DefaultTableStorageSelection(), got)
+				return
+			}
+			require.Error(t, err)
+			require.Truef(t, errors.Is(err, tt.want), "error %q does not wrap %v", err, tt.want)
+		})
+	}
+}
+
+func TestTableStorageSelectionContext(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	object := TableStorageSelection{Kind: TableStorageObject, Explicit: true, Source: "test"}
+	require.NoError(t, SetTableStorageSelection(ctx, object))
+
+	got, ok := TableStorageSelectionFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, object, got)
+
+	local := TableStorageSelection{Kind: TableStorageLocal, Explicit: true, Source: "copy"}
+	copyCtx, err := WithTableStorageSelection(ctx, local)
+	require.NoError(t, err)
+	copyGot, copyOK := TableStorageSelectionFromContext(copyCtx)
+	require.True(t, copyOK)
+	require.Equal(t, local, copyGot)
+
+	originalGot, originalOK := TableStorageSelectionFromContext(ctx)
+	require.True(t, originalOK)
+	require.Equal(t, object, originalGot)
+
+	_, ok = TableStorageSelectionFromContext(sql.NewEmptyContext())
+	require.False(t, ok)
+	require.Error(t, SetTableStorageSelection(nil, object))
+	require.Error(t, SetTableStorageSelection(ctx, TableStorageSelection{}))
+	_, err = WithTableStorageSelection(nil, object)
+	require.Error(t, err)
+}
+
+func TestTableStorageSelectionEffectiveKind(t *testing.T) {
+	require.Equal(t, TableStorageLocal, (TableStorageSelection{}).EffectiveKind())
+	require.Equal(t, TableStorageObject, (TableStorageSelection{Kind: TableStorageObject}).EffectiveKind())
+}

--- a/pgserver/duck_handler.go
+++ b/pgserver/duck_handler.go
@@ -173,6 +173,11 @@ func (h *DuckHandler) ComPrepareParsed(ctx context.Context, c *mysql.Conn, query
 		return nil, nil, nil, err
 	}
 
+	prepareQuery, err := postgresCreateTableQueryForPrepare(query, parsed)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	var (
 		stmt       *duckdb.Stmt
 		stmtType   duckdb.StmtType
@@ -182,7 +187,7 @@ func (h *DuckHandler) ComPrepareParsed(ctx context.Context, c *mysql.Conn, query
 	// But we know that the connection is a DuckDB connection and it is kept alive.
 	err = conn.Raw(func(driverConn interface{}) error {
 		dc := driverConn.(*duckdb.Conn)
-		s, err := dc.PrepareContext(sqlCtx, query)
+		s, err := dc.PrepareContext(sqlCtx, prepareQuery)
 		if err != nil {
 			return err
 		}
@@ -505,8 +510,37 @@ func (h *DuckHandler) executeQuery(ctx *sql.Context, query string, parsed tree.S
 	// NOTE: The query is parsed using Postgres parser, which does not support all DuckDB syntax.
 	//   Consequently, the following classification is not perfect.
 	switch parsed := parsed.(type) {
+	case *tree.CreateTable:
+		selection, createErr := setPostgresCreateTableStorage(ctx, parsed)
+		if createErr != nil {
+			err = createErr
+			break
+		}
+		if parsed.Persistence == tree.PersistenceTemporary && selection.IsObjectStorage() {
+			err = fmt.Errorf("%w: temporary tables cannot use object storage", catalog.ErrInvalidTableStorage)
+			break
+		}
+		executionQuery, _, createErr := postgresCreateTableExecutionQuery(query, parsed)
+		if createErr != nil {
+			err = createErr
+			break
+		}
+		result, err = adapter.Exec(ctx, executionQuery)
+		if err == nil {
+			err = persistPostgresCreateTableStorage(ctx, parsed, selection)
+		}
+		if err != nil {
+			break
+		}
+		affected, _ := result.RowsAffected()
+		insertId, _ := result.LastInsertId()
+		schema = types.OkResultSchema
+		iter = sql.RowsToRowIter(sql.NewRow(types.OkResult{
+			RowsAffected: uint64(affected),
+			InsertID:     uint64(insertId),
+		}))
 	case *tree.BeginTransaction, *tree.CommitTransaction, *tree.RollbackTransaction,
-		*tree.CreateTable, *tree.DropTable, *tree.AlterTable, *tree.CreateIndex, *tree.DropIndex,
+		*tree.DropTable, *tree.AlterTable, *tree.CreateIndex, *tree.DropIndex,
 		*tree.Update, *tree.Delete, *tree.Truncate, *tree.CopyFrom, *tree.CopyTo, *tree.SetVar:
 		result, err = adapter.Exec(ctx, query)
 		if err != nil {
@@ -720,6 +754,37 @@ func (h *DuckHandler) executeBoundPlan(ctx *sql.Context, query string, parsed tr
 			rows.Close()
 		}
 		return schema, iter, nil, err
+	}
+
+	// Prepared PostgreSQL DDL is executed through this bound-plan path rather
+	// than executeQuery. Keep CREATE TABLE's selector and metadata behavior
+	// identical to the simple-query path, and remove MyDuck-only WITH options
+	// before handing the statement to DuckDB.
+	if create, ok := parsed.(*tree.CreateTable); ok {
+		selection, createErr := setPostgresCreateTableStorage(ctx, create)
+		if createErr != nil {
+			return nil, nil, nil, createErr
+		}
+		if create.Persistence == tree.PersistenceTemporary && selection.IsObjectStorage() {
+			return nil, nil, nil, fmt.Errorf("%w: temporary tables cannot use object storage", catalog.ErrInvalidTableStorage)
+		}
+		executionQuery, _, createErr := postgresCreateTableExecutionQuery(query, create)
+		if createErr != nil {
+			return nil, nil, nil, createErr
+		}
+		result, createErr := adapter.ExecCatalog(ctx, executionQuery, vars...)
+		if createErr != nil {
+			return nil, nil, nil, createErr
+		}
+		if createErr = persistPostgresCreateTableStorage(ctx, create, selection); createErr != nil {
+			return nil, nil, nil, createErr
+		}
+		affected, _ := result.RowsAffected()
+		insertID, _ := result.LastInsertId()
+		return types.OkResultSchema, sql.RowsToRowIter(sql.NewRow(types.OkResult{
+			RowsAffected: uint64(affected),
+			InsertID:     uint64(insertID),
+		})), nil, nil
 	}
 
 	switch stmtType {

--- a/pgserver/table_storage.go
+++ b/pgserver/table_storage.go
@@ -1,0 +1,124 @@
+package pgserver
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/apecloud/myduckserver/adapter"
+	"github.com/apecloud/myduckserver/catalog"
+	"github.com/apecloud/myduckserver/mycontext"
+	"github.com/cockroachdb/cockroachdb-parser/pkg/sql/sem/tree"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// postgresCreateTableStorage normalizes the table-level storage parameters
+// while preserving their order (and therefore duplicate declarations). The
+// Cockroach parser exposes expressions as String values; the catalog resolver
+// validates that selector values are simple literals and contain no secrets or
+// paths.
+func postgresCreateTableStorage(stmt *tree.CreateTable) (catalog.TableStorageSelection, error) {
+	if stmt == nil {
+		return catalog.DefaultTableStorageSelection(), nil
+	}
+	options := make([]catalog.TableStorageOption, 0, len(stmt.StorageParams))
+	for _, param := range stmt.StorageParams {
+		var value any
+		if param.Value != nil {
+			value = param.Value.String()
+		}
+		options = append(options, catalog.TableStorageOption{
+			Name:  param.Key.String(),
+			Value: value,
+		})
+	}
+	return catalog.ResolvePostgresStorageOptions(options)
+}
+
+// postgresCreateTableExecutionQuery returns a query that is safe to hand to
+// DuckDB. PostgreSQL's custom WITH (myduck_storage=...) parameter is consumed
+// by MyDuck and must not be forwarded as an unknown DuckDB storage option.
+// Other PostgreSQL storage parameters remain in the formatted statement and
+// retain the existing execution behavior.
+func postgresCreateTableExecutionQuery(query string, stmt *tree.CreateTable) (string, catalog.TableStorageSelection, error) {
+	selection, err := postgresCreateTableStorage(stmt)
+	if err != nil {
+		return "", catalog.TableStorageSelection{}, err
+	}
+	if stmt == nil || len(stmt.StorageParams) == 0 {
+		return query, selection, nil
+	}
+
+	custom := false
+	params := make(tree.StorageParams, 0, len(stmt.StorageParams))
+	for _, param := range stmt.StorageParams {
+		if strings.EqualFold(strings.TrimSpace(param.Key.String()), catalog.TableStorageOptionName) {
+			custom = true
+			continue
+		}
+		params = append(params, param)
+	}
+	if !custom {
+		return query, selection, nil
+	}
+
+	copyStmt := *stmt
+	if len(params) == 0 {
+		copyStmt.StorageParams = nil
+	} else {
+		copyStmt.StorageParams = params
+	}
+	return tree.AsString(&copyStmt), selection, nil
+}
+
+// setPostgresCreateTableStorage validates and attaches the request-scoped
+// selection used by the catalog boundary. Replication-origin DDL deliberately
+// keeps its historical path and metadata behavior unchanged.
+func setPostgresCreateTableStorage(ctx *sql.Context, stmt *tree.CreateTable) (catalog.TableStorageSelection, error) {
+	selection, err := postgresCreateTableStorage(stmt)
+	if err != nil {
+		return catalog.TableStorageSelection{}, err
+	}
+	if err := catalog.SetTableStorageSelection(ctx, selection); err != nil {
+		return catalog.TableStorageSelection{}, err
+	}
+	return selection, nil
+}
+
+func persistPostgresCreateTableStorage(ctx *sql.Context, stmt *tree.CreateTable, selection catalog.TableStorageSelection) error {
+	if stmt == nil || stmt.Persistence == tree.PersistenceTemporary || mycontext.IsReplicationQuery(ctx) {
+		return nil
+	}
+
+	schemaName := stmt.Table.Schema()
+	if schemaName == "" {
+		schemaName = adapter.GetCurrentSchema(ctx)
+	}
+	if schemaName == "" {
+		schemaName = ctx.GetCurrentDatabase()
+	}
+	if schemaName == "" {
+		return fmt.Errorf("cannot determine PostgreSQL schema for table %q", stmt.Table.Table())
+	}
+	catalogName := stmt.Table.Catalog()
+	if catalogName == "" {
+		catalogName = adapter.GetCurrentCatalog(ctx)
+	}
+	if catalogName == "" {
+		return fmt.Errorf("cannot determine PostgreSQL catalog for table %q", stmt.Table.Table())
+	}
+
+	db := catalog.NewDatabase(schemaName, catalogName)
+	return db.RecordTableStorageSelection(ctx, stmt.Table.Table(), selection)
+}
+
+// postgresCreateTableQueryForPrepare sanitizes only CREATE TABLE statements;
+// it is shared by simple and extended PostgreSQL protocol paths so a
+// prepared DDL sees the same selector semantics as a simple query.
+func postgresCreateTableQueryForPrepare(query string, parsed tree.Statement) (string, error) {
+	stmt, ok := parsed.(*tree.CreateTable)
+	if !ok {
+		return query, nil
+	}
+	executionQuery, _, err := postgresCreateTableExecutionQuery(query, stmt)
+	return executionQuery, err
+}

--- a/pgserver/table_storage_wire_test.go
+++ b/pgserver/table_storage_wire_test.go
@@ -1,0 +1,71 @@
+package pgserver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/apecloud/myduckserver/catalog"
+	"github.com/apecloud/myduckserver/testutil"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableStorageSelectionWireMetadata(t *testing.T) {
+	originalWorkingDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { require.NoError(t, os.Chdir(originalWorkingDir)) }()
+
+	testDir := testutil.CreateTestDir(t)
+	testEnv := testutil.NewTestEnv()
+	require.NoError(t, testutil.StartDuckSqlServer(t, testDir, nil, testEnv))
+	t.Cleanup(func() {
+		require.NoError(t, testEnv.MyDuckServer.Close())
+		testutil.StopDuckSqlServer(t, testEnv.DuckProcess)
+	})
+
+	db := testEnv.MyDuckServer
+	_, err = db.Exec("CREATE DATABASE storage_wire")
+	require.NoError(t, err)
+	_, err = db.Exec("USE storage_wire")
+	require.NoError(t, err)
+
+	_, err = db.Exec("CREATE TABLE mysql_object (id INT, payload VARCHAR(32)) ENGINE=DUCKLAKE")
+	require.NoError(t, err)
+	_, err = db.Exec("CREATE TABLE mysql_default (id INT)")
+	require.NoError(t, err)
+	_, err = db.Exec("CREATE TABLE mysql_local (id INT) ENGINE=LOCAL")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	pg, err := pgx.Connect(ctx, "postgresql://postgres@127.0.0.1:"+strconv.Itoa(testEnv.DuckPgPort)+"/postgres")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pg.Close(ctx) })
+	requireStorageKindPG(t, ctx, pg, "storage_wire", "mysql_object", catalog.TableStorageObject)
+	requireStorageKindPG(t, ctx, pg, "storage_wire", "mysql_default", catalog.TableStorageLocal)
+	requireStorageKindPG(t, ctx, pg, "storage_wire", "mysql_local", catalog.TableStorageLocal)
+
+	_, err = pg.Exec(ctx, "CREATE TABLE storage_wire.pg_object (id INTEGER) WITH (myduck_storage = 'object')")
+	require.NoError(t, err)
+	_, err = pg.Exec(ctx, "CREATE TABLE storage_wire.pg_default (id INTEGER)")
+	require.NoError(t, err)
+	_, err = pg.Prepare(ctx, "storage_wire_prepared_object", "CREATE TABLE storage_wire.pg_prepared_object (id INTEGER) WITH (myduck_storage = 'object')")
+	require.NoError(t, err)
+	_, err = pg.Exec(ctx, "storage_wire_prepared_object")
+	require.NoError(t, err)
+	requireStorageKindPG(t, ctx, pg, "storage_wire", "pg_object", catalog.TableStorageObject)
+	requireStorageKindPG(t, ctx, pg, "storage_wire", "pg_default", catalog.TableStorageLocal)
+	requireStorageKindPG(t, ctx, pg, "storage_wire", "pg_prepared_object", catalog.TableStorageObject)
+}
+
+func requireStorageKindPG(t *testing.T, ctx context.Context, db *pgx.Conn, catalogName, tableName string, want catalog.TableStorageKind) {
+	t.Helper()
+	var raw string
+	// PostgreSQL exposes MyDuck's physical catalog as `myduck` and maps the
+	// user database to the schema name.
+	query := fmt.Sprintf("SELECT comment FROM duckdb_tables() WHERE database_name = 'myduck' AND schema_name = '%s' AND table_name = '%s'", catalogName, tableName)
+	require.NoError(t, db.QueryRow(ctx, query).Scan(&raw))
+	require.Equal(t, want, catalog.DecodeComment[catalog.ExtraTableInfo](raw).Meta.StorageKind())
+}


### PR DESCRIPTION
## Scope

Persist the locked table-level storage selector for newly created tables:

- PostgreSQL: `WITH (myduck_storage = 'object'|'local')`
- MySQL: `ENGINE=DUCKLAKE` (ordinary engines retain local compatibility behavior)
- omitted selector defaults to `local`
- selector values reject credentials, endpoints, paths, duplicates, and conflicts
- managed table metadata survives catalog reload

This PR does not implement physical DuckLake CRUD, migration of existing tables, replication changes, release/image changes, or changes to PR #488.

## Verification

- `go test ./catalog -run '^Test(TableStorage|Normalize|Resolve)' -count=1`
- `go test -tags gms_pure_go ./backend -run '^TestMySQLParser|^TestMySQLCompatibility' -count=1`
- `go test -tags 'gms_pure_go duckdb_arrow ducklake_integration' ./pgserver -run '^$' -count=1`
