### PR TITLE
fix: compare DuckLake metadata paths on the same absolute file

### DIFF
--- a/catalog/provider.go
+++ b/catalog/provider.go
@@ -525,6 +525,31 @@ func (prov *DatabaseProvider) HasCatalog(name string) bool {
 }
 
 // attachCatalogs attaches all the databases in the data directory
+func duckLakeSamePath(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	infoA, errA := os.Stat(a)
+	infoB, errB := os.Stat(b)
+	if errA == nil && errB == nil {
+		return os.SameFile(infoA, infoB)
+	}
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	if errA != nil || errB != nil {
+		return filepath.Clean(a) == filepath.Clean(b)
+	}
+	if ev, err := filepath.EvalSymlinks(absA); err == nil {
+		absA = ev
+	}
+	if ev, err := filepath.EvalSymlinks(absB); err == nil {
+		absB = ev
+	}
+	return absA == absB
+}
+
 func (prov *DatabaseProvider) duckLakeMetadataFile(name string) bool {
 	if prov == nil || prov.duckLake == nil {
 		return false
@@ -533,7 +558,10 @@ func (prov *DatabaseProvider) duckLakeMetadataFile(name string) bool {
 	if meta == "" {
 		return false
 	}
-	return filepath.Clean(filepath.Join(prov.dataDir, name)) == filepath.Clean(meta)
+	// The image entrypoint cds into DATA_PATH and leaves --datadir at ".".
+	// Compare the same absolute file so "./ducklake.db" matches an absolute
+	// MYDUCK_DUCKLAKE_METADATA_PATH. Ordinary catalogs in dataDir are not skipped.
+	return duckLakeSamePath(filepath.Join(prov.dataDir, name), meta)
 }
 
 func (prov *DatabaseProvider) attachCatalogs() error {

--- a/catalog/provider_ducklake_test.go
+++ b/catalog/provider_ducklake_test.go
@@ -166,6 +166,48 @@ func TestAttachCatalogSkipsDuckLakeMetadataFile(t *testing.T) {
 	require.NoError(t, prov.AttachCatalog(info, false))
 }
 
+func TestAttachCatalogSkipsDuckLakeMetadataRelativeDataDir(t *testing.T) {
+	dir := t.TempDir()
+	meta := filepath.Join(dir, "ducklake.db")
+	require.NoError(t, os.WriteFile(meta, []byte("existing"), 0o600))
+	userConnector, err := duckdb.NewConnector(filepath.Join(dir, "myduck.db"), nil)
+	require.NoError(t, err)
+	require.NoError(t, userConnector.Close())
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.Chdir(cwd)) })
+	require.NoError(t, os.Chdir(dir))
+	prov := &DatabaseProvider{
+		dataDir: ".",
+		duckLake: &duckLakeRuntime{config: configuration.DuckLakeConfig{
+			MetadataPath: meta,
+		}},
+	}
+	info, err := os.Stat("ducklake.db")
+	require.NoError(t, err)
+	require.True(t, prov.duckLakeMetadataFile(info.Name()))
+	require.False(t, prov.duckLakeMetadataFile("myduck.db"))
+
+	connector, err := duckdb.NewConnector("", nil)
+	require.NoError(t, err)
+	db := stdsql.OpenDB(connector)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+		require.NoError(t, connector.Close())
+	})
+	prov.storage = db
+	userDB, err := os.Stat("myduck.db")
+	require.NoError(t, err)
+	require.NoError(t, prov.AttachCatalog(userDB, false))
+	require.NoError(t, prov.AttachCatalog(info, false))
+
+	var attached int
+	require.NoError(t, db.QueryRow("SELECT count(*) FROM duckdb_databases() WHERE database_name = 'myduck'").Scan(&attached))
+	require.Equal(t, 1, attached)
+	require.NoError(t, db.QueryRow("SELECT count(*) FROM duckdb_databases() WHERE database_name = 'ducklake'").Scan(&attached))
+	require.Equal(t, 0, attached)
+}
+
 func TestDuckLakeAttachStatNonExistErrorDoesNotCreate(t *testing.T) {
 	orig := duckLakeStat
 	t.Cleanup(func() { duckLakeStat = orig })


### PR DESCRIPTION
## Summary

Same-volume recreate of `v0.3.0-dev.20260907.2` (`055524a1`) still failed `ATTACH` with `stage=attach reason=driver_error`.

The image entrypoint `cd`s into `DATA_PATH` and leaves `--datadir` at `.`. The metadata skip compared `./ducklake.db` with the absolute `MYDUCK_DUCKLAKE_METADATA_PATH`, so `attachCatalogs` still opened the catalog as a regular database.

Identify the catalog file with `os.SameFile` after `Stat`, with `Abs`/`EvalSymlinks` fallback. Ordinary catalogs in the data directory still ATTACH.

Empty named volume first start on `055524a1` passed without pre-chown. `be2cd5bd` and `055524a1` must not be promoted. Does not change `v0.2.1` / `latest`. Does not touch PR #489.

## Test

- `go test ./catalog -count=1 -run 'TestAttachCatalogSkipsDuckLakeMetadata'`