### PR TITLE
fix: reopen DuckLake catalog after restart and seed data dir ownership

### DIFF
--- a/catalog/ducklake.go
+++ b/catalog/ducklake.go
@@ -1841,9 +1841,9 @@ func (rt *duckLakeRuntime) attachLocked(ctx context.Context, key any, execer dri
 	}
 	// Both values have already passed configuration validation. SQL-literal
 	// quoting is still required because service paths can contain apostrophes.
-	attach := "ATTACH IF NOT EXISTS " + duckDBStringLiteral("ducklake:"+metadata) +
-		" AS " + QuoteIdentifierANSI(DuckLakeCatalogName) +
-		" (DATA_PATH " + duckDBStringLiteral(dataPath) + ", DATA_INLINING_ROW_LIMIT 0, CREATE_IF_NOT_EXISTS true)"
+	// CREATE_IF_NOT_EXISTS is only for first attach. Reopening an existing
+	// local catalog with that option fails DuckDB ATTACH after restart.
+	attach := duckLakeAttachSQL(metadata, dataPath)
 	if _, err := execer.ExecContext(ctx, attach, nil); err != nil {
 		return newDuckLakeInitError(duckLakeStageAttach, "", err)
 	}
@@ -1884,6 +1884,16 @@ func localDuckLakeCatalogPath() (string, error) {
 		return "", err
 	}
 	return filepath.Join(dir, "ducklake-catalog.duckdb"), nil
