### PR TITLE
fix: wait for log FIFO reader before dropping the guard

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -354,6 +354,7 @@ run_replica_setup() {
 
 run_server_in_background() {
     local status
+    local _log_pipe_guard_wait
 
     cd "$DATA_PATH" || { echo "Error: Could not change directory to ${DATA_PATH}"; return 1; }
     rm -f "${LOG_PIPE}"
@@ -393,6 +394,23 @@ run_server_in_background() {
     tee -a "${LOG_PATH}/server.log" 9>&- < "${LOG_PIPE}" &
     LOGGER_PID=$!
     signal_children
+    # Closing FD 9 before tee opens the FIFO leaves myduckserver as the only
+    # writer with no reader, which is SIGPIPE (exit 141). Wait until tee has
+    # consumed at least one log byte, then drop the guard.
+    _log_pipe_guard_wait=0
+    while [[ ! -s "${LOG_PATH}/server.log" ]]; do
+        if [[ -n "${SERVER_PID}" ]] && ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+            break
+        fi
+        if [[ -n "${LOGGER_PID}" ]] && ! kill -0 "${LOGGER_PID}" 2>/dev/null; then
+            break
+        fi
+        _log_pipe_guard_wait=$((_log_pipe_guard_wait + 1))
+        if [[ "${_log_pipe_guard_wait}" -ge 200 ]]; then
+            break
+        fi
+        sleep 0.01
+    done
     close_log_pipe_guard
     if [[ -n "${SHUTDOWN_SIGNAL}" ]]; then
         complete_shutdown

--- a/docker/entrypoint_test.go
+++ b/docker/entrypoint_test.go
@@ -50,11 +50,13 @@ func TestEntrypointKeepsFIFOOpenAcrossChildLaunches(t *testing.T) {
 	guardOpen := strings.Index(launch, `exec 9<> "${LOG_PIPE}"`)
 	serverLaunch := strings.Index(launch, `myduckserver "${SERVER_OPTIONS[@]}" 9>&-`)
 	loggerLaunch := strings.Index(launch, `tee -a "${LOG_PATH}/server.log" 9>&-`)
+	logReady := strings.Index(launch, `[[ ! -s "${LOG_PATH}/server.log" ]]`)
 	guardClose := strings.Index(launch, "close_log_pipe_guard")
 	require.GreaterOrEqual(t, guardOpen, 0)
 	require.Greater(t, serverLaunch, guardOpen)
 	require.Greater(t, loggerLaunch, serverLaunch)
-	require.Greater(t, guardClose, loggerLaunch)
+	require.Greater(t, logReady, loggerLaunch)
+	require.Greater(t, guardClose, logReady)
 }
 
 func TestEntrypointPreservesLegacyInitBehavior(t *testing.T) {


### PR DESCRIPTION
## Summary

r1 same-volume recreate of `v0.3.0-dev.20260907.3` (`1b3eadb4`) exited **141 (SIGPIPE)** in ~0.5s with `CRITICAL: MyDuck Server process died during startup`.

Failed container `581abd19`: default `ENTRYPOINT ["/home/admin/entrypoint.sh"]`, `User=admin`, bind only `task88-1b3eadb4-data:/home/admin/data`, no PATH wrapper.

Cause: `close_log_pipe_guard` ran immediately after `tee &`. If tee has not opened the FIFO yet, `myduckserver` writes with no reader → SIGPIPE.

Fix: wait until `server.log` is non-empty (tee has the FIFO) before dropping FD 9.

r2 functional matrix remains independently verified. This does not promote `1b3eadb4`. Does not change `v0.2.1` / `latest`.

## Test

- `go test ./docker -count=1`