### PR TITLE
fix: resolve image source from main or release/X.Y.Z

### DIFF
--- a/.github/scripts/release-source-validate-test.sh
+++ b/.github/scripts/release-source-validate-test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/release-source-validate.sh"
+
+expect_fail() {
+  local label=$1
+  shift
+  if "$@" >/dev/null 2>&1; then
+    echo "expected failure: $label" >&2
+    exit 1
+  fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+git_dir="$tmpdir/repo"
+mkdir -p "$git_dir"
+git -C "$git_dir" init -q
+git -C "$git_dir" config user.name test
+git -C "$git_dir" config user.email test@example.com
+git -C "$git_dir" checkout -q -b main
+
+echo one >"$git_dir/file"
+git -C "$git_dir" add file
+git -C "$git_dir" commit -q -m c1
+c1="$(git -C "$git_dir" rev-parse HEAD)"
+
+echo two >>"$git_dir/file"
+git -C "$git_dir" commit -q -am c2
+c2="$(git -C "$git_dir" rev-parse HEAD)"
+
+git -C "$git_dir" branch release/0.2.1 "$c1"
+git -C "$git_dir" checkout -q release/0.2.1
+echo rel >>"$git_dir/file"
+git -C "$git_dir" commit -q -am c3
+c3="$(git -C "$git_dir" rev-parse HEAD)"
+git -C "$git_dir" checkout -q main
+
+git -C "$git_dir" update-ref refs/remotes/origin/main "$c2"
+git -C "$git_dir" update-ref refs/remotes/origin/release/0.2.1 "$c3"
+
+missing_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+output_file="$tmpdir/out"
+
+# Original main path: ancestor of resolved main tip.
+: >"$output_file"
+release_source_validate \
+  refs/heads/main \
+  main \
+  "$c1" \
+  v0.1.0-dev.20260822.1 \
+  "$git_dir" \
+  "$output_file"
+grep -Fxq "source_branch=main" "$output_file"
+grep -Fxq "source_branch_sha=$c2" "$output_file"
+grep -Fxq "sha_tag=sha-${c1:0:8}" "$output_file"
+
+release_source_validate \
+  refs/heads/main \
+  main \
+  "$c2" \
+  v0.1.0-rc.1 \
+  "$git_dir"
+
+# Main-source cross-dev-version promotion remains allowed.
+STABLE_VERSION=v0.2.0 release_source_validate \
+  refs/heads/main \
+  main \
+  "$c1" \
+  v0.1.0-dev.20260822.3 \
+  "$git_dir"
+
+# Legal release source.
+: >"$output_file"
+release_source_validate \
+  refs/heads/main \
+  release/0.2.1 \
+  "$c3" \
+  v0.2.1-dev.20260906.1 \
+  "$git_dir" \
+  "$output_file"
+grep -Fxq "source_branch=release/0.2.1" "$output_file"
+grep -Fxq "source_branch_sha=$c3" "$output_file"
+
+STABLE_VERSION=v0.2.1 release_source_validate \
+  refs/heads/main \
+  release/0.2.1 \
+  "$c1" \
+  v0.2.1-rc.1 \
+  "$git_dir"
+
+# Reject wrong branch names.
+expect_fail wrong-branch release_source_validate \
+  refs/heads/main develop "$c2" v0.1.0-dev.20260822.1 "$git_dir"
+expect_fail incomplete-release release_source_validate \
+  refs/heads/main release/0.2 "$c3" v0.2.0-dev.20260822.1 "$git_dir"
+expect_fail release-prefix release_source_validate \
+  refs/heads/main release/v0.2.1 "$c3" v0.2.1-dev.20260906.1 "$git_dir"
+expect_fail not-from-main release_source_validate \
+  refs/heads/release/0.2.1 release/0.2.1 "$c3" v0.2.1-dev.20260906.1 "$git_dir"
+
+# Reject wrong version correspondence on a release branch.
+expect_fail wrong-release-version release_source_validate \
+  refs/heads/main release/0.2.1 "$c3" v0.3.0-dev.20260906.1 "$git_dir"
+if STABLE_VERSION=v0.3.0 release_source_validate \
+  refs/heads/main release/0.2.1 "$c3" v0.2.1-dev.20260906.1 "$git_dir" \
+  >/dev/null 2>&1; then
+  echo "expected failure: wrong-stable" >&2
+  exit 1
+fi
+
+# Reject unknown ref and commits that are not on the selected branch.
+expect_fail unknown-ref release_source_validate \
+  refs/heads/main release/9.9.9 "$c3" v9.9.9-dev.20260906.1 "$git_dir"
+expect_fail main-missing-release-commit release_source_validate \
+  refs/heads/main main "$c3" v0.1.0-dev.20260822.1 "$git_dir"
+expect_fail release-missing-main-commit release_source_validate \
+  refs/heads/main release/0.2.1 "$c2" v0.2.1-dev.20260906.1 "$git_dir"
+expect_fail missing-sha release_source_validate \
+  refs/heads/main main "$missing_sha" v0.1.0-dev.20260822.1 "$git_dir"
+
+echo "release source validation tests passed"

--- a/.github/scripts/release-source-validate.sh
+++ b/.github/scripts/release-source-validate.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+# Shared source-branch checks for Release Image and Promote Image.
+# Tooling still runs from a fixed main commit. Application source must belong
+# to main or an explicit release/X.Y.Z branch; arbitrary SHAs are rejected.
+
+release_source_branch_ok() {
+  local branch=$1
+  [[ "$branch" == "main" ]] && return 0
+  [[ "$branch" =~ ^release/(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+}
+
+release_prerelease_ok() {
+  [[ "$1" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-(dev\.[0-9]{8}\.[1-9][0-9]*|rc\.[1-9][0-9]*)$ ]]
+}
+
+release_stable_ok() {
+  [[ "$1" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+}
+
+release_source_validate_inputs() {
+  if (( $# != 4 )); then
+    echo "usage: release_source_validate_inputs GITHUB_REF SOURCE_BRANCH SOURCE_SHA VERSION" >&2
+    return 2
+  fi
+
+  local github_ref="$1"
+  local source_branch="$2"
+  local source_sha="$3"
+  local version="$4"
+  local stable_version="${STABLE_VERSION:-}"
+
+  if [[ "$github_ref" != "refs/heads/main" ]]; then
+    echo "release workflow must be dispatched from the main branch" >&2
+    return 1
+  fi
+  if ! release_source_branch_ok "$source_branch"; then
+    echo "source_branch must be main or release/X.Y.Z" >&2
+    return 1
+  fi
+  if [[ ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "source_sha must be a lowercase, full 40-character commit SHA" >&2
+    return 1
+  fi
+  if ! release_prerelease_ok "$version"; then
+    echo "version must match vX.Y.Z-dev.YYYYMMDD.N or vX.Y.Z-rc.N" >&2
+    return 1
+  fi
+  if [[ -n "$stable_version" ]] && ! release_stable_ok "$stable_version"; then
+    echo "stable_version must match vX.Y.Z" >&2
+    return 1
+  fi
+
+  if [[ "$source_branch" != "main" ]]; then
+    local rel="${source_branch#release/}"
+    local rel_re="${rel//./\\.}"
+    if [[ ! "$version" =~ ^v${rel_re}-(dev\.[0-9]{8}\.[1-9][0-9]*|rc\.[1-9][0-9]*)$ ]]; then
+      echo "version $version does not correspond to $source_branch" >&2
+      return 1
+    fi
+    if [[ -n "$stable_version" && "$stable_version" != "v${rel}" ]]; then
+      echo "stable_version $stable_version does not correspond to $source_branch" >&2
+      return 1
+    fi
+  fi
+}
+
+release_source_resolve() {
+  if (( $# < 3 || $# > 4 )); then
+    echo "usage: release_source_resolve SOURCE_BRANCH SOURCE_SHA GIT_DIR [OUTPUT_FILE]" >&2
+    return 2
+  fi
+
+  local source_branch="$1"
+  local source_sha="$2"
+  local git_dir="$3"
+  local output_file="${4:-}"
+  local branch_sha=""
+
+  if [[ ! -d "$git_dir" ]]; then
+    echo "git directory is missing: $git_dir" >&2
+    return 1
+  fi
+  if ! release_source_branch_ok "$source_branch"; then
+    echo "source_branch must be main or release/X.Y.Z" >&2
+    return 1
+  fi
+  if [[ ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "source_sha must be a lowercase, full 40-character commit SHA" >&2
+    return 1
+  fi
+
+  if branch_sha="$(git -C "$git_dir" rev-parse --verify --quiet "refs/remotes/origin/${source_branch}^{commit}")"; then
+    :
+  elif branch_sha="$(git -C "$git_dir" rev-parse --verify --quiet "refs/heads/${source_branch}^{commit}")"; then
+    :
+  else
+    echo "unknown source branch ref: $source_branch" >&2
+    return 1
+  fi
+
+  if ! git -C "$git_dir" cat-file -e "${source_sha}^{commit}" 2>/dev/null; then
+    echo "source commit $source_sha is missing from selected branch history" >&2
+    return 1
+  fi
+  if ! git -C "$git_dir" merge-base --is-ancestor "$source_sha" "$branch_sha"; then
+    echo "source_sha must be reachable from $source_branch at $branch_sha" >&2
+    return 1
+  fi
+
+  if [[ -n "$output_file" ]]; then
+    {
+      printf 'source_branch=%s\n' "$source_branch"
+      printf 'source_branch_sha=%s\n' "$branch_sha"
+      printf 'sha_tag=sha-%s\n' "${source_sha:0:8}"
+    } >> "$output_file"
+  fi
+}
+
+release_source_validate() {
+  if (( $# < 5 || $# > 6 )); then
+    echo "usage: release_source_validate GITHUB_REF SOURCE_BRANCH SOURCE_SHA VERSION GIT_DIR [OUTPUT_FILE]" >&2
+    return 2
+  fi
+  release_source_validate_inputs "$1" "$2" "$3" "$4" || return
+  release_source_resolve "$2" "$3" "$5" "${6:-}"
+}
+
+release_source_fetch() {
+  if (( $# != 2 )); then
+    echo "usage: release_source_fetch GIT_DIR SOURCE_BRANCH" >&2
+    return 2
+  fi
+  local git_dir="$1"
+  local source_branch="$2"
+  if ! release_source_branch_ok "$source_branch"; then
+    echo "source_branch must be main or release/X.Y.Z" >&2
+    return 1
+  fi
+  if ! git -C "$git_dir" fetch --no-tags origin \
+    "+refs/heads/${source_branch}:refs/remotes/origin/${source_branch}"; then
+    echo "unknown source branch ref: $source_branch" >&2
+    return 1
+  fi
+}

--- a/.github/workflows/promote-image.yml
+++ b/.github/workflows/promote-image.yml
@@ -8,6 +8,11 @@ on:
         description: Full 40-character source commit SHA of the accepted image
         required: true
         type: string
+      source_branch:
+        description: Source branch whose history must contain source_sha (main or release/X.Y.Z)
+        required: false
+        default: main
+        type: string
       source_version:
         description: Existing immutable dev or release-candidate tag
         required: true
@@ -51,6 +56,7 @@ jobs:
         shell: bash
         env:
           SOURCE_SHA: ${{ inputs.source_sha }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
           SOURCE_VERSION: ${{ inputs.source_version }}
           SOURCE_DIGEST: ${{ inputs.source_digest }}
           STABLE_VERSION: ${{ inputs.stable_version }}
@@ -58,6 +64,7 @@ jobs:
         run: |
           set -euo pipefail
           source .github/scripts/promote-image-validate.sh
+          source .github/scripts/release-source-validate.sh
           promote_image_validate \
             "$GITHUB_REF" \
             "$SOURCE_SHA" \
@@ -66,15 +73,24 @@ jobs:
             "$STABLE_VERSION" \
             "$ACCEPTANCE_REFERENCE" \
             "$GITHUB_OUTPUT"
+          release_source_validate_inputs \
+            "$GITHUB_REF" \
+            "$SOURCE_BRANCH" \
+            "$SOURCE_SHA" \
+            "$SOURCE_VERSION"
 
       - name: Test promotion input validation
         shell: bash
-        run: bash .github/scripts/promote-image-validate-test.sh
+        run: |
+          bash .github/scripts/promote-image-validate-test.sh
+          bash .github/scripts/release-source-validate-test.sh
 
-      - name: Verify source is reachable from main
+      - name: Fetch and resolve source branch
+        id: source-ref
         shell: bash
         env:
           SOURCE_SHA: ${{ inputs.source_sha }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
           WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
@@ -83,14 +99,9 @@ jobs:
             echo "checked out workflow commit $actual_workflow_sha, expected $WORKFLOW_SHA" >&2
             exit 1
           fi
-          if ! git cat-file -e "$SOURCE_SHA^{commit}"; then
-            echo "source commit $SOURCE_SHA is missing from release history" >&2
-            exit 1
-          fi
-          if ! git merge-base --is-ancestor "$SOURCE_SHA" "$WORKFLOW_SHA"; then
-            echo "source_sha must be reachable from main at workflow commit $WORKFLOW_SHA" >&2
-            exit 1
-          fi
+          source .github/scripts/release-source-validate.sh
+          release_source_fetch . "$SOURCE_BRANCH"
+          release_source_resolve "$SOURCE_BRANCH" "$SOURCE_SHA" . "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -192,6 +203,8 @@ jobs:
         shell: bash
         env:
           SOURCE_SHA: ${{ inputs.source_sha }}
+          SOURCE_BRANCH: ${{ steps.source-ref.outputs.source_branch }}
+          SOURCE_BRANCH_SHA: ${{ steps.source-ref.outputs.source_branch_sha }}
           SOURCE_VERSION: ${{ inputs.source_version }}
           SOURCE_DIGEST: ${{ inputs.source_digest }}
           SHA_TAG: ${{ steps.metadata.outputs.sha_tag }}
@@ -246,6 +259,8 @@ jobs:
           jq -n \
             --arg image "$IMAGE" \
             --arg source_sha "$SOURCE_SHA" \
+            --arg source_branch "$SOURCE_BRANCH" \
+            --arg source_branch_sha "$SOURCE_BRANCH_SHA" \
             --arg workflow_sha "$WORKFLOW_SHA" \
             --arg workflow_run_id "$GITHUB_RUN_ID" \
             --arg workflow_run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
@@ -261,6 +276,8 @@ jobs:
             '{
               image: $image,
               source_sha: $source_sha,
+              source_branch: $source_branch,
+              source_branch_sha: $source_branch_sha,
               workflow_sha: $workflow_sha,
               workflow_run_id: $workflow_run_id,
               workflow_run_url: $workflow_run_url,
@@ -281,6 +298,7 @@ jobs:
             echo "## Promoted accepted image"
             echo
             echo "- Acceptance: $ACCEPTANCE_REFERENCE"
+            echo "- Source branch: \`$SOURCE_BRANCH\` at \`$SOURCE_BRANCH_SHA\`"
             echo "- Source: \`$SOURCE_SHA\`"
             echo "- Stable tag: \`$IMAGE:$STABLE_VERSION\`"
             echo "- Latest: \`$IMAGE:latest\`"

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -8,6 +8,11 @@ on:
         description: Full 40-character application source commit SHA
         required: true
         type: string
+      source_branch:
+        description: Source branch whose history must contain source_sha (main or release/X.Y.Z)
+        required: false
+        default: main
+        type: string
       version:
         description: Immutable prerelease version (vX.Y.Z-dev.YYYYMMDD.N or vX.Y.Z-rc.N)
         required: true
@@ -28,28 +33,43 @@ jobs:
       contents: read
     outputs:
       digest: ${{ steps.build.outputs.digest }}
-      sha_tag: ${{ steps.metadata.outputs.sha_tag }}
+      sha_tag: ${{ steps.source-ref.outputs.sha_tag }}
       version: ${{ inputs.version }}
     steps:
+      - name: Checkout exact release tooling
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.sha }}
+          path: release-tools
+          fetch-depth: 0
+          persist-credentials: false
+
       - name: Validate release inputs
         shell: bash
         env:
           SOURCE_SHA: ${{ inputs.source_sha }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
-            echo "release workflow must be dispatched from the main branch" >&2
-            exit 1
-          fi
-          if [[ ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "source_sha must be a lowercase, full 40-character commit SHA" >&2
-            exit 1
-          fi
-          if [[ ! "$VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-(dev\.[0-9]{8}\.[1-9][0-9]*|rc\.[1-9][0-9]*)$ ]]; then
-            echo "version must match vX.Y.Z-dev.YYYYMMDD.N or vX.Y.Z-rc.N" >&2
-            exit 1
-          fi
+          source release-tools/.github/scripts/release-source-validate.sh
+          release_source_validate_inputs "$GITHUB_REF" "$SOURCE_BRANCH" "$SOURCE_SHA" "$VERSION"
+
+      - name: Test source branch validation
+        shell: bash
+        run: bash release-tools/.github/scripts/release-source-validate-test.sh
+
+      - name: Fetch and resolve source branch
+        id: source-ref
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
+        run: |
+          set -euo pipefail
+          source release-tools/.github/scripts/release-source-validate.sh
+          release_source_fetch release-tools "$SOURCE_BRANCH"
+          release_source_resolve "$SOURCE_BRANCH" "$SOURCE_SHA" release-tools "$GITHUB_OUTPUT"
 
       - name: Checkout exact application source
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -57,14 +77,6 @@ jobs:
           ref: ${{ inputs.source_sha }}
           path: source
           fetch-depth: 0
-          persist-credentials: false
-
-      - name: Checkout exact release tooling
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        with:
-          ref: ${{ github.sha }}
-          path: release-tools
-          fetch-depth: 1
           persist-credentials: false
 
       - name: Verify checkout and derive metadata
@@ -83,14 +95,6 @@ jobs:
           actual_workflow_sha="$(git -C release-tools rev-parse HEAD)"
           if [[ "$actual_workflow_sha" != "$WORKFLOW_SHA" ]]; then
             echo "checked out workflow commit $actual_workflow_sha, expected $WORKFLOW_SHA" >&2
-            exit 1
-          fi
-          if ! git -C source cat-file -e "$WORKFLOW_SHA^{commit}"; then
-            echo "workflow commit $WORKFLOW_SHA is missing from the checkout" >&2
-            exit 1
-          fi
-          if ! git -C source merge-base --is-ancestor "$SOURCE_SHA" "$WORKFLOW_SHA"; then
-            echo "source_sha must be reachable from main at workflow commit $WORKFLOW_SHA" >&2
             exit 1
           fi
           mapfile -t base_images < <(
@@ -156,7 +160,7 @@ jobs:
         shell: bash
         env:
           VERSION: ${{ inputs.version }}
-          SHA_TAG: ${{ steps.metadata.outputs.sha_tag }}
+          SHA_TAG: ${{ steps.source-ref.outputs.sha_tag }}
         run: |
           set -euo pipefail
           source release-tools/.github/scripts/dockerhub-manifest.sh
@@ -185,7 +189,7 @@ jobs:
           sbom: false
           tags: |
             ${{ env.IMAGE }}:${{ inputs.version }}
-            ${{ env.IMAGE }}:${{ steps.metadata.outputs.sha_tag }}
+            ${{ env.IMAGE }}:${{ steps.source-ref.outputs.sha_tag }}
           labels: |
             org.opencontainers.image.source=${{ env.SOURCE_REPOSITORY }}
             org.opencontainers.image.version=${{ inputs.version }}
@@ -203,8 +207,10 @@ jobs:
         shell: bash
         env:
           SOURCE_SHA: ${{ inputs.source_sha }}
+          SOURCE_BRANCH: ${{ steps.source-ref.outputs.source_branch }}
+          SOURCE_BRANCH_SHA: ${{ steps.source-ref.outputs.source_branch_sha }}
           VERSION: ${{ inputs.version }}
-          SHA_TAG: ${{ steps.metadata.outputs.sha_tag }}
+          SHA_TAG: ${{ steps.source-ref.outputs.sha_tag }}
           BUILD_TIME: ${{ steps.metadata.outputs.build_time }}
           BUILD_DIGEST: ${{ steps.build.outputs.digest }}
           WORKFLOW_SHA: ${{ github.sha }}
@@ -279,6 +285,8 @@ jobs:
           jq -n \
             --arg image "$IMAGE" \
             --arg source_sha "$SOURCE_SHA" \
+            --arg source_branch "$SOURCE_BRANCH" \
+            --arg source_branch_sha "$SOURCE_BRANCH_SHA" \
             --arg workflow_sha "$WORKFLOW_SHA" \
             --arg workflow_run_id "$GITHUB_RUN_ID" \
             --arg workflow_run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
@@ -295,6 +303,8 @@ jobs:
             '{
               image: $image,
               source_sha: $source_sha,
+              source_branch: $source_branch,
+              source_branch_sha: $source_branch_sha,
               workflow_sha: $workflow_sha,
               workflow_run_id: $workflow_run_id,
               workflow_run_url: $workflow_run_url,
@@ -321,6 +331,7 @@ jobs:
           {
             echo "## Published immutable image"
             echo
+            echo "- Source branch: \`$SOURCE_BRANCH\` at \`$SOURCE_BRANCH_SHA\`"
             echo "- Source: \`$SOURCE_SHA\`"
             echo "- Version tag: \`$IMAGE:$VERSION\`"
             echo "- Commit tag: \`$IMAGE:$SHA_TAG\`"

--- a/docs/release.md
+++ b/docs/release.md
@@ -34,17 +34,27 @@ secrets.
 Run the **Release Image** workflow from the `main` branch with:
 
 - `source_sha`: the full, lowercase, 40-character application commit SHA;
+- `source_branch`: `main` (default) or an explicit `release/X.Y.Z` branch;
 - `version`: a development or release-candidate version.
 
-The workflow checks out that exact SHA into an isolated directory, compares the
-actual checkout SHA byte for byte with the input, and verifies that it is an
-ancestor of the `main` commit from which the workflow was dispatched. The
-workflow definition may be newer than the application source, but the build
-context and Dockerfile both come from the requested application commit.
+The workflow always runs its tooling from the `main` commit that dispatched
+it. It resolves `source_branch` once to a fixed commit, verifies that
+`source_sha` is reachable from that resolved history, and records both the
+branch name and resolved commit in `release-metadata.json`. Arbitrary SHAs
+that are not on `main` or the named `release/X.Y.Z` branch are rejected.
+Unknown refs, incomplete names such as `release/0.2`, and other branch names
+are rejected.
+
+When `source_branch` is `release/X.Y.Z`, `version` must be a prerelease of
+that same `vX.Y.Z`. When `source_branch` is `main`, any allowed prerelease
+version may be used. The workflow definition may be newer than the
+application source, but the build context and Dockerfile both come from the
+requested application commit.
 
 One multi-architecture build publishes the version and commit tags. Both tags
 must resolve to the digest returned by the build. The workflow uploads
-`release-metadata.json` with the source and workflow SHAs, run ID and URL,
+`release-metadata.json` with the source SHA, source branch and resolved
+branch commit, workflow SHA, run ID and URL,
 immutable tags, top-level digest, per-platform digests, and build time.
 
 The application Dockerfile must pin both its builder and runtime images with a
@@ -93,19 +103,25 @@ Only an accepted immutable development build or release candidate may become
 stable. Run the **Promote Image** workflow from the `main` branch with:
 
 - the full source SHA;
+- `source_branch`: `main` (default) or the same `release/X.Y.Z` used to build;
 - the existing immutable development or release-candidate version;
 - the accepted `sha256:...` digest;
-- the explicit stable `vX.Y.Z` version (which may have a different prerelease
-  base when that product version change is intentional);
+- the explicit stable `vX.Y.Z` version;
 - the independent acceptance reference.
 
-The workflow verifies that the source commit is reachable from `main` and that
-both the prerelease tag and `sha-<commit>` tag point to the accepted digest. It
-then adds the stable version and `latest` to that digest with
+The workflow resolves `source_branch` once and verifies that the source
+commit is reachable from that history. It also verifies that both the
+prerelease tag and `sha-<commit>` tag point to the accepted digest. It then
+adds the stable version and `latest` to that digest with
 `docker buildx imagetools create`. It does not invoke a build. The workflow
 inspects both promoted tags afterward and uploads `promotion-metadata.json`,
-including the workflow run, per-platform digests, acceptance reference, and
-previous `latest` digest.
+including the source branch and resolved commit, workflow run, per-platform
+digests, acceptance reference, and previous `latest` digest.
+
+When promoting a `main` source, the stable version may have a different
+prerelease base if that product version change is intentional. When promoting
+a `release/X.Y.Z` source, both the prerelease version and stable version must
+correspond to that same `vX.Y.Z`.
 
 For example, after accepting `v0.1.0-rc.1`, promote its existing digest to
 `v0.1.0` and `latest`. For a development build that includes a deliberate
@@ -118,13 +134,15 @@ the stable tag records that this exact candidate passed release acceptance.
 
 Do not rebuild an old version and do not move its immutable tags. Re-run the
 **Promote Image** workflow using the previous stable version, its original
-prerelease tag, source SHA, digest, and acceptance reference. The workflow
-verifies all immutable references and moves only `latest` back to that digest.
+prerelease tag, source SHA, source branch, digest, and acceptance reference.
+The workflow verifies all immutable references and moves only `latest` back
+to that digest.
 
 Every release record must keep:
 
 - workflow run URL;
 - full application source SHA;
+- source branch and the commit it resolved to;
 - prerelease, source-commit, and stable tags as applicable;
 - multi-architecture digest;
 - builder and runtime top-level manifest digests;


### PR DESCRIPTION
Task #84: let Release Image and Promote Image run from a fixed `main` tooling commit while validating application source against `main` or an explicit `release/X.Y.Z` branch.

- Resolve `source_branch` once and record the branch plus resolved commit in evidence
- Reject wrong branch names, unknown refs, version mismatch, and SHAs not on the selected history
- Keep immutable tags, dual-arch builds, digest checks, no-rebuild promotion, and main-source cross-dev-version promotion
- Do not allow arbitrary SHAs
- Application source for 0.2.1 remains `5a66d1f2`

Independent review: @云浅雪. Not a merge, not an image, not `v0.2.1`/`latest`.