+}
+
+func duckLakeAttachSQL(metadata, dataPath string) string {
+	opts := "DATA_PATH " + duckDBStringLiteral(dataPath) + ", DATA_INLINING_ROW_LIMIT 0"
+	if _, err := os.Stat(metadata); err != nil {
+		opts += ", CREATE_IF_NOT_EXISTS true"
+	}
+	return "ATTACH IF NOT EXISTS " + duckDBStringLiteral("ducklake:"+metadata) +
+		" AS " + QuoteIdentifierANSI(DuckLakeCatalogName) +
+		" (" + opts + ")"
 }
 
 func duckDBStringLiteral(value string) string {

--- a/catalog/ducklake.go
+++ b/catalog/ducklake.go
@@ -1843,7 +1843,11 @@ func (rt *duckLakeRuntime) attachLocked(ctx context.Context, key any, execer dri
 	// quoting is still required because service paths can contain apostrophes.
 	// CREATE_IF_NOT_EXISTS is only for first attach. Reopening an existing
 	// local catalog with that option fails DuckDB ATTACH after restart.
-	attach := duckLakeAttachSQL(metadata, dataPath)
+	missing, err := duckLakeCatalogMissing(metadata)
+	if err != nil {
+		return newDuckLakeInitError(duckLakeStageAttach, "", err)
+	}
+	attach := duckLakeAttachSQL(metadata, dataPath, missing)
 	if _, err := execer.ExecContext(ctx, attach, nil); err != nil {
 		return newDuckLakeInitError(duckLakeStageAttach, "", err)
 	}
@@ -1886,9 +1890,20 @@ func localDuckLakeCatalogPath() (string, error) {
 	return filepath.Join(dir, "ducklake-catalog.duckdb"), nil
 }
 
-func duckLakeAttachSQL(metadata, dataPath string) string {
+func duckLakeCatalogMissing(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return false, nil
+	}
+	if os.IsNotExist(err) {
+		return true, nil
+	}
+	return false, err
+}
+
+func duckLakeAttachSQL(metadata, dataPath string, catalogMissing bool) string {
 	opts := "DATA_PATH " + duckDBStringLiteral(dataPath) + ", DATA_INLINING_ROW_LIMIT 0"
-	if _, err := os.Stat(metadata); err != nil {
+	if catalogMissing {
 		opts += ", CREATE_IF_NOT_EXISTS true"
 	}
 	return "ATTACH IF NOT EXISTS " + duckDBStringLiteral("ducklake:"+metadata) +

--- a/catalog/ducklake.go
+++ b/catalog/ducklake.go
@@ -1841,8 +1841,10 @@ func (rt *duckLakeRuntime) attachLocked(ctx context.Context, key any, execer dri
 	}
 	// Both values have already passed configuration validation. SQL-literal
 	// quoting is still required because service paths can contain apostrophes.
-	// CREATE_IF_NOT_EXISTS is only for first attach. Reopening an existing
-	// local catalog with that option fails DuckDB ATTACH after restart.
+	// CREATE_IF_NOT_EXISTS is only for first attach when the catalog file is
+	// missing. An existing catalog ATTACHes with or without that option.
+	// Restart failed because attachCatalogs opened the metadata file as a
+	// regular DuckDB database before the ducklake: ATTACH.
 	missing, err := duckLakeCatalogMissing(metadata)
 	if err != nil {
 		return newDuckLakeInitError(duckLakeStageAttach, "", err)
@@ -1890,8 +1892,12 @@ func localDuckLakeCatalogPath() (string, error) {
 	return filepath.Join(dir, "ducklake-catalog.duckdb"), nil
 }
 
+// duckLakeStat is os.Stat in production. Tests replace it to inject Stat
+// failures that chmod 000 cannot produce when the process is root.
+var duckLakeStat = os.Stat
+
 func duckLakeCatalogMissing(path string) (bool, error) {
-	_, err := os.Stat(path)
+	_, err := duckLakeStat(path)
 	if err == nil {
 		return false, nil
 	}

--- a/catalog/provider.go
+++ b/catalog/provider.go
@@ -525,6 +525,17 @@ func (prov *DatabaseProvider) HasCatalog(name string) bool {
 }
 
 // attachCatalogs attaches all the databases in the data directory
+func (prov *DatabaseProvider) duckLakeMetadataFile(name string) bool {
+	if prov == nil || prov.duckLake == nil {
+		return false
+	}
+	meta := strings.TrimSpace(prov.duckLake.config.MetadataPath)
+	if meta == "" {
+		return false
+	}
+	return filepath.Clean(filepath.Join(prov.dataDir, name)) == filepath.Clean(meta)
+}
+
 func (prov *DatabaseProvider) attachCatalogs() error {
 	files, err := os.ReadDir(prov.dataDir)
 	if err != nil {
@@ -554,6 +565,12 @@ func (prov *DatabaseProvider) AttachCatalog(file interface {
 			return nil
 		}
 		return fmt.Errorf("file %s is not a database file", file.Name())
+	}
+	// The DuckLake catalog file lives in dataDir but must not be ATTACHed as a
+	// regular DuckDB database. Doing so occupies the file and makes the later
+	// ducklake: ATTACH fail after restart.
+	if prov.duckLakeMetadataFile(file.Name()) {
+		return nil
 	}
 	name := strings.TrimSuffix(file.Name(), ".db")
 	quoted := QuoteIdentifierANSI(name)

--- a/catalog/provider_ducklake_test.go
+++ b/catalog/provider_ducklake_test.go
@@ -167,19 +167,20 @@ func TestAttachCatalogSkipsDuckLakeMetadataFile(t *testing.T) {
 }
 
 func TestDuckLakeAttachStatNonExistErrorDoesNotCreate(t *testing.T) {
-	dir := t.TempDir()
-	blocked := filepath.Join(dir, "blocked")
-	require.NoError(t, os.Mkdir(blocked, 0o000))
-	t.Cleanup(func() { _ = os.Chmod(blocked, 0o700) })
-	metadata := filepath.Join(blocked, "catalog.ducklake")
+	orig := duckLakeStat
+	t.Cleanup(func() { duckLakeStat = orig })
+	duckLakeStat = func(string) (os.FileInfo, error) {
+		return nil, os.ErrPermission
+	}
 	runtime := &duckLakeRuntime{config: configuration.DuckLakeConfig{
-		MetadataPath: metadata,
+		MetadataPath: "/injected/catalog.ducklake",
 		DataPath:     "s3://test-bucket/data",
 	}}
 	execer := &recordingDuckLakeExecer{}
 
 	err := runtime.attachLocked(context.Background(), nil, execer)
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "reason=permission_denied")
 	require.Empty(t, execer.queries)
 }
 

--- a/catalog/provider_ducklake_test.go
+++ b/catalog/provider_ducklake_test.go
@@ -151,6 +151,38 @@ func TestDuckLakeAttachOmitsCreateIfCatalogExists(t *testing.T) {
 	require.NotContains(t, execer.queries[0], "CREATE_IF_NOT_EXISTS")
 }
 
+func TestAttachCatalogSkipsDuckLakeMetadataFile(t *testing.T) {
+	dir := t.TempDir()
+	meta := filepath.Join(dir, "ducklake.db")
+	require.NoError(t, os.WriteFile(meta, []byte("existing"), 0o600))
+	prov := &DatabaseProvider{
+		dataDir: dir,
+		duckLake: &duckLakeRuntime{config: configuration.DuckLakeConfig{
+			MetadataPath: meta,
+		}},
+	}
+	info, err := os.Stat(meta)
+	require.NoError(t, err)
+	require.NoError(t, prov.AttachCatalog(info, false))
+}
+
+func TestDuckLakeAttachStatNonExistErrorDoesNotCreate(t *testing.T) {
+	dir := t.TempDir()
+	blocked := filepath.Join(dir, "blocked")
+	require.NoError(t, os.Mkdir(blocked, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o700) })
+	metadata := filepath.Join(blocked, "catalog.ducklake")
+	runtime := &duckLakeRuntime{config: configuration.DuckLakeConfig{
+		MetadataPath: metadata,
+		DataPath:     "s3://test-bucket/data",
+	}}
+	execer := &recordingDuckLakeExecer{}
+
+	err := runtime.attachLocked(context.Background(), nil, execer)
+	require.Error(t, err)
+	require.Empty(t, execer.queries)
+}
+
 func TestDuckLakeAttachRejectsRemoteCatalogURI(t *testing.T) {
 	runtime := &duckLakeRuntime{config: configuration.DuckLakeConfig{
 		MetadataPath: "s3://test-bucket/catalog.ducklake",

--- a/catalog/provider_ducklake_test.go
+++ b/catalog/provider_ducklake_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	stdsql "database/sql"
 	"database/sql/driver"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -130,6 +132,23 @@ func TestDuckLakeAttachUsesServicePaths(t *testing.T) {
 	require.Equal(t, []string{
 		"ATTACH IF NOT EXISTS 'ducklake:/var/lib/myduck/catalog.ducklake' AS \"__myduck_ducklake\" (DATA_PATH 's3://test-bucket/data', DATA_INLINING_ROW_LIMIT 0, CREATE_IF_NOT_EXISTS true)",
 	}, execer.queries)
+}
+
+func TestDuckLakeAttachOmitsCreateIfCatalogExists(t *testing.T) {
+	dir := t.TempDir()
+	metadata := filepath.Join(dir, "catalog.ducklake")
+	require.NoError(t, os.WriteFile(metadata, []byte("existing"), 0o600))
+	runtime := &duckLakeRuntime{config: configuration.DuckLakeConfig{
+		MetadataPath: metadata,
+		DataPath:     "s3://test-bucket/data",
+	}}
+	execer := &recordingDuckLakeExecer{}
+
+	require.NoError(t, runtime.attachLocked(context.Background(), nil, execer))
+	require.Equal(t, []string{
+		"ATTACH IF NOT EXISTS 'ducklake:" + metadata + "' AS \"__myduck_ducklake\" (DATA_PATH 's3://test-bucket/data', DATA_INLINING_ROW_LIMIT 0)",
+	}, execer.queries)
+	require.NotContains(t, execer.queries[0], "CREATE_IF_NOT_EXISTS")
 }
 
 func TestDuckLakeAttachRejectsRemoteCatalogURI(t *testing.T) {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -116,6 +116,9 @@ RUN chmod 755 /usr/local/lib/myduckserver /usr/local/lib/myduckserver/duckdb-ext
 
 USER admin
 WORKDIR /home/admin
+# Empty Docker named volumes copy this directory's ownership. Without it the
+# volume is root:root and admin cannot create myduck.db / ducklake.db.
+RUN mkdir -p /home/admin/data /home/admin/log
 
 # Copy application files
 COPY --from=builder /myduckserver /usr/local/bin/myduckserver

--- a/docs/object-storage.md
+++ b/docs/object-storage.md
@@ -14,6 +14,13 @@ must not include diagnostic inject switches.
    catalog file (`MYDUCK_DUCKLAKE_METADATA_PATH`). The object bucket stores
    table data only. Losing the catalog cannot be recovered from the bucket
    alone.
+4. **Object tables do not support PRIMARY KEY.** `CREATE TABLE ... ENGINE=DUCKLAKE`
+   with a primary key returns 1105. The table is not created and no object
+   prefix is written.
+5. **Data directory ownership.** The image user is `admin` (uid 1000). The
+   image ships `/home/admin/data` owned by admin so an empty Docker named
+   volume mounted there inherits that ownership. A bind-mounted host directory
+   that is `root:root` still needs `chown 1000:1000` before first start.
 
 ## Scope
 


### PR DESCRIPTION
## Summary

Fixes two 0.3-dev image blockers from task #88 (`be2cd5bd` must not be promoted):

1. Same-volume recreate failed `ATTACH` with `stage=attach reason=driver_error`. **Root cause:** `attachCatalogs` ATTACHes every `*.db` in the data directory as a regular DuckDB database, so on restart the DuckLake metadata file is opened first and the later `ducklake:` ATTACH fails. Fix: skip the configured metadata path in `AttachCatalog`.

   CLI ATTACH of the r5 catalog copy succeeded **both with and without** `CREATE_IF_NOT_EXISTS` when the file was not already attached as a regular database. Omitting that option on existing files is still kept (`os.Stat` only `ErrNotExist` creates; permission/IO fail closed) but is not the recreate root cause.

2. Empty Docker named volumes mounted at `/home/admin/data` were `root:root`, so user `admin` (uid 1000) could not create `myduck.db`. The image now seeds `/home/admin/data` and `/home/admin/log` as admin.

Also documents object-table PRIMARY KEY rejection (1105, no leftover files).

Does not change `v0.2.1` / `latest`. Does not touch PR #489.

## Test

- `go test ./catalog -count=1 -run 'TestDuckLakeAttachUsesServicePaths|TestDuckLakeAttachOmitsCreateIfCatalogExists|TestAttachCatalogSkipsDuckLakeMetadataFile|TestDuckLakeAttachStatNonExistErrorDoesNotCreate|TestDuckLakeAttachRejectsRemoteCatalogURI'`