### PR TITLE
fix: coordinate graceful shutdown

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -126,4 +126,4 @@ COPY --chown=admin:admin --chmod=755 devtools/replica-setup-postgres ./replica-s
 RUN myduckserver --init
 
 EXPOSE 3306 5432
-ENTRYPOINT /home/admin/entrypoint.sh
+ENTRYPOINT ["/home/admin/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,7 +5,18 @@ export LOG_PATH="${HOME}/log"
 export MYSQL_REPLICA_SETUP_PATH="${HOME}/replica-setup-mysql"
 export POSTGRES_REPLICA_SETUP_PATH="${HOME}/replica-setup-postgres"
 export PID_FILE="${LOG_PATH}/myduck.pid"
+export LOG_PIPE="${LOG_PATH}/myduck.log.pipe"
 export INIT_SQLS_DIR="/docker-entrypoint-initdb.d"
+
+SERVER_PID=""
+LOGGER_PID=""
+SETUP_PID=""
+SERVER_SIGNAL_SENT=false
+SETUP_SIGNAL_SENT=false
+LOG_PIPE_GUARD_OPEN=false
+PID_TEMP_FILE="${PID_FILE}.tmp.$$"
+SHUTDOWN_SIGNAL=""
+SERVER_OPTIONS=()
 
 parse_dsn() {
     # Check if SOURCE_DSN is set
@@ -130,13 +141,173 @@ parse_dsn() {
     fi
 }
 
-# Add signal handling function
-cleanup() {
-    echo "Received shutdown signal, cleaning up..."
-    if [[ -f "${PID_FILE}" ]]; then
-        kill "$(cat "${PID_FILE}")" 2>/dev/null
-        rm -f "${PID_FILE}"
+cleanup_process_files() {
+    close_log_pipe_guard
+    rm -f "${PID_FILE}" "${PID_TEMP_FILE}" "${LOG_PIPE}"
+}
+
+close_log_pipe_guard() {
+    if [[ "${LOG_PIPE_GUARD_OPEN}" == "true" ]]; then
+        exec 9>&-
+        LOG_PIPE_GUARD_OPEN=false
     fi
+}
+
+signal_exit_status() {
+    case "$1" in
+        HUP) return 129 ;;
+        INT) return 130 ;;
+        QUIT) return 131 ;;
+        TERM) return 143 ;;
+        *) return 1 ;;
+    esac
+}
+
+signal_children() {
+    if [[ -z "${SHUTDOWN_SIGNAL}" ]]; then
+        return
+    fi
+    if [[ "${SERVER_SIGNAL_SENT}" == "false" ]] && [[ -n "${SERVER_PID}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+        if kill -s "${SHUTDOWN_SIGNAL}" "${SERVER_PID}" 2>/dev/null; then
+            SERVER_SIGNAL_SENT=true
+        fi
+    fi
+    if [[ "${SETUP_SIGNAL_SENT}" == "false" ]] && [[ -n "${SETUP_PID}" ]] && kill -0 "${SETUP_PID}" 2>/dev/null; then
+        if kill -s TERM "${SETUP_PID}" 2>/dev/null; then
+            SETUP_SIGNAL_SENT=true
+        fi
+    fi
+}
+
+# Signal delivery interrupts Bash's current wait. Record the request and signal
+# every known child immediately; the main flow performs the blocking reap.
+# shellcheck disable=SC2329
+request_shutdown() {
+    if [[ -n "${SHUTDOWN_SIGNAL}" ]]; then
+        return
+    fi
+    SHUTDOWN_SIGNAL="$1"
+    echo "Received ${SHUTDOWN_SIGNAL}, forwarding it to MyDuck Server..."
+    signal_children
+}
+
+wait_for_pid() {
+    local pid="$1"
+    local status
+
+    while true; do
+        wait "${pid}" 2>/dev/null
+        status=$?
+        if kill -0 "${pid}" 2>/dev/null; then
+            continue
+        fi
+        return "${status}"
+    done
+}
+
+stop_setup_process() {
+    local setup_pid="${SETUP_PID}"
+
+    if [[ -z "${setup_pid}" ]]; then
+        return
+    fi
+    if [[ "${SETUP_SIGNAL_SENT}" == "false" ]] && kill -0 "${setup_pid}" 2>/dev/null; then
+        if kill -s TERM "${setup_pid}" 2>/dev/null; then
+            SETUP_SIGNAL_SENT=true
+        fi
+    fi
+    # The database has already drained at every call site. Do not let a
+    # TERM-resistant readiness/init client keep PID 1 alive until Docker KILLs it.
+    if kill -0 "${setup_pid}" 2>/dev/null; then
+        kill -s KILL "${setup_pid}" 2>/dev/null
+    fi
+    wait_for_pid "${setup_pid}" >/dev/null 2>&1
+    SETUP_PID=""
+    SETUP_SIGNAL_SENT=false
+}
+
+run_setup_command() {
+    local status
+
+    if [[ -n "${SHUTDOWN_SIGNAL}" ]]; then
+        complete_shutdown
+    fi
+    "$@" &
+    SETUP_PID=$!
+    SETUP_SIGNAL_SENT=false
+    signal_children
+    wait "${SETUP_PID}" 2>/dev/null
+    status=$?
+    if [[ -n "${SHUTDOWN_SIGNAL}" ]]; then
+        complete_shutdown
+    fi
+    while kill -0 "${SETUP_PID}" 2>/dev/null; do
+        wait "${SETUP_PID}" 2>/dev/null
+        status=$?
+    done
+    SETUP_PID=""
+    SETUP_SIGNAL_SENT=false
+    return "${status}"
+}
+
+wait_for_server_and_logger() {
+    local server_status=0
+    local logger_status=0
+
+    if [[ -n "${SERVER_PID}" ]]; then
+        wait_for_pid "${SERVER_PID}"
+        server_status=$?
+        SERVER_PID=""
+        SERVER_SIGNAL_SENT=false
+    fi
+
+    if [[ -n "${LOGGER_PID}" ]]; then
+        wait_for_pid "${LOGGER_PID}"
+        logger_status=$?
+        LOGGER_PID=""
+    fi
+
+    if [[ ${server_status} -ne 0 ]]; then
+        return "${server_status}"
+    fi
+    return "${logger_status}"
+}
+
+complete_shutdown() {
+    local had_server=false
+    local status
+
+    trap - EXIT
+    trap '' SIGTERM SIGINT SIGQUIT
+    if [[ -n "${SERVER_PID}" ]]; then
+        had_server=true
+    fi
+    signal_children
+    wait_for_server_and_logger
+    status=$?
+    stop_setup_process
+    cleanup_process_files
+
+    if [[ "${had_server}" == "true" ]]; then
+        exit "${status}"
+    fi
+    signal_exit_status "${SHUTDOWN_SIGNAL}"
+    exit $?
+}
+
+# Reached through the EXIT trap below.
+# shellcheck disable=SC2329
+cleanup_on_exit() {
+    local original_status=$?
+
+    trap - EXIT
+    trap '' SIGTERM SIGINT SIGQUIT
+    SHUTDOWN_SIGNAL="TERM"
+    signal_children
+    wait_for_server_and_logger >/dev/null 2>&1
+    stop_setup_process
+    cleanup_process_files
+    exit "${original_status}"
 }
 
 # Define MYSQL_PASSWORD_OPTION based on SUPERUSER_PASSWORD
@@ -172,6 +343,7 @@ run_replica_setup() {
     export MYDUCK_PASSWORD="${SUPERUSER_PASSWORD}"
 
     # Run replica_setup.sh and check for errors
+    # shellcheck source=/dev/null
     if source replica_setup.sh; then
         echo "Replica setup completed."
     else
@@ -181,18 +353,63 @@ run_replica_setup() {
 }
 
 run_server_in_background() {
-      cd "$DATA_PATH" || { echo "Error: Could not change directory to ${DATA_PATH}"; exit 1; }
-      nohup myduckserver \
-        ${DEFAULT_DB_OPTION} \
-        ${SUPERUSER_PASSWORD_OPTION} \
-        ${LOG_LEVEL_OPTION} \
-        ${PROFILER_PORT_OPTION} \
-        ${RESTORE_FILE_OPTION} \
-        ${RESTORE_ENDPOINT_OPTION} \
-        ${RESTORE_ACCESS_KEY_ID_OPTION} \
-        ${RESTORE_SECRET_ACCESS_KEY_OPTION} \
-        | tee -a "${LOG_PATH}/server.log" 2>&1 &
-      echo "$!" > "${PID_FILE}"
+    local status
+
+    cd "$DATA_PATH" || { echo "Error: Could not change directory to ${DATA_PATH}"; return 1; }
+    rm -f "${LOG_PIPE}"
+    status=$?
+    if [[ ${status} -ne 0 ]]; then
+        return "${status}"
+    fi
+    mkfifo "${LOG_PIPE}"
+    status=$?
+    if [[ ${status} -ne 0 ]]; then
+        return "${status}"
+    fi
+    if [[ -n "${SHUTDOWN_SIGNAL}" ]]; then
+        complete_shutdown
+    fi
+
+    exec 9<> "${LOG_PIPE}"
+    status=$?
+    if [[ ${status} -ne 0 ]]; then
+        return "${status}"
+    fi
+    LOG_PIPE_GUARD_OPEN=true
+    if [[ -n "${SHUTDOWN_SIGNAL}" ]]; then
+        complete_shutdown
+    fi
+
+    # FD 9 keeps both FIFO ends open until both child PIDs are known. Each child
+    # closes its inherited guard before opening the endpoint it actually owns.
+    myduckserver "${SERVER_OPTIONS[@]}" 9>&- > "${LOG_PIPE}" 2>&1 &
+    SERVER_PID=$!
+    SERVER_SIGNAL_SENT=false
+    signal_children
+    if [[ -n "${SHUTDOWN_SIGNAL}" ]]; then
+        complete_shutdown
+    fi
+
+    tee -a "${LOG_PATH}/server.log" 9>&- < "${LOG_PIPE}" &
+    LOGGER_PID=$!
+    signal_children
+    close_log_pipe_guard
+    if [[ -n "${SHUTDOWN_SIGNAL}" ]]; then
+        complete_shutdown
+    fi
+
+    printf '%s\n' "${SERVER_PID}" > "${PID_TEMP_FILE}"
+    status=$?
+    if [[ ${status} -eq 0 ]]; then
+        mv "${PID_TEMP_FILE}" "${PID_FILE}"
+        status=$?
+    fi
+    if [[ ${status} -ne 0 ]]; then
+        return "${status}"
+    fi
+    if [[ -n "${SHUTDOWN_SIGNAL}" ]]; then
+        complete_shutdown
+    fi
 }
 
 wait_for_my_duck_server_ready() {
@@ -202,14 +419,36 @@ wait_for_my_duck_server_ready() {
     local max_attempts=30
     local attempt=0
     local wait_time=2
+    local status
 
     echo "Waiting for MyDuck Server at $host:$port to be ready..."
 
-    until mysqlsh --sql --host "$host" --port "$port" --user "$user" ${MYSQL_PASSWORD_OPTION} --execute "SELECT VERSION();" &> /dev/null; do
+    until run_setup_command mysqlsh --sql --host "$host" --port "$port" --user "$user" "${MYSQL_PASSWORD_OPTION}" --execute "SELECT VERSION();" &> /dev/null; do
+        if [[ -n "${SERVER_PID}" ]] && ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+            wait_for_pid "${SERVER_PID}"
+            status=$?
+            SERVER_PID=""
+            SERVER_SIGNAL_SENT=false
+            echo "CRITICAL: MyDuck Server process died during startup."
+            if [[ ${status} -eq 0 ]]; then
+                return 1
+            fi
+            return "${status}"
+        fi
+        if [[ -n "${LOGGER_PID}" ]] && ! kill -0 "${LOGGER_PID}" 2>/dev/null; then
+            wait_for_pid "${LOGGER_PID}"
+            status=$?
+            LOGGER_PID=""
+            echo "CRITICAL: server logger process died during startup."
+            if [[ ${status} -eq 0 ]]; then
+                return 1
+            fi
+            return "${status}"
+        fi
         attempt=$((attempt+1))
         if [ "$attempt" -ge "$max_attempts" ]; then
             echo "Error: MySQL connection timeout after $max_attempts attempts."
-            exit 1
+            return 1
         fi
         echo "Attempt $attempt/$max_attempts: MyDuck Server is unavailable - retrying in $wait_time seconds..."
         sleep $wait_time
@@ -218,27 +457,6 @@ wait_for_my_duck_server_ready() {
     echo "MyDuck Server is ready!"
 }
 
-
-# Function to check if a process is alive by its PID file
-check_process_alive() {
-    local pid_file="$1"
-    local proc_name="$2"
-
-    if [[ -f "${pid_file}" ]]; then
-        local pid
-        pid=$(<"${pid_file}")
-
-        if [[ -n "${pid}" && -e "/proc/${pid}" ]]; then
-            return 0  # Process is running
-        else
-            echo "${proc_name} (PID: ${pid}) is not running."
-            return 1
-        fi
-    else
-        echo "PID file for ${proc_name} not found!"
-        return 1
-    fi
-}
 
 execute_init_sqls() {
     local host="127.0.0.1"
@@ -250,70 +468,71 @@ execute_init_sqls() {
         echo "Executing init SQL scripts from $INIT_SQLS_DIR/mysql..."
         for file in "$INIT_SQLS_DIR/mysql"/*.sql; do
             echo "Executing $file..."
-            mysqlsh --sql --host "$host" --port "$mysql_port" --user "$mysql_user" $MYSQL_PASSWORD_OPTION --file="$file"
+            run_setup_command mysqlsh --sql --host "$host" --port "$mysql_port" --user "$mysql_user" "${MYSQL_PASSWORD_OPTION}" --file="$file" || true
         done
     fi
     if [ -d "$INIT_SQLS_DIR/postgres" ] && [ "$(find "$INIT_SQLS_DIR/postgres" -maxdepth 1 -name '*.sql' -type f | head -n 1)" ]; then
         echo "Executing init SQL scripts from $INIT_SQLS_DIR/postgres..."
         for file in "$INIT_SQLS_DIR/postgres"/*.sql; do
             echo "Executing $file..."
-            PGPASSWORD="$SUPERUSER_PASSWORD" psql -h "$host" -p "$postgres_port" -U "$postgres_user" -f "$file"
+            run_setup_command env PGPASSWORD="$SUPERUSER_PASSWORD" psql -h "$host" -p "$postgres_port" -U "$postgres_user" -f "$file" || true
         done
     fi
+    return 0
 }
 
 # Handle the setup_mode
 setup() {
-    # Setup signal handlers
-    trap cleanup SIGTERM SIGINT SIGQUIT
-
     if [ -n "$DEFAULT_DB" ]; then
-        export DEFAULT_DB_OPTION="--default-db=$DEFAULT_DB"
+        SERVER_OPTIONS+=("--default-db=$DEFAULT_DB")
     fi
 
     if [ -n "$SUPERUSER_PASSWORD" ]; then
-        export SUPERUSER_PASSWORD_OPTION="--superuser-password=$SUPERUSER_PASSWORD"
+        SERVER_OPTIONS+=("--superuser-password=$SUPERUSER_PASSWORD")
     fi
 
     if [ -n "$LOG_LEVEL" ]; then
-        export LOG_LEVEL_OPTION="--loglevel=$LOG_LEVEL"
+        SERVER_OPTIONS+=("--loglevel=$LOG_LEVEL")
     fi
     
     if [ -n "$PROFILER_PORT" ]; then
-        export PROFILER_PORT_OPTION="--profiler-port=$PROFILER_PORT"
+        SERVER_OPTIONS+=("--profiler-port=$PROFILER_PORT")
     fi
 
     if [ -n "$RESTORE_FILE" ]; then
-        export RESTORE_FILE_OPTION="--restore-file=$RESTORE_FILE"
+        SERVER_OPTIONS+=("--restore-file=$RESTORE_FILE")
     fi
 
     if [ -n "$RESTORE_ENDPOINT" ]; then
-        export RESTORE_ENDPOINT_OPTION="--restore-endpoint=$RESTORE_ENDPOINT"
+        SERVER_OPTIONS+=("--restore-endpoint=$RESTORE_ENDPOINT")
     fi
 
     if [ -n "$RESTORE_ACCESS_KEY_ID" ]; then
-        export RESTORE_ACCESS_KEY_ID_OPTION="--restore-access-key-id=$RESTORE_ACCESS_KEY_ID"
+        SERVER_OPTIONS+=("--restore-access-key-id=$RESTORE_ACCESS_KEY_ID")
     fi
 
     if [ -n "$RESTORE_SECRET_ACCESS_KEY" ]; then
-        export RESTORE_SECRET_ACCESS_KEY_OPTION="--restore-secret-access-key=$RESTORE_SECRET_ACCESS_KEY"
+        SERVER_OPTIONS+=("--restore-secret-access-key=$RESTORE_SECRET_ACCESS_KEY")
     fi
 
     # Ensure required directories exist
-    mkdir -p "${DATA_PATH}" "${LOG_PATH}"
+    mkdir -p "${DATA_PATH}" "${LOG_PATH}" || return $?
+    if [[ -n "${SHUTDOWN_SIGNAL}" ]]; then
+        complete_shutdown
+    fi
 
     case "$SETUP_MODE" in
         "" | "SERVER")
             echo "Starting MyDuck Server in SERVER mode..."
-            run_server_in_background
-            wait_for_my_duck_server_ready
+            run_server_in_background || return $?
+            wait_for_my_duck_server_ready || return $?
             execute_init_sqls
             ;;
         "REPLICA")
             echo "Starting MyDuck Server in REPLICA mode..."
             parse_dsn
-            run_server_in_background
-            wait_for_my_duck_server_ready
+            run_server_in_background || return $?
+            wait_for_my_duck_server_ready || return $?
             execute_init_sqls
             run_replica_setup
             ;;
@@ -324,16 +543,26 @@ setup() {
     esac
 }
 
+trap 'request_shutdown TERM' SIGTERM
+trap 'request_shutdown INT' SIGINT
+trap 'request_shutdown QUIT' SIGQUIT
+trap cleanup_on_exit EXIT
+
 setup
+setup_status=$?
+if [[ ${setup_status} -ne 0 ]]; then
+    exit "${setup_status}"
+fi
 
-while true; do
-    # Check if the processes have started
-    if ! check_process_alive "$PID_FILE" "MyDuck Server"; then
-        echo "CRITICAL: MyDuck Server process died unexpectedly."
-        cleanup
-        exit 1
-    fi
+if [[ -n "${SHUTDOWN_SIGNAL}" ]]; then
+    complete_shutdown
+fi
 
-    # Sleep before the next status check
-    sleep 10
-done
+wait_for_server_and_logger
+server_status=$?
+cleanup_process_files
+if [[ -z "${SHUTDOWN_SIGNAL}" && ${server_status} -eq 0 ]]; then
+    echo "CRITICAL: MyDuck Server process exited unexpectedly."
+    exit 1
+fi
+exit "${server_status}"

--- a/docker/entrypoint_test.go
+++ b/docker/entrypoint_test.go
@@ -1,0 +1,410 @@
+//go:build unix
+
+package docker_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const processWaitTimeout = 5 * time.Second
+
+type entrypointFixture struct {
+	cmd               *exec.Cmd
+	stdout            *bytes.Buffer
+	stderr            *bytes.Buffer
+	homeDir           string
+	serverPIDFile     string
+	loggerPIDFile     string
+	readinessPIDFile  string
+	forwardedSignals  string
+	entrypointPIDFile string
+	logPipe           string
+	pidPublishStarted string
+	pidPublishRelease string
+}
+
+func TestDockerfileUsesExecFormEntrypoint(t *testing.T) {
+	contents, err := os.ReadFile("Dockerfile")
+	require.NoError(t, err)
+	require.Contains(t, string(contents), `ENTRYPOINT ["/home/admin/entrypoint.sh"]`)
+	require.NotContains(t, string(contents), "ENTRYPOINT /home/admin/entrypoint.sh")
+}
+
+func TestEntrypointKeepsFIFOOpenAcrossChildLaunches(t *testing.T) {
+	contents, err := os.ReadFile("entrypoint.sh")
+	require.NoError(t, err)
+	launch := string(contents)
+	launch = launch[strings.Index(launch, "run_server_in_background()"):]
+	guardOpen := strings.Index(launch, `exec 9<> "${LOG_PIPE}"`)
+	serverLaunch := strings.Index(launch, `myduckserver "${SERVER_OPTIONS[@]}" 9>&-`)
+	loggerLaunch := strings.Index(launch, `tee -a "${LOG_PATH}/server.log" 9>&-`)
+	guardClose := strings.Index(launch, "close_log_pipe_guard")
+	require.GreaterOrEqual(t, guardOpen, 0)
+	require.Greater(t, serverLaunch, guardOpen)
+	require.Greater(t, loggerLaunch, serverLaunch)
+	require.Greater(t, guardClose, loggerLaunch)
+}
+
+func TestEntrypointPreservesLegacyInitBehavior(t *testing.T) {
+	contents, err := os.ReadFile("entrypoint.sh")
+	require.NoError(t, err)
+	script := string(contents)
+	require.Contains(t, script, `export INIT_SQLS_DIR="/docker-entrypoint-initdb.d"`)
+	require.Contains(t, script, `--file="$file" || true`)
+	require.Contains(t, script, `-f "$file" || true`)
+}
+
+func TestEntrypointGoServerHelper(t *testing.T) {
+	if os.Getenv("FAKE_SERVER_IMPL") != "go" {
+		return
+	}
+
+	shutdownSignals := make(chan os.Signal, 1)
+	signal.Notify(shutdownSignals, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
+	require.NoError(t, os.WriteFile(os.Getenv("FAKE_SERVER_PID_FILE"), []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644))
+	fmt.Println("server-started")
+	received := <-shutdownSignals
+	name := map[os.Signal]string{
+		os.Interrupt:    "INT",
+		syscall.SIGTERM: "TERM",
+		syscall.SIGQUIT: "QUIT",
+	}[received]
+	require.NotEmpty(t, name)
+	require.NoError(t, os.WriteFile(os.Getenv("FAKE_SIGNAL_FILE"), []byte(name+"\n"), 0o644))
+	fmt.Println("server-drained")
+	time.Sleep(300 * time.Millisecond)
+	os.Exit(0)
+}
+
+func TestEntrypointForwardsOneSignalAndReapsServerAndLogger(t *testing.T) {
+	fixture := newEntrypointFixture(t, "ready")
+	require.NoError(t, fixture.cmd.Start())
+	t.Cleanup(func() { cleanupCommand(fixture.cmd) })
+
+	serverPID := waitForPIDFile(t, fixture.serverPIDFile)
+	loggerPID := waitForPIDFile(t, fixture.loggerPIDFile)
+	entrypointPID := waitForPIDFile(t, fixture.entrypointPIDFile)
+	require.Equal(t, serverPID, entrypointPID)
+	require.NotEqual(t, serverPID, loggerPID)
+
+	require.NoError(t, fixture.cmd.Process.Signal(syscall.SIGTERM))
+	waitForFile(t, fixture.forwardedSignals)
+	// A repeated stop request must not interrupt PID 1 while it is reaping.
+	require.NoError(t, fixture.cmd.Process.Signal(syscall.SIGTERM))
+	require.NoError(t, waitForCommand(fixture.cmd))
+
+	require.Equal(t, "TERM\n", readFile(t, fixture.forwardedSignals))
+	require.Contains(t, fixture.stdout.String(), "server-drained")
+	serverLog := readFile(t, filepath.Join(fixture.homeDir, "log", "server.log"))
+	require.Contains(t, serverLog, "server-started")
+	require.Contains(t, serverLog, "server-drained")
+	require.NoFileExists(t, fixture.entrypointPIDFile)
+	require.NoFileExists(t, fixture.logPipe)
+	requireProcessGone(t, serverPID)
+	requireProcessGone(t, loggerPID)
+}
+
+func TestEntrypointTermDuringReadinessReapsAllChildren(t *testing.T) {
+	fixture := newEntrypointFixture(t, "block-readiness")
+	require.NoError(t, fixture.cmd.Start())
+	t.Cleanup(func() { cleanupCommand(fixture.cmd) })
+
+	serverPID := waitForPIDFile(t, fixture.serverPIDFile)
+	loggerPID := waitForPIDFile(t, fixture.loggerPIDFile)
+	readinessPID := waitForPIDFile(t, fixture.readinessPIDFile)
+	require.NoError(t, fixture.cmd.Process.Signal(syscall.SIGTERM))
+	require.NoError(t, waitForCommand(fixture.cmd))
+
+	require.Equal(t, "TERM\n", readFile(t, fixture.forwardedSignals))
+	require.NoFileExists(t, fixture.entrypointPIDFile)
+	require.NoFileExists(t, fixture.logPipe)
+	requireProcessGone(t, serverPID)
+	requireProcessGone(t, loggerPID)
+	requireProcessGone(t, readinessPID)
+}
+
+func TestEntrypointTermDuringResistantReadinessDrainsServerAndReapsSetup(t *testing.T) {
+	fixture := newEntrypointFixture(t, "ignore-readiness-term")
+	require.NoError(t, fixture.cmd.Start())
+	t.Cleanup(func() { cleanupCommand(fixture.cmd) })
+
+	serverPID := waitForPIDFile(t, fixture.serverPIDFile)
+	loggerPID := waitForPIDFile(t, fixture.loggerPIDFile)
+	readinessPID := waitForPIDFile(t, fixture.readinessPIDFile)
+	require.NoError(t, fixture.cmd.Process.Signal(syscall.SIGTERM))
+	require.NoError(t, waitForCommand(fixture.cmd))
+
+	require.Equal(t, "TERM\n", readFile(t, fixture.forwardedSignals))
+	require.Contains(t, fixture.stdout.String(), "server-drained")
+	requireProcessGone(t, serverPID)
+	requireProcessGone(t, loggerPID)
+	requireProcessGone(t, readinessPID)
+}
+
+func TestEntrypointTermBeforePIDPublicationReapsChildren(t *testing.T) {
+	fixture := newEntrypointFixture(t, "ready", "FAKE_MV_MODE=block")
+	require.NoError(t, fixture.cmd.Start())
+	t.Cleanup(func() { cleanupCommand(fixture.cmd) })
+
+	serverPID := waitForPIDFile(t, fixture.serverPIDFile)
+	loggerPID := waitForPIDFile(t, fixture.loggerPIDFile)
+	waitForFile(t, fixture.pidPublishStarted)
+	require.NoFileExists(t, fixture.entrypointPIDFile)
+	require.NoError(t, fixture.cmd.Process.Signal(syscall.SIGTERM))
+	require.NoError(t, os.WriteFile(fixture.pidPublishRelease, []byte("release\n"), 0o644))
+	require.NoError(t, waitForCommand(fixture.cmd))
+
+	require.Equal(t, "TERM\n", readFile(t, fixture.forwardedSignals))
+	require.NoFileExists(t, fixture.entrypointPIDFile)
+	require.NoFileExists(t, fixture.logPipe)
+	requireProcessGone(t, serverPID)
+	requireProcessGone(t, loggerPID)
+}
+
+func TestEntrypointPreservesEarlyServerFailureStatus(t *testing.T) {
+	fixture := newEntrypointFixture(t, "not-ready", "FAKE_SERVER_MODE=exit-23")
+	require.NoError(t, fixture.cmd.Start())
+	t.Cleanup(func() { cleanupCommand(fixture.cmd) })
+	serverPID := waitForPIDFile(t, fixture.serverPIDFile)
+	loggerPID := waitForPIDFile(t, fixture.loggerPIDFile)
+
+	err := waitForCommand(fixture.cmd)
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 23, exitErr.ExitCode())
+	require.Contains(t, fixture.stdout.String(), "died during startup")
+	require.NoFileExists(t, fixture.entrypointPIDFile)
+	require.NoFileExists(t, fixture.logPipe)
+	requireProcessGone(t, serverPID)
+	requireProcessGone(t, loggerPID)
+}
+
+func TestEntrypointForwardsInterruptAndQuitToGoServer(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		signal syscall.Signal
+		want   string
+	}{
+		{name: "interrupt", signal: syscall.SIGINT, want: "INT\n"},
+		{name: "quit", signal: syscall.SIGQUIT, want: "QUIT\n"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			fixture := newEntrypointFixture(t, "ready", "FAKE_SERVER_IMPL=go")
+			require.NoError(t, fixture.cmd.Start())
+			t.Cleanup(func() { cleanupCommand(fixture.cmd) })
+			serverPID := waitForPIDFile(t, fixture.serverPIDFile)
+			loggerPID := waitForPIDFile(t, fixture.loggerPIDFile)
+
+			require.NoError(t, fixture.cmd.Process.Signal(testCase.signal))
+			require.NoError(t, waitForCommand(fixture.cmd))
+
+			require.Equal(t, testCase.want, readFile(t, fixture.forwardedSignals))
+			requireProcessGone(t, serverPID)
+			requireProcessGone(t, loggerPID)
+		})
+	}
+}
+
+func newEntrypointFixture(t *testing.T, mysqlshMode string, extraEnv ...string) *entrypointFixture {
+	t.Helper()
+	homeDir := t.TempDir()
+	fakeBin := filepath.Join(homeDir, "bin")
+	require.NoError(t, os.MkdirAll(fakeBin, 0o755))
+
+	serverPIDFile := filepath.Join(homeDir, "server.pid")
+	loggerPIDFile := filepath.Join(homeDir, "logger.pid")
+	readinessPIDFile := filepath.Join(homeDir, "readiness.pid")
+	forwardedSignals := filepath.Join(homeDir, "signals.log")
+	entrypointPIDFile := filepath.Join(homeDir, "log", "myduck.pid")
+	logPipe := filepath.Join(homeDir, "log", "myduck.log.pipe")
+	pidPublishStarted := filepath.Join(homeDir, "pid-publish.started")
+	pidPublishRelease := filepath.Join(homeDir, "pid-publish.release")
+	testBinary, err := filepath.Abs(os.Args[0])
+	require.NoError(t, err)
+
+	writeExecutable(t, filepath.Join(fakeBin, "myduckserver"), `#!/bin/bash
+if [[ "$FAKE_SERVER_IMPL" == "go" ]]; then
+  exec "$FAKE_TEST_BINARY" -test.run '^TestEntrypointGoServerHelper$'
+fi
+on_signal() {
+  printf '%s\n' "$1" >> "$FAKE_SIGNAL_FILE"
+  printf 'server-drained\n'
+  sleep "${FAKE_SERVER_EXIT_DELAY:-0.1}"
+  exit 0
+}
+printf '%s\n' "$$" > "$FAKE_SERVER_PID_FILE"
+if [[ "$FAKE_SERVER_MODE" == "exit-23" ]]; then
+  printf 'server-started\n'
+  exit 23
+fi
+trap 'on_signal TERM' TERM
+trap 'on_signal INT' INT
+trap 'on_signal QUIT' QUIT
+printf 'server-started\n'
+while true; do sleep 0.05; done
+`)
+
+	writeExecutable(t, filepath.Join(fakeBin, "mysqlsh"), `#!/bin/bash
+is_file=false
+for arg in "$@"; do
+  case "$arg" in
+    --file=*) is_file=true ;;
+  esac
+done
+if [[ "$FAKE_MYSQLSH_MODE" == "block-readiness" && "$is_file" == "false" ]]; then
+  printf '%s\n' "$$" > "$FAKE_READINESS_PID_FILE"
+  trap 'exit 0' TERM INT QUIT
+  while true; do sleep 0.05; done
+fi
+if [[ "$FAKE_MYSQLSH_MODE" == "ignore-readiness-term" && "$is_file" == "false" ]]; then
+  printf '%s\n' "$$" > "$FAKE_READINESS_PID_FILE"
+  trap '' TERM INT QUIT
+  while true; do sleep 0.05; done
+fi
+if [[ "$FAKE_MYSQLSH_MODE" == "not-ready" && "$is_file" == "false" ]]; then
+  exit 1
+fi
+exit 0
+`)
+
+	writeExecutable(t, filepath.Join(fakeBin, "psql"), "#!/bin/bash\nexit 0\n")
+	realTee, err := exec.LookPath("tee")
+	require.NoError(t, err)
+	writeExecutable(t, filepath.Join(fakeBin, "tee"), fmt.Sprintf(`#!/bin/bash
+printf '%%s\n' "$$" > "$FAKE_LOGGER_PID_FILE"
+exec %q "$@"
+`, realTee))
+	realMv, err := exec.LookPath("mv")
+	require.NoError(t, err)
+	writeExecutable(t, filepath.Join(fakeBin, "mv"), fmt.Sprintf(`#!/bin/bash
+if [[ "$FAKE_MV_MODE" == "block" ]]; then
+  printf 'started\n' > "$FAKE_PID_PUBLISH_STARTED"
+  until [[ -f "$FAKE_PID_PUBLISH_RELEASE" ]]; do sleep 0.01; done
+fi
+exec %q "$@"
+`, realMv))
+
+	entrypointPath, err := filepath.Abs("entrypoint.sh")
+	require.NoError(t, err)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd := exec.Command("/bin/bash", entrypointPath)
+	cmd.Env = []string{
+		"HOME=" + homeDir,
+		"PATH=" + fakeBin + ":/usr/bin:/bin",
+		"SETUP_MODE=SERVER",
+		"FAKE_MYSQLSH_MODE=" + mysqlshMode,
+		"FAKE_SERVER_PID_FILE=" + serverPIDFile,
+		"FAKE_LOGGER_PID_FILE=" + loggerPIDFile,
+		"FAKE_READINESS_PID_FILE=" + readinessPIDFile,
+		"FAKE_SIGNAL_FILE=" + forwardedSignals,
+		"FAKE_SERVER_EXIT_DELAY=0.3",
+		"FAKE_PID_PUBLISH_STARTED=" + pidPublishStarted,
+		"FAKE_PID_PUBLISH_RELEASE=" + pidPublishRelease,
+		"FAKE_TEST_BINARY=" + testBinary,
+	}
+	cmd.Env = append(cmd.Env, extraEnv...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("entrypoint stdout:\n%s", stdout.String())
+			t.Logf("entrypoint stderr:\n%s", stderr.String())
+		}
+	})
+
+	return &entrypointFixture{
+		cmd:               cmd,
+		stdout:            stdout,
+		stderr:            stderr,
+		homeDir:           homeDir,
+		serverPIDFile:     serverPIDFile,
+		loggerPIDFile:     loggerPIDFile,
+		readinessPIDFile:  readinessPIDFile,
+		forwardedSignals:  forwardedSignals,
+		entrypointPIDFile: entrypointPIDFile,
+		logPipe:           logPipe,
+		pidPublishStarted: pidPublishStarted,
+		pidPublishRelease: pidPublishRelease,
+	}
+}
+
+func writeExecutable(t *testing.T, path, contents string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o755))
+}
+
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(processWaitTimeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.FailNow(t, "timed out waiting for file", path)
+}
+
+func waitForPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(processWaitTimeout)
+	for time.Now().Before(deadline) {
+		contents, err := os.ReadFile(path)
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(contents)))
+			if parseErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.FailNow(t, "timed out waiting for complete PID file", path)
+	return 0
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(contents)
+}
+
+func waitForCommand(cmd *exec.Cmd) error {
+	result := make(chan error, 1)
+	go func() { result <- cmd.Wait() }()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(processWaitTimeout):
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		<-result
+		return fmt.Errorf("command did not exit within %s", processWaitTimeout)
+	}
+}
+
+func requireProcessGone(t *testing.T, pid int) {
+	t.Helper()
+	require.Error(t, syscall.Kill(pid, 0), "process %d is still alive", pid)
+}
+
+func cleanupCommand(cmd *exec.Cmd) {
+	if cmd.Process == nil || cmd.ProcessState != nil {
+		return
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	_ = cmd.Wait()
+}

--- a/docs/design-task83-graceful-shutdown.md
+++ b/docs/design-task83-graceful-shutdown.md
@@ -1,0 +1,167 @@
+# task #83：0.2.1 / 0.3 优雅退出设计
+
+## 1. 背景与基线
+
+task #74 的既有记录包含初始化、双协议读写和删除容器后重建读回操作，但 wrapper、初始主容器 bind 和同卷连续 provenance 没有完全证明；其中正常停止也明确不合格。task #83 会在独立目录里重新保存完整命令和路径身份，不把旧记录越界写成已经完成的本次证据：
+
+- 镜像：`apecloud/myduckserver:v0.2.1-dev.20260827.2`
+- 不可变索引：`sha256:8285369844a1da259910c2d100d8af7196019d7f9cf0ec72babcacdccdd0a780`
+- 源码：`2eb4143b82ca1102d5162079dcc481cfc9093d6d`
+- 父提交：`68760b5a7433e45607e9db69fc84412c0ec2989e`
+- 源码树：`38c864cbc1e6051558f4faa9097add3b868b1492`
+
+既有运行记录显示，Docker 在 `16:37:37.423557589` 发送 `SIGTERM`，30.007 秒后又发送 `SIGKILL`，容器最终 `ExitCode=137`、`OOMKilled=false`。`docker stop --time 30` 本身返回 0 只代表 Docker 成功执行停止操作，不能代表服务优雅退出。
+
+只读比较还确认：上述 `0.2.1` 源码与比较时的 `0.3/main`（`dd6d79113ca0b3132141c6f7ee7f36025b62f843`，tree `cdfcb7dc831b07a27136ce6cc026dd94d49293dd`）都使用同一套 `docker/entrypoint.sh`，Dockerfile 也都使用 shell 形式的入口。因此两条线具有同一个启动和信号传递缺陷，应使用同一份最小修复，再分别验证。若 @卡特 最终指定更新的 `0.3` 集成基线，移植前必须重新核对启动、信号和关闭链，不能沿用这个比较结论代替复核。
+
+## 2. 根因
+
+当前关闭链同时存在三个问题，缺少其中任一层都不能宣称数据库优雅退出。
+
+### 2.1 Docker 的 1 号进程没有直接运行入口脚本
+
+Dockerfile 使用：
+
+```dockerfile
+ENTRYPOINT /home/admin/entrypoint.sh
+```
+
+实际容器 1 号进程是 `/bin/sh -c /home/admin/entrypoint.sh`。Docker 把 `SIGTERM` 发给 `/bin/sh`，后面的 Bash trap 没有收到信号。既有日志中也没有 `Received shutdown signal`。
+
+### 2.2 入口脚本记录了错误的 PID
+
+脚本使用：
+
+```bash
+nohup myduckserver ... | tee ... &
+echo "$!" > "${PID_FILE}"
+```
+
+Bash 中 `$!` 是后台管道最后一个进程的 PID，这里是 `tee`，不是 `myduckserver`。即使 Bash 收到信号，现有 `cleanup` 也会杀错进程；函数返回后脚本仍会继续 readiness/init 或永久轮询。
+
+### 2.3 Go 主进程没有关闭协调器
+
+`main.go` 没有处理 `SIGTERM`/`SIGINT`。MySQL `Start()` 阻塞在监听循环，PostgreSQL 在另一个 goroutine 中监听。默认信号终止会直接结束 Go 进程，`myServer.Close()`、`pgServer.Close()`、`engine.Close()` 以及 `defer provider.Close()` 都没有可靠执行；现有证据因此只能证明被强制终止后的恢复能力，不能证明有序关闭完成。
+
+Flight SQL 当前把 `os.Kill` 注册为关闭信号，但 `SIGKILL` 不能被捕获，而且它与 MySQL/PostgreSQL 没有统一关闭顺序。
+
+## 3. 目标与非目标
+
+### 3.1 目标
+
+1. Docker 的 `SIGTERM` 能到达入口脚本。
+2. 入口脚本只向真实 `myduckserver` 进程转发一次信号，并等待它退出、回收子进程、删除 PID 文件，然后用服务的退出状态结束容器。
+3. Go 进程收到 `SIGTERM`、`SIGINT` 或 `SIGQUIT` 后停止 MySQL/PostgreSQL 新连接，等待两套 serve loop 返回，依次完成 `engine.Close()` 和 `provider.Close()`，留下明确的关闭日志。
+4. `SETUP_MODE=SERVER`、无活动客户端/长查询、无 MySQL replica 和 PostgreSQL subscription 的场景在 Docker 30 秒宽限期内正常退出，容器退出码为 0，无 `SIGKILL`、无 OOM。
+5. 停止前分别通过 MySQL 和 PostgreSQL 写入的数据，在停止、同盘重启以及删除/重建容器后都能由两套协议读回。
+6. 同一逻辑补丁分别落到 `0.2.1` 和 `0.3` 的独立干净工作树，各自产生可追溯的源码、镜像和运行证据。
+
+### 3.2 非目标
+
+- 不修改任何 stable 版本标签、`latest`、promotion workflow 或已冻结镜像；不向 registry push 本任务候选。
+- 不在 task #77 的共享 `0.3` 工作树里改代码或混入提交。
+- 不为任意长查询承诺固定强制终止时间，也不以 `SIGKILL` 冒充优雅退出。
+- 不在本任务重构 replica、事务或存储层生命周期；`REPLICA` 模式和存在 PostgreSQL subscription 的退出仍属未证明范围。
+- 不把一次本机结果直接描述成正式发布结果。
+- `0.3` 验证关闭 DuckLake/默认对象存储配置，只证明本地表关闭与恢复，不证明 task #77 的对象存储、rollback 或 orphan 行为。
+- Flight SQL backend 没有统一 Close，可能仍持有 prepared statement/open transaction；task #83 产品验证保持默认 `flightsql-port=-1`。实现可以停止并 join Flight transport，但不能据此声称 Flight 资源已优雅关闭。
+
+## 4. 共用最小修复
+
+### 4.1 Dockerfile
+
+把入口改成 exec 形式：
+
+```dockerfile
+ENTRYPOINT ["/home/admin/entrypoint.sh"]
+```
+
+这样 Bash 直接成为容器 1 号进程，能收到 Docker 发出的信号。
+
+### 4.2 入口脚本
+
+保留现有 readiness、初始化 SQL 和 replica setup 行为，只改变进程监督方式：
+
+1. 在容器自己的日志目录创建 FIFO。Bash 在启动窗口临时持有一个读写保护描述符，`myduckserver` 和 `tee` 各自关闭继承的保护描述符后打开自己的 FIFO 端；等两个 PID 都登记后，Bash 再关闭保护描述符。这样任一端都不会在 PID 尚未登记时卡在 FIFO open，同时仍保留 Docker logs 和文件日志。
+2. 把真实服务 PID 和 `tee` PID 都保存在内存中，PID 文件只写真实服务 PID。
+3. trap 只记录第一个 TERM/INT/QUIT，并立即同时向已经登记的真实服务和 readiness/init 子进程发信号；它不在 trap 内等待。主流程随后等待服务完成关闭、等待 `tee` 排空日志，再回收 setup 子进程。每个子进程都有独立的“已经发过信号”状态，重复 Docker 信号和后续收尾调用都不能把同一信号重复发给服务。
+4. 无论正常退出、readiness 超时、启动步骤失败还是信号退出，都终止并回收仍存活的服务进程、等待 `tee`、删除临时/PID/FIFO 文件；入口脚本保留服务或原始启动步骤的退出状态。初始化 SQL 继续保持旧版 best-effort 语义，单条 `mysqlsh`/`psql` 失败不能在本任务中被改成容器启动失败。
+5. 若停止发生在 readiness/init 客户端运行期间，必须先同时 TERM 服务和客户端，不能先无界等待客户端。数据库和日志已完成收尾后，仍拒绝 TERM 的 setup 客户端会被单独强制回收；这不是向数据库进程发送 KILL，也不能拿来掩盖数据库未优雅退出。
+6. 完成 readiness/init 后直接 `wait` 服务，不再每 10 秒读 PID 文件轮询。这样 Bash 会回收子进程，服务异常退出也能立即反映为容器退出。
+7. 信号在服务尚未启动或 PID 文件尚未原子发布时到达也必须安全退出，不能 `kill 0`、误伤别的进程或留下 FIFO reader/writer。
+
+### 4.3 Go 服务生命周期
+
+建立一个小型、可单测的关闭协调器，不改变查询执行路径：
+
+1. 订阅 `SIGTERM`、`SIGINT`、`SIGQUIT`，不再注册不可捕获的 `SIGKILL`。
+2. MySQL `Start()`、PostgreSQL `Start()` 和启用时的 Flight SQL `Serve()` 都由协调器持有完成 channel；协调器等待“收到信号”或“任一 serve loop 提前返回”。Flight 不再单独注册信号处理器，但只把它作为 transport 收尾，不扩大产品证明范围。
+3. 关闭动作只执行一次，先停止 PostgreSQL/MySQL 和已启用的 Flight transport 新连接，再等待所有已启用的 serve loop 返回。现有 PostgreSQL `Start`/`Close` 没有错误返回，因此只保留当前 API 可观察到的 MySQL/Flight/engine/provider 错误，不声称能捕获 PostgreSQL listener 内部已打印并忽略的错误。
+4. serve loop 全部停止后调用 `engine.Close()`，让 GMS 结束 process/background lifecycle；只有它完成后才能调用 `provider.Close()`，不能在仍存活的 engine/handler 下关闭存储。Flight 不再单独 `defer provider.Storage().Close()`，provider 是存储 DB 的唯一关闭 owner。由于 Flight backend 没有 Close，本任务运行门必须保持它禁用。
+5. 当前 MySQL 和 PostgreSQL listener close 都不等待每条 client handler；本任务产品证明因此严格要求停止前所有一次性 SQL 客户端已经退出，不能外推为“活动连接已优雅排空”。
+6. 把当前 API 可见的 engine 和 provider 关闭结果写入日志。provider 关闭完成加上后续重启读回，只证明有序关闭路径完成且数据可恢复；`provider.Close()` 当前不返回 connector 的 defer 错误，除非扩大修复范围补齐该 API，不能声称 connector 内部错误已被审计。
+7. 若可观察的 serve/close/finalize 返回错误，合并并记录错误，不能因为关闭路径调用 `Fatal` 而跳过尚未执行的收尾。
+
+关闭顺序为：
+
+```text
+Docker SIGTERM
+  -> Bash PID 1 trap
+  -> real myduckserver PID
+  -> Go signal coordinator
+  -> stop PostgreSQL/MySQL admissions (and Flight transport if enabled)
+  -> join every enabled protocol serve loop
+  -> engine.Close
+  -> provider.Close
+  -> Go exit 0
+  -> Bash wait returns 0
+  -> container exit 0
+```
+
+## 5. 测试设计
+
+### 5.1 确定性回归
+
+- Dockerfile 断言入口为 JSON/exec 形式。
+- 入口脚本测试使用假的 `myduckserver`、`mysqlsh`、`tee` 和临时目录，验证 PID 文件属于服务而不是 `tee`、TERM 只向服务转发一次、PID 文件发布前的 TERM 不会挂住、TERM-responsive 和 TERM-resistant readiness 子进程都会被回收、服务早退状态不丢、日志完全排空、脚本清理临时/PID/FIFO 且服务和 `tee` 都无孤儿进程。测试不得把旧版 best-effort init 擅自改成 fatal init。
+- Go 生命周期测试使用假的 serve/close/finalize 函数和信号 channel，验证立即信号、重复信号、任一 serve loop 提前返回、MySQL-only/PG-enabled/Flight-transport-enabled 组合、所有 serve loop join 后才进入 engine/provider 收尾，以及当前 API 可见的 serve/close/finalize 错误不丢失。Flight 组合只证明 transport join，不算 backend 资源关闭证明。
+- `gofmt`、`git diff --check`、focused test、race、vet 和全仓编译门均需通过；命令、退出码和原始输出单独保存。
+
+### 5.2 `0.2.1` 产品验证
+
+1. 用不可变旧镜像和独立临时数据目录复现一次 30 秒超时，保存 inspect、process tree、PID 文件、日志和 scoped Docker events。
+2. 从精确源码 `2eb4143b...` 构建使用唯一 task-local 标签的本地候选，以 image ID 锁定后续命令；记录父提交、子提交、tree、二进制哈希、镜像 ID、OCI revision 和 `--version`。本地标签可移动，不能称为不可变引用或虚构 RepoDigest。
+3. 用唯一容器名、端口和 bind 目录在 `SETUP_MODE=SERVER` 启动，保持 `flightsql-port=-1`，关闭所有 DuckLake/对象存储配置，不配置 MySQL replica 或 PostgreSQL subscription；复用已知 init fixtures，并保存这些禁用条件的检查结果。
+4. MySQL 和 PostgreSQL 分别写入来源可区分的 sentinel 行，并保存完整的“2 个协议 × 停止前、原容器重启后、同盘重建后 3 个阶段”读回矩阵。
+5. 执行 `docker stop --timeout 30`，要求实际耗时小于 30 秒、host command exit 0、container exit 0、`OOMKilled=false`、events 有 TERM 无 KILL，日志包含应用关闭完成点。
+6. 用原容器再次启动并双协议读回，证明正常停止后已落盘。
+7. 删除且只删除该已停止容器，使用同一候选镜像和完全相同的 host bind path 重建，不挂 init SQL，再次双协议读回全部值。
+
+### 5.3 `0.3` 产品验证
+
+根因和补丁形态在 `0.2.1` 做实后，由 @卡特 明确一个不与 task #77 冲突的干净 `0.3/main` 集成落点。重新核对所选基线后，只移植同一逻辑修复，并重新执行 5.1 与 5.2 的正常退出、落盘、原容器重启读回和同盘删除/重建读回；证据、提交和镜像身份与 `0.2.1` 分开记录。
+
+`0.3` 的相关 API 保持向后兼容，错误移植即使漏参数也可能编译并通过 DuckLake-off 产品门。因此移植测试还必须静态核对 `configuration.LoadDuckLakeConfig`、`catalog.WithDuckLakeConfig(duckLakeConfig)`、`provider.InitializeConnection` 以及 Dockerfile 的 extension COPY 都仍存在；不能把“可以 cherry-pick/可以编译”当成语义等价证明。
+
+任一条线未通过，都不能对外宣称两条线已解决。task #83 最终只提交一次完整双线证据包给独立验收人。
+
+## 6. 证据与资源隔离
+
+- baseline、`0.2.1` candidate、`0.3` candidate 使用不同的 `mktemp -d` 数据目录、容器名、端口和日志目录。
+- 不复用或删除 task #74、task #77 的容器、数据目录、工作树或镜像标签。
+- 不执行广泛 Docker cleanup、Compose teardown 或未限定目标的删除命令。
+- 生产改动 allowlist 为 `docker/Dockerfile`、`docker/entrypoint.sh`、`main.go` 及其定向测试和本设计文档；超出范围必须先说明原因。
+- 两条线分别记录 base/child/tree、逐文件 diff 和 patch-id；共同逻辑必须有稳定 patch-id 或逐行等价证明，不能只说“已经同步”。
+- 在验证前后分别记录 stable 版本标签和 `latest` 的远端引用，证明未发生 promotion 或标签移动。
+- 每个命令保存命令文本、开始/结束时间、退出码和原始 stdout/stderr；每个文件生成 SHA-256，最终生成 manifest 和 `SHA256SUMS`。
+- 证据描述只到实际证明的强度：本地候选通过不等于正式版本已发布。
+
+## 7. 失败判定
+
+出现下列任一情况即为 FAIL：
+
+- 30 秒内未退出，或 Docker 发送了 `SIGKILL`。
+- 容器退出码非 0、`OOMKilled=true`，或只证明 wrapper 退出而没有应用/provider 关闭证据。
+- 任一协议写入或任一阶段的双协议读回不一致。
+- 删除/重建时数据目录或镜像身份发生变化。
+- 两条线混用提交、工作树、镜像或证据，导致来源无法复核。

--- a/main.go
+++ b/main.go
@@ -16,13 +16,17 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"net"
 	"os"
+	"os/signal"
 	"strconv"
+	"sync"
 	"sync/atomic"
+	"syscall"
 
 	"github.com/apache/arrow-go/v18/arrow/flight"
 	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
@@ -43,6 +47,7 @@ import (
 	"github.com/dolthub/vitess/go/mysql"
 	_ "github.com/duckdb/duckdb-go/v2"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
 )
 
 var (
@@ -76,6 +81,73 @@ var (
 	flightsqlHost = "localhost"
 	flightsqlPort = -1 // Disabled by default
 )
+
+var errServeLoopStopped = errors.New("serve loop stopped unexpectedly")
+
+type serveLoop struct {
+	name  string
+	serve func() error
+}
+
+type serveResult struct {
+	name string
+	err  error
+}
+
+func serveResultError(result serveResult, expected bool) error {
+	if result.err != nil {
+		return fmt.Errorf("%s serve loop: %w", result.name, result.err)
+	}
+	if !expected {
+		return fmt.Errorf("%w: %s", errServeLoopStopped, result.name)
+	}
+	return nil
+}
+
+func normalizeFlightServeError(err error) error {
+	if errors.Is(err, grpc.ErrServerStopped) {
+		return nil
+	}
+	return err
+}
+
+func runServerLifecycle(
+	shutdownSignals <-chan os.Signal,
+	loops []serveLoop,
+	stopProtocols func() error,
+	finalize func() error,
+) error {
+	if len(loops) == 0 {
+		return errors.Join(stopProtocols(), finalize())
+	}
+
+	results := make(chan serveResult, len(loops))
+	for _, loop := range loops {
+		loop := loop
+		go func() {
+			results <- serveResult{name: loop.name, err: loop.serve()}
+		}()
+	}
+
+	remaining := len(loops)
+	var lifecycleErr error
+	select {
+	case receivedSignal := <-shutdownSignals:
+		logrus.WithField("signal", receivedSignal).Infoln("Shutdown signal received")
+	case result := <-results:
+		remaining--
+		lifecycleErr = errors.Join(lifecycleErr, serveResultError(result, false))
+	}
+
+	lifecycleErr = errors.Join(lifecycleErr, stopProtocols())
+	for range remaining {
+		result := <-results
+		lifecycleErr = errors.Join(lifecycleErr, serveResultError(result, true))
+	}
+	logrus.Infoln("Protocol serve loops stopped")
+
+	return errors.Join(lifecycleErr, finalize())
+}
 
 func init() {
 	flag.BoolVar(&initMode, "init", initMode, "Initialize the program and exit. The necessary extensions will be installed.")
@@ -122,6 +194,12 @@ func main() {
 		fmt.Println(versionInfo())
 		return
 	}
+	var shutdownSignals chan os.Signal
+	if !initMode {
+		shutdownSignals = make(chan os.Signal, 1)
+		signal.Notify(shutdownSignals, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
+		defer signal.Stop(shutdownSignals)
+	}
 
 	if replicaOptions.ReportPort == 0 {
 		replicaOptions.ReportPort = port
@@ -150,12 +228,33 @@ func main() {
 	if err != nil {
 		logrus.Fatalln("Failed to open the database:", err)
 	}
-	defer provider.Close()
+	closeProvider := sync.OnceValue(func() error {
+		logrus.Infoln("Closing database provider")
+		closeErr := provider.Close()
+		if closeErr != nil {
+			logrus.WithError(closeErr).Errorln("Failed to close database provider")
+			return closeErr
+		}
+		logrus.Infoln("Database provider closed")
+		return nil
+	})
+	defer func() { _ = closeProvider() }()
 
 	// Clear the pipes directory on startup.
 	backend.RemoveAllPipes(dataDirectory)
 
 	engine, builder := backend.NewEngine(provider)
+	finalize := sync.OnceValue(func() error {
+		logrus.Infoln("Closing SQL engine")
+		engineErr := engine.Close()
+		if engineErr != nil {
+			logrus.WithError(engineErr).Errorln("Failed to close SQL engine")
+		} else {
+			logrus.Infoln("SQL engine closed")
+		}
+		return errors.Join(engineErr, closeProvider())
+	})
+	defer func() { _ = finalize() }()
 	engine.Analyzer.Catalog.RegisterFunction(sql.NewContext(context.Background()), myfunc.ExtraBuiltIns...)
 	engine.Analyzer.Catalog.MySQLDb.SetPlugins(plugin.AuthPlugins)
 
@@ -186,10 +285,11 @@ func main() {
 		logrus.WithError(err).Fatalln("Failed to create MySQL-protocol server")
 	}
 
+	var postgresServer *pgserver.Server
 	if postgresPort > 0 {
 		var postgresConnID atomic.Uint32
 		postgresConnID.Store(1 << 31)
-		pgServer, err := pgserver.NewServer(
+		postgresServer, err = pgserver.NewServer(
 			provider,
 			address, postgresPort,
 			superuserPassword,
@@ -207,37 +307,67 @@ func main() {
 		}
 
 		// Check if there is a replication subscription and start replication if there is.
-		err = logrepl.UpdateSubscriptions(pgServer.NewInternalCtx())
+		err = logrepl.UpdateSubscriptions(postgresServer.NewInternalCtx())
 		if err != nil {
 			logrus.WithError(err).Warnln("Failed to update subscriptions")
 		}
 
 		// Load the configuration for the Postgres server.
 		pgconfig.Init()
-		go pgServer.Start()
 	}
 
+	var flightServer flight.Server
 	if flightsqlPort > 0 {
 		db := provider.Storage()
-		defer db.Close()
 
 		srv, err := flightsqlserver.NewSQLiteFlightSQLServer(db, provider.InitializeConnection)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		server := flight.NewServerWithMiddleware(nil)
-		server.RegisterFlightService(flightsql.NewFlightServer(srv))
-		server.Init(net.JoinHostPort(*&flightsqlHost, strconv.Itoa(*&flightsqlPort)))
-		server.SetShutdownOnSignals(os.Interrupt, os.Kill)
+		flightServer = flight.NewServerWithMiddleware(nil)
+		flightServer.RegisterFlightService(flightsql.NewFlightServer(srv))
+		flightServer.Init(net.JoinHostPort(*&flightsqlHost, strconv.Itoa(*&flightsqlPort)))
 
-		fmt.Println("Starting SQLite Flight SQL Server on", server.Addr(), "...")
-
-		go server.Serve()
+		fmt.Println("Starting SQLite Flight SQL Server on", flightServer.Addr(), "...")
 	}
 
-	if err = myServer.Start(); err != nil {
-		logrus.WithError(err).Fatalln("Failed to start MySQL-protocol server")
+	loops := []serveLoop{{name: "mysql", serve: myServer.Start}}
+	if postgresServer != nil {
+		loops = append(loops, serveLoop{
+			name: "postgres",
+			serve: func() error {
+				postgresServer.Start()
+				return nil
+			},
+		})
+	}
+	if flightServer != nil {
+		loops = append(loops, serveLoop{
+			name: "flight",
+			serve: func() error {
+				return normalizeFlightServeError(flightServer.Serve())
+			},
+		})
+	}
+
+	stopProtocols := sync.OnceValue(func() error {
+		logrus.Infoln("Stopping protocol servers")
+		var stopErr error
+		if postgresServer != nil {
+			postgresServer.Close()
+		}
+		if closeErr := myServer.Close(); closeErr != nil {
+			stopErr = errors.Join(stopErr, fmt.Errorf("close MySQL server: %w", closeErr))
+		}
+		if flightServer != nil {
+			flightServer.Shutdown()
+		}
+		return stopErr
+	})
+
+	if err = runServerLifecycle(shutdownSignals, loops, stopProtocols, finalize); err != nil {
+		logrus.WithError(err).Fatalln("Server stopped with an error")
 	}
 }
 

--- a/main_shutdown_test.go
+++ b/main_shutdown_test.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"errors"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/flight"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestMainRegistersShutdownSignalsOnlyForServerMode(t *testing.T) {
+	contents, err := os.ReadFile("main.go")
+	require.NoError(t, err)
+	source := string(contents)
+	serverModeGuard := strings.Index(source, "\tif !initMode {")
+	notify := strings.Index(source, "\tsignal.Notify(shutdownSignals")
+	initBranch := strings.Index(source, "\tif initMode {")
+	serverProvider := strings.Index(source, "\tprovider, err := catalog.NewDBProvider")
+	require.GreaterOrEqual(t, serverModeGuard, 0)
+	require.Greater(t, notify, serverModeGuard)
+	require.Greater(t, initBranch, notify)
+	require.Greater(t, serverProvider, notify)
+}
+
+func TestRunServerLifecycleSignalStopsAndJoinsAllLoops(t *testing.T) {
+	shutdownSignals := make(chan os.Signal, 2)
+	releaseLoops := make(chan struct{})
+	var started sync.WaitGroup
+	started.Add(3)
+	var stopped atomic.Int32
+	var stopCalls atomic.Int32
+	var finalizeCalls atomic.Int32
+
+	loops := make([]serveLoop, 0, 3)
+	for _, name := range []string{"mysql", "postgres", "flight"} {
+		name := name
+		loops = append(loops, serveLoop{
+			name: name,
+			serve: func() error {
+				started.Done()
+				<-releaseLoops
+				stopped.Add(1)
+				return nil
+			},
+		})
+	}
+
+	go func() {
+		started.Wait()
+		shutdownSignals <- syscall.SIGTERM
+		shutdownSignals <- syscall.SIGTERM
+	}()
+
+	err := runServerLifecycle(
+		shutdownSignals,
+		loops,
+		func() error {
+			stopCalls.Add(1)
+			close(releaseLoops)
+			return nil
+		},
+		func() error {
+			finalizeCalls.Add(1)
+			require.Equal(t, int32(3), stopped.Load(), "finalize ran before every serve loop returned")
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, int32(3), stopped.Load())
+	require.Equal(t, int32(1), stopCalls.Load())
+	require.Equal(t, int32(1), finalizeCalls.Load())
+}
+
+func TestRunServerLifecyclePreloadedSignalStopsAndJoinsAllLoops(t *testing.T) {
+	shutdownSignals := make(chan os.Signal, 1)
+	shutdownSignals <- syscall.SIGTERM
+	releaseLoops := make(chan struct{})
+	var stopped atomic.Int32
+
+	loops := make([]serveLoop, 0, 3)
+	for _, name := range []string{"mysql", "postgres", "flight"} {
+		name := name
+		loops = append(loops, serveLoop{
+			name: name,
+			serve: func() error {
+				<-releaseLoops
+				stopped.Add(1)
+				return nil
+			},
+		})
+	}
+
+	err := runServerLifecycle(
+		shutdownSignals,
+		loops,
+		func() error {
+			close(releaseLoops)
+			return nil
+		},
+		func() error {
+			require.Equal(t, int32(3), stopped.Load(), "finalize ran before preloaded-signal joins completed")
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, int32(3), stopped.Load())
+}
+
+func TestRunServerLifecycleUnexpectedServeReturn(t *testing.T) {
+	var stopCalls atomic.Int32
+	var finalizeCalls atomic.Int32
+
+	err := runServerLifecycle(
+		make(chan os.Signal),
+		[]serveLoop{{name: "mysql", serve: func() error { return nil }}},
+		func() error {
+			stopCalls.Add(1)
+			return nil
+		},
+		func() error {
+			finalizeCalls.Add(1)
+			return nil
+		},
+	)
+
+	require.ErrorIs(t, err, errServeLoopStopped)
+	require.Equal(t, int32(1), stopCalls.Load())
+	require.Equal(t, int32(1), finalizeCalls.Load())
+}
+
+func TestRunServerLifecycleUnexpectedReturnStopsAndJoinsPeer(t *testing.T) {
+	peerStarted := make(chan struct{})
+	releasePeer := make(chan struct{})
+	var peerStopped atomic.Bool
+
+	err := runServerLifecycle(
+		make(chan os.Signal),
+		[]serveLoop{
+			{
+				name: "postgres",
+				serve: func() error {
+					close(peerStarted)
+					<-releasePeer
+					peerStopped.Store(true)
+					return nil
+				},
+			},
+			{
+				name: "mysql",
+				serve: func() error {
+					<-peerStarted
+					return nil
+				},
+			},
+		},
+		func() error {
+			close(releasePeer)
+			return nil
+		},
+		func() error {
+			require.True(t, peerStopped.Load(), "finalize ran before the peer serve loop returned")
+			return nil
+		},
+	)
+
+	require.ErrorIs(t, err, errServeLoopStopped)
+	require.True(t, peerStopped.Load())
+}
+
+func TestRunServerLifecyclePreservesObservableErrors(t *testing.T) {
+	serveErr := errors.New("serve failed")
+	stopErr := errors.New("stop failed")
+	finalizeErr := errors.New("finalize failed")
+
+	err := runServerLifecycle(
+		make(chan os.Signal),
+		[]serveLoop{{name: "mysql", serve: func() error { return serveErr }}},
+		func() error { return stopErr },
+		func() error { return finalizeErr },
+	)
+
+	require.ErrorIs(t, err, serveErr)
+	require.ErrorIs(t, err, stopErr)
+	require.ErrorIs(t, err, finalizeErr)
+}
+
+func TestRunServerLifecycleSignalPreservesStoppedLoopError(t *testing.T) {
+	shutdownSignals := make(chan os.Signal, 1)
+	releaseLoop := make(chan struct{})
+	started := make(chan struct{})
+	serveErr := errors.New("serve stopped with error")
+	var stopped atomic.Bool
+
+	go func() {
+		<-started
+		shutdownSignals <- syscall.SIGTERM
+	}()
+
+	err := runServerLifecycle(
+		shutdownSignals,
+		[]serveLoop{{
+			name: "mysql",
+			serve: func() error {
+				close(started)
+				<-releaseLoop
+				stopped.Store(true)
+				return serveErr
+			},
+		}},
+		func() error {
+			close(releaseLoop)
+			return nil
+		},
+		func() error {
+			require.True(t, stopped.Load(), "finalize ran before the serve loop returned")
+			return nil
+		},
+	)
+
+	require.ErrorIs(t, err, serveErr)
+}
+
+func TestNormalizeFlightServeError(t *testing.T) {
+	require.NoError(t, normalizeFlightServeError(grpc.ErrServerStopped))
+	serveErr := errors.New("flight listener failed")
+	require.ErrorIs(t, normalizeFlightServeError(serveErr), serveErr)
+}
+
+func TestFlightServerShutdownBeforeServeReturns(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	server := flight.NewServerWithMiddleware(nil)
+	server.InitListener(listener)
+	server.Shutdown()
+	require.NoError(t, normalizeFlightServeError(server.Serve()))
+}

--- a/mysql_server_shutdown_test.go
+++ b/mysql_server_shutdown_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apecloud/myduckserver/backend"
+	"github.com/apecloud/myduckserver/catalog"
+	"github.com/dolthub/go-mysql-server/server"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/require"
+)
+
+type mysqlAcceptObservedListener struct {
+	net.Listener
+	acceptOnce    sync.Once
+	acceptEntered chan struct{}
+}
+
+func (l *mysqlAcceptObservedListener) Accept() (net.Conn, error) {
+	l.acceptOnce.Do(func() { close(l.acceptEntered) })
+	return l.Listener.Accept()
+}
+
+func TestMySQLServerStartReturnsAfterClose(t *testing.T) {
+	testMySQLServerClose(t, false)
+}
+
+func TestMySQLServerCloseBeforeStartReturns(t *testing.T) {
+	testMySQLServerClose(t, true)
+}
+
+func testMySQLServerClose(t *testing.T, closeBeforeStart bool) {
+	t.Helper()
+	tcpListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tcpListener.Close() })
+	listener := &mysqlAcceptObservedListener{
+		Listener:      tcpListener,
+		acceptEntered: make(chan struct{}),
+	}
+
+	provider := catalog.NewInMemoryDBProvider()
+	engine, _ := backend.NewEngine(provider)
+	t.Cleanup(func() {
+		if err := engine.Close(); err != nil {
+			t.Errorf("close SQL engine: %v", err)
+		}
+		if err := provider.Close(); err != nil {
+			t.Errorf("close database provider: %v", err)
+		}
+	})
+	mysqlServer, err := server.NewServer(
+		server.Config{
+			Protocol:                 "tcp",
+			Address:                  tcpListener.Addr().String(),
+			Listener:                 listener,
+			DisableConnectionWatcher: true,
+		},
+		engine,
+		sql.NewContext,
+		backend.NewSessionBuilder(provider),
+		nil,
+	)
+	require.NoError(t, err)
+
+	closeServer := sync.OnceValue(mysqlServer.Close)
+	t.Cleanup(func() {
+		if err := closeServer(); err != nil {
+			t.Errorf("close MySQL server: %v", err)
+		}
+	})
+
+	serveDone := make(chan error, 1)
+	if closeBeforeStart {
+		require.NoError(t, closeServer())
+	}
+	go func() {
+		serveDone <- mysqlServer.Start()
+	}()
+
+	select {
+	case <-listener.acceptEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("MySQL server did not enter its accept loop")
+	}
+
+	if !closeBeforeStart {
+		require.NoError(t, closeServer())
+	}
+	select {
+	case err := <-serveDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("MySQL server Start did not return after Close")
+	}
+}

--- a/pgserver/server_shutdown_test.go
+++ b/pgserver/server_shutdown_test.go
@@ -1,0 +1,80 @@
+package pgserver
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apecloud/myduckserver/backend"
+	"github.com/apecloud/myduckserver/catalog"
+	"github.com/dolthub/go-mysql-server/memory"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/require"
+)
+
+type postgresAcceptObservedListener struct {
+	net.Listener
+	acceptOnce    sync.Once
+	acceptEntered chan struct{}
+}
+
+func (l *postgresAcceptObservedListener) Accept() (net.Conn, error) {
+	l.acceptOnce.Do(func() { close(l.acceptEntered) })
+	return l.Listener.Accept()
+}
+
+func TestPostgresServerStartReturnsAfterClose(t *testing.T) {
+	testPostgresServerClose(t, false)
+}
+
+func TestPostgresServerCloseBeforeStartReturns(t *testing.T) {
+	testPostgresServerClose(t, true)
+}
+
+func testPostgresServerClose(t *testing.T, closeBeforeStart bool) {
+	t.Helper()
+	provider := catalog.NewInMemoryDBProvider()
+	t.Cleanup(func() {
+		require.NoError(t, provider.Close())
+	})
+
+	newCtx := func() *sql.Context {
+		session := backend.NewSession(memory.NewSession(sql.NewBaseSession(), provider), provider)
+		return sql.NewContext(context.Background(), sql.WithSession(session))
+	}
+	postgresServer, err := NewServer(provider, "127.0.0.1", 0, "", newCtx)
+	require.NoError(t, err)
+	t.Cleanup(postgresServer.Close)
+
+	listener := &postgresAcceptObservedListener{
+		Listener:      postgresServer.Listener.listener,
+		acceptEntered: make(chan struct{}),
+	}
+	postgresServer.Listener.listener = listener
+
+	serveDone := make(chan struct{})
+	if closeBeforeStart {
+		postgresServer.Close()
+	}
+	go func() {
+		postgresServer.Start()
+		close(serveDone)
+	}()
+
+	select {
+	case <-listener.acceptEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("PostgreSQL server did not enter its accept loop")
+	}
+
+	if !closeBeforeStart {
+		postgresServer.Close()
+	}
+	select {
+	case <-serveDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("PostgreSQL server Start did not return after Close")
+	}
+}


### PR DESCRIPTION
Task #83: replay the idle `SETUP_MODE=SERVER` graceful-shutdown fix onto exact current main.

- Signed head: `034c7c5f01b9b5e55adf07e808c47b2294f25880`
- Unique parent: `dd6d79113ca0b3132141c6f7ee7f36025b62f843`
- Tree: `5bd931726a1b2d7823d97a21cf525e31f65600a7` (matches sealed 0.3 candidate)
- Eight files only: `docker/Dockerfile`, `docker/entrypoint.sh`, `docker/entrypoint_test.go`, `docs/design-task83-graceful-shutdown.md`, `main.go`, `main_shutdown_test.go`, `mysql_server_shutdown_test.go`, `pgserver/server_shutdown_test.go`

Review-only until independent GitHub approval. Do not merge from this description. Do not promote `v0.2.1` or `latest` in this PR